### PR TITLE
Protocol handling refactor

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -1,3 +1,4 @@
+#include "App/Log.h"
 #include "Application.h"
 #include "AppLog.h"
 
@@ -186,17 +187,17 @@ void Application::MigrateUserData()
         std::error_code ec;
         fs::create_directories(dst.parent_path(), ec);
         if (ec) {
-            SDL_Log("[Migration] Could not create directory %s: %s",
+            LOG_INFO("Application", "[Migration] Could not create directory %s: %s",
                     dst.parent_path().string().c_str(), ec.message().c_str());
             return false;
         }
         fs::copy_file(src, dst, fs::copy_options::skip_existing, ec);
         if (ec) {
-            SDL_Log("[Migration] Could not copy %s → %s: %s",
+            LOG_INFO("Application", "[Migration] Could not copy %s → %s: %s",
                     src.string().c_str(), dst.string().c_str(), ec.message().c_str());
             return false;
         }
-        SDL_Log("[Migration] %s → %s", src.string().c_str(), dst.string().c_str());
+        LOG_INFO("Application", "[Migration] %s → %s", src.string().c_str(), dst.string().c_str());
         return true;
     };
 
@@ -226,10 +227,10 @@ void Application::MigrateUserData()
     total += migrateDir(oldRoot / "protocols", newData / "protocols");
 
     if (total > 0)
-        SDL_Log("[Migration] Migrated %d file(s) from legacy path %s",
+        LOG_INFO("Application", "[Migration] Migrated %d file(s) from legacy path %s",
                 total, oldRoot.string().c_str());
     else
-        SDL_Log("[Migration] Legacy path %s exists but all files already migrated.",
+        LOG_INFO("Application", "[Migration] Legacy path %s exists but all files already migrated.",
                 oldRoot.string().c_str());
 #endif
 }

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -187,17 +187,17 @@ void Application::MigrateUserData()
         std::error_code ec;
         fs::create_directories(dst.parent_path(), ec);
         if (ec) {
-            LOG_INFO("Application", "[Migration] Could not create directory %s: %s",
+            LOG_INFO("Application", "Migration: Could not create directory %s: %s",
                     dst.parent_path().string().c_str(), ec.message().c_str());
             return false;
         }
         fs::copy_file(src, dst, fs::copy_options::skip_existing, ec);
         if (ec) {
-            LOG_INFO("Application", "[Migration] Could not copy %s → %s: %s",
+            LOG_INFO("Application", "Migration: Could not copy %s → %s: %s",
                     src.string().c_str(), dst.string().c_str(), ec.message().c_str());
             return false;
         }
-        LOG_INFO("Application", "[Migration] %s → %s", src.string().c_str(), dst.string().c_str());
+        LOG_INFO("Application", "Migration: %s → %s", src.string().c_str(), dst.string().c_str());
         return true;
     };
 
@@ -227,10 +227,10 @@ void Application::MigrateUserData()
     total += migrateDir(oldRoot / "protocols", newData / "protocols");
 
     if (total > 0)
-        LOG_INFO("Application", "[Migration] Migrated %d file(s) from legacy path %s",
+        LOG_INFO("Application", "Migration: Migrated %d file(s) from legacy path %s",
                 total, oldRoot.string().c_str());
     else
-        LOG_INFO("Application", "[Migration] Legacy path %s exists but all files already migrated.",
+        LOG_INFO("Application", "Migration: Legacy path %s exists but all files already migrated.",
                 oldRoot.string().c_str());
 #endif
 }

--- a/src/App/Log.h
+++ b/src/App/Log.h
@@ -7,10 +7,16 @@
  * std::cout logging with these macros.  Every call is routed through SDL's
  * logging system so AppLog captures it automatically with the correct level.
  *
- * Usage:
+ * Usage with a string literal tag (zero runtime overhead):
  *   LOG_INFO ("OSCServer", "Listening on port %d", port);
  *   LOG_WARN ("HapticDevice", "Rumble init failed: %s", SDL_GetError());
  *   LOG_ERROR("ProtocolRegistry", "Cannot write %s", path.c_str());
+ *
+ * Usage with a const std::string tag (avoids duplicate string storage):
+ *   static const std::string kTag = "OSCServer";
+ *   LOG_INFO_S (kTag, "Listening on port %d", port);
+ *   LOG_WARN_S (kTag, "Rumble init failed: %s", SDL_GetError());
+ *   LOG_ERROR_S(kTag, "Cannot write %s", path.c_str());
  *
  * The category string appears as a prefix inside the message so the existing
  * AppLog UI text-filter can match on it (e.g. filter "OSCServer").
@@ -26,6 +32,7 @@
  */
 
 #include <SDL3/SDL_log.h>
+#include <string>
 
 // ── Helper: pick an SDL category from the subsystem tag ──────────────────────
 // This keeps SDL's own category-level filtering meaningful while still letting
@@ -34,7 +41,8 @@
 // clang-format off
 #define _LOG_SDL_CAT(tag) SDL_LOG_CATEGORY_APPLICATION
 
-// ── Public macros ─────────────────────────────────────────────────────────────
+// ── Public macros — literal tag variants ─────────────────────────────────────
+// tag must be a string literal; the "[tag] " prefix is composed at compile time.
 
 /// Noisy per-frame or repeated diagnostic messages — hidden by default in the UI.
 #define LOG_VERBOSE(tag, fmt, ...) \
@@ -59,4 +67,27 @@
 /// Unrecoverable errors — application integrity may be compromised.
 #define LOG_CRITICAL(tag, fmt, ...) \
     SDL_LogCritical(_LOG_SDL_CAT(tag), "[" tag "] " fmt, ##__VA_ARGS__)
+
+// ── Public macros — std::string tag variants ─────────────────────────────────
+// Use these when the tag is stored as a const std::string (e.g. a class member
+// or static constant) to avoid duplicating the string as a literal.
+// The tag value is prepended at runtime; all other behaviour is identical.
+
+#define LOG_VERBOSE_S(stag, fmt, ...) \
+    SDL_LogVerbose(SDL_LOG_CATEGORY_APPLICATION, ("[" + (stag) + "] " fmt).c_str(), ##__VA_ARGS__)
+
+#define LOG_DEBUG_S(stag, fmt, ...) \
+    SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION, ("[" + (stag) + "] " fmt).c_str(), ##__VA_ARGS__)
+
+#define LOG_INFO_S(stag, fmt, ...) \
+    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, ("[" + (stag) + "] " fmt).c_str(), ##__VA_ARGS__)
+
+#define LOG_WARN_S(stag, fmt, ...) \
+    SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, ("[" + (stag) + "] " fmt).c_str(), ##__VA_ARGS__)
+
+#define LOG_ERROR_S(stag, fmt, ...) \
+    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, ("[" + (stag) + "] " fmt).c_str(), ##__VA_ARGS__)
+
+#define LOG_CRITICAL_S(stag, fmt, ...) \
+    SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION, ("[" + (stag) + "] " fmt).c_str(), ##__VA_ARGS__)
 // clang-format on

--- a/src/App/Log.h
+++ b/src/App/Log.h
@@ -1,0 +1,62 @@
+#pragma once
+/**
+ * @file Log.h
+ * @brief Levelled logging macros for InputBridge.
+ *
+ * Replace all bare SDL_Log(), fprintf(stderr,...), printf(), std::cerr and
+ * std::cout logging with these macros.  Every call is routed through SDL's
+ * logging system so AppLog captures it automatically with the correct level.
+ *
+ * Usage:
+ *   LOG_INFO ("OSCServer", "Listening on port %d", port);
+ *   LOG_WARN ("HapticDevice", "Rumble init failed: %s", SDL_GetError());
+ *   LOG_ERROR("ProtocolRegistry", "Cannot write %s", path.c_str());
+ *
+ * The category string appears as a prefix inside the message so the existing
+ * AppLog UI text-filter can match on it (e.g. filter "OSCServer").
+ *
+ * SDL log categories used:
+ *   SDL_LOG_CATEGORY_APPLICATION  — general / UI / protocol / mapper
+ *   SDL_LOG_CATEGORY_INPUT        — devices, haptics, sensors
+ *   SDL_LOG_CATEGORY_SYSTEM       — network (OSC / WebSocket)
+ *
+ * If you need finer per-category SDL filtering you can switch the second
+ * argument of SDL_LogMessage to any SDL_LOG_CATEGORY_* constant; the text
+ * prefix makes it identifiable in the AppLog UI regardless.
+ */
+
+#include <SDL3/SDL_log.h>
+
+// ── Helper: pick an SDL category from the subsystem tag ──────────────────────
+// This keeps SDL's own category-level filtering meaningful while still letting
+// every message land in AppLog via the single shared callback.
+
+// clang-format off
+#define _LOG_SDL_CAT(tag) SDL_LOG_CATEGORY_APPLICATION
+
+// ── Public macros ─────────────────────────────────────────────────────────────
+
+/// Noisy per-frame or repeated diagnostic messages — hidden by default in the UI.
+#define LOG_VERBOSE(tag, fmt, ...) \
+    SDL_LogVerbose(_LOG_SDL_CAT(tag), "[" tag "] " fmt, ##__VA_ARGS__)
+
+/// Internal state tracing useful during development.
+#define LOG_DEBUG(tag, fmt, ...) \
+    SDL_LogDebug(_LOG_SDL_CAT(tag), "[" tag "] " fmt, ##__VA_ARGS__)
+
+/// Normal operational events (startup, device connect/disconnect, etc.).
+#define LOG_INFO(tag, fmt, ...) \
+    SDL_LogInfo(_LOG_SDL_CAT(tag), "[" tag "] " fmt, ##__VA_ARGS__)
+
+/// Unexpected but recoverable situations.
+#define LOG_WARN(tag, fmt, ...) \
+    SDL_LogWarn(_LOG_SDL_CAT(tag), "[" tag "] " fmt, ##__VA_ARGS__)
+
+/// Failures that affect functionality but don't require a shutdown.
+#define LOG_ERROR(tag, fmt, ...) \
+    SDL_LogError(_LOG_SDL_CAT(tag), "[" tag "] " fmt, ##__VA_ARGS__)
+
+/// Unrecoverable errors — application integrity may be compromised.
+#define LOG_CRITICAL(tag, fmt, ...) \
+    SDL_LogCritical(_LOG_SDL_CAT(tag), "[" tag "] " fmt, ##__VA_ARGS__)
+// clang-format on

--- a/src/Core/BackupManager.cpp
+++ b/src/Core/BackupManager.cpp
@@ -1,3 +1,4 @@
+#include "App/Log.h"
 #include "BackupManager.h"
 #include <filesystem>
 #include <algorithm>
@@ -35,7 +36,7 @@ std::string BackupManager::CreateBackup(const std::string& filePath) {
 
         return backupPath.string();
     } catch (const std::exception& e) {
-        fprintf(stderr, "Failed to create backup: %s\n", e.what());
+        LOG_ERROR("BackupManager", "Failed to create backup: %s", e.what());
         return "";
     }
 }
@@ -58,7 +59,7 @@ std::string BackupManager::CreateDirectoryBackup(const std::string& dirPath) {
 
         return backupPath.string();
     } catch (const std::exception& e) {
-        fprintf(stderr, "Failed to create directory backup: %s\n", e.what());
+        LOG_ERROR("BackupManager", "Failed to create directory backup: %s", e.what());
         return "";
     }
 }
@@ -87,7 +88,7 @@ bool BackupManager::RestoreBackup(const std::string& backupPath,
 
         return true;
     } catch (const std::exception& e) {
-        fprintf(stderr, "Failed to restore backup: %s\n", e.what());
+        LOG_ERROR("BackupManager", "Failed to restore backup: %s", e.what());
         return false;
     }
 }
@@ -133,7 +134,7 @@ std::vector<std::string> BackupManager::ListBackups(const std::string& filePath)
                      return tA > tB;
                  });
     } catch (const std::exception& e) {
-        fprintf(stderr, "Failed to list backups: %s\n", e.what());
+        LOG_ERROR("BackupManager", "Failed to list backups: %s", e.what());
     }
 
     return backups;
@@ -178,7 +179,7 @@ void BackupManager::CleanupOldBackups(const std::string& filePath) {
                 allBackups.erase(allBackups.begin());
             }
         } catch (const std::exception& e) {
-            fprintf(stderr, "Failed to cleanup backups: %s\n", e.what());
+            LOG_ERROR("BackupManager", "Failed to cleanup backups: %s", e.what());
         }
     } else {
         // Cleanup backups for specific file
@@ -213,7 +214,7 @@ size_t BackupManager::GetTotalBackupSize() const {
             }
         }
     } catch (const std::exception& e) {
-        fprintf(stderr, "Failed to calculate backup size: %s\n", e.what());
+        LOG_ERROR("BackupManager", "Failed to calculate backup size: %s", e.what());
     }
 
     return totalSize;
@@ -228,7 +229,7 @@ void BackupManager::ClearAllBackups() {
         fs::remove_all(m_backupDir);
         EnsureBackupDirectoryExists();
     } catch (const std::exception& e) {
-        fprintf(stderr, "Failed to clear backups: %s\n", e.what());
+        LOG_ERROR("BackupManager", "Failed to clear backups: %s", e.what());
     }
 }
 
@@ -266,7 +267,7 @@ bool BackupManager::EnsureBackupDirectoryExists() {
         }
         return fs::is_directory(m_backupDir);
     } catch (const std::exception& e) {
-        fprintf(stderr, "Failed to create backup directory: %s\n", e.what());
+        LOG_ERROR("BackupManager", "Failed to create backup directory: %s", e.what());
         return false;
     }
 }

--- a/src/Core/BackupManager.h
+++ b/src/Core/BackupManager.h
@@ -84,7 +84,6 @@ public:
 private:
     std::string m_backupDir;
     size_t m_maxBackups;
-    
     /**
      * Generate backup filename with timestamp.
      */

--- a/src/Core/ProtocolValidator.cpp
+++ b/src/Core/ProtocolValidator.cpp
@@ -8,10 +8,15 @@ namespace {
     const std::string KEY_NAME = "name";
     const std::string KEY_TRANSPORT = "transport";
     const std::string KEY_DIRECTION = "direction";
-    const std::string KEY_OSC_HOST = "oscHost";
-    const std::string KEY_OSC_SEND_PORT = "oscSendPort";
-    const std::string KEY_OSC_RECV_PORT = "oscRecvPort";
-    const std::string KEY_WSS_PORT = "wssPort";
+    // Nested transport blocks — the actual on-disk format uses
+    //   "osc": { "host": "...", "sendPort": N, "recvPort": N }
+    //   "ws":  { "port": N }
+    const std::string KEY_OSC_BLOCK = "osc";
+    const std::string KEY_OSC_HOST = "host";        // inside the "osc" block
+    const std::string KEY_OSC_SEND_PORT = "sendPort"; // inside the "osc" block
+    const std::string KEY_OSC_RECV_PORT = "recvPort"; // inside the "osc" block
+    const std::string KEY_WS_BLOCK  = "ws";
+    const std::string KEY_WSS_PORT  = "port";       // inside the "ws" block
     const std::string KEY_FIELDS = "fields";
     const std::string KEY_FIELD_ID = "fieldId";
     const std::string KEY_ENABLED = "enabled";
@@ -174,14 +179,16 @@ ValidationResult ProtocolValidator::ValidateProtocolJSON(const json& j) {
 
         // Validate transport-specific fields
         if (transport == VAL_TRANSPORT_OSC) {
-            if (!j.contains(KEY_OSC_HOST)) {
+            if (!j.contains(KEY_OSC_BLOCK) || !j[KEY_OSC_BLOCK].contains(KEY_OSC_HOST)) {
                 result.AddWarning(WARN_MISSING_OSC_HOST);
             }
-            if (!j.contains(KEY_OSC_SEND_PORT) && !j.contains(KEY_OSC_RECV_PORT)) {
+            if (!j.contains(KEY_OSC_BLOCK) ||
+                (!j[KEY_OSC_BLOCK].contains(KEY_OSC_SEND_PORT) &&
+                 !j[KEY_OSC_BLOCK].contains(KEY_OSC_RECV_PORT))) {
                 result.AddWarning(WARN_MISSING_OSC_PORTS);
             }
         } else if (transport == VAL_TRANSPORT_WEBSOCKET) {
-            if (!j.contains(KEY_WSS_PORT)) {
+            if (!j.contains(KEY_WS_BLOCK) || !j[KEY_WS_BLOCK].contains(KEY_WSS_PORT)) {
                 result.AddWarning(WARN_MISSING_WSS_PORT);
             }
         }

--- a/src/Devices/DeviceFactory.cpp
+++ b/src/Devices/DeviceFactory.cpp
@@ -1,8 +1,8 @@
+#include "App/Log.h"
 #include "DeviceFactory.h"
 #include "Haptics/GamepadHaptics.h"
 #include "Haptics/SteeringWheelHaptics.h"
 #include "Haptics/FlightStickHaptics.h"
-#include <SDL3/SDL_log.h>
 
 namespace InputBridge {
 
@@ -24,7 +24,7 @@ std::optional<DeviceCreationResult> DeviceFactory::CreateDevice(SDL_JoystickID i
 std::optional<DeviceCreationResult> DeviceFactory::CreateWheelDevice(SDL_JoystickID instance_id) {
     SDL_Joystick* joystick = SDL_OpenJoystick(instance_id);
     if (!joystick) {
-        SDL_Log("Failed to open steering wheel device %d: %s", instance_id, SDL_GetError());
+        LOG_ERROR("DeviceFactory", "Failed to open steering wheel device %d: %s", instance_id, SDL_GetError());
         return std::nullopt;
     }
     
@@ -41,13 +41,13 @@ std::optional<DeviceCreationResult> DeviceFactory::CreateWheelDevice(SDL_Joystic
 std::optional<DeviceCreationResult> DeviceFactory::CreateGamepadDevice(SDL_JoystickID instance_id) {
     SDL_Gamepad* gamepad = SDL_OpenGamepad(instance_id);
     if (!gamepad) {
-        SDL_Log("Failed to open gamepad device %d: %s", instance_id, SDL_GetError());
+        LOG_ERROR("DeviceFactory", "Failed to open gamepad device %d: %s", instance_id, SDL_GetError());
         return std::nullopt;
     }
     
     SDL_Joystick* joystick = SDL_GetGamepadJoystick(gamepad);
     if (!joystick) {
-        SDL_Log("Failed to get joystick from gamepad %d", instance_id);
+        LOG_ERROR("DeviceFactory", "Failed to get joystick from gamepad %d", instance_id);
         SDL_CloseGamepad(gamepad);
         return std::nullopt;
     }
@@ -67,7 +67,7 @@ std::optional<DeviceCreationResult> DeviceFactory::CreateGamepadDevice(SDL_Joyst
 std::optional<DeviceCreationResult> DeviceFactory::CreateGenericDevice(SDL_JoystickID instance_id) {
     SDL_Joystick* joystick = SDL_OpenJoystick(instance_id);
     if (!joystick) {
-        SDL_Log("Failed to open generic device %d: %s", instance_id, SDL_GetError());
+        LOG_ERROR("DeviceFactory", "Failed to open generic device %d: %s", instance_id, SDL_GetError());
         return std::nullopt;
     }
     
@@ -102,7 +102,7 @@ std::unique_ptr<HapticDevice> DeviceFactory::CreateHapticDevice(SDL_Joystick* jo
     if (device_type == SDL_JOYSTICK_TYPE_GAMEPAD) {
         auto haptic = std::make_unique<GamepadHaptics>(joystick);
         if (haptic && !haptic->Init()) {
-            SDL_Log("Failed to initialize gamepad haptics");
+            LOG_ERROR("DeviceFactory", "Failed to initialize gamepad haptics");
             return nullptr;
         }
         return haptic;
@@ -126,12 +126,12 @@ std::unique_ptr<HapticDevice> DeviceFactory::CreateHapticDevice(SDL_Joystick* jo
             break;
             
         default:
-            SDL_Log("Unknown haptic device type: %d", static_cast<int>(device_type));
+            LOG_INFO("DeviceFactory", "Unknown haptic device type: %d", static_cast<int>(device_type));
             return nullptr;
     }
     
     if (haptic && !haptic->Init()) {
-        SDL_Log("Failed to initialize haptic device");
+        LOG_ERROR("DeviceFactory", "Failed to initialize haptic device");
         return nullptr;
     }
     

--- a/src/Devices/DeviceManager.cpp
+++ b/src/Devices/DeviceManager.cpp
@@ -1,8 +1,8 @@
+#include "App/Log.h"
 #include "DeviceManager.h"
 #include "DeviceFactory.h"
 #include "SensorReader.h"
 #include "SDL3/SDL_joystick.h"
-#include "SDL3/SDL_log.h"
 #include <algorithm>
 #include <cstdlib>
 
@@ -33,7 +33,7 @@ std::string DeviceManager::GetDeviceGUIDString(const DeviceState &dev) {
 void DeviceManager::HandleDeviceAdded(SDL_JoystickID instance_id) {
     auto result = InputBridge::DeviceFactory::CreateDevice(instance_id);
     if (!result) {
-        SDL_Log("Failed to create device %d", instance_id);
+        LOG_ERROR("DeviceManager", "Failed to create device %d", instance_id);
         return;
     }
     
@@ -153,7 +153,7 @@ void DeviceManager::Update(bool isMinimized) {
 
 void DeviceManager::ScanWheelRPMDevices() {
     m_WheelRPMDevices = wheel::WheelManager::scan();
-    SDL_Log("WheelRPM scan complete: %zu device(s) found",
+    LOG_INFO("DeviceManager", "WheelRPM scan complete: %zu device(s) found",
             m_WheelRPMDevices.size());
 }
 
@@ -198,11 +198,11 @@ void DeviceManager::UpdateBatteryInfo(DeviceState &dev) {
             }
 
             if (dev.battery_state == SDL_POWERSTATE_UNKNOWN) {
-                SDL_Log("Battery [%s]: State=%s (battery info not available)",
+                LOG_INFO("DeviceManager", "Battery [%s]: State=%s (battery info not available)",
                         dev.name.c_str(), state_str);
-                SDL_Log("  Possible causes: hid_playstation not loaded, missing udev rules, or SDL can't read battery");
+                LOG_INFO("DeviceManager", "Possible causes: hid_playstation not loaded, missing udev rules, or SDL can't read battery");
             } else if (dev.battery_state != SDL_POWERSTATE_NO_BATTERY) {
-                SDL_Log("Battery [%s]: State=%s, Percent=%d%%",
+                LOG_INFO("DeviceManager", "Battery [%s]: State=%s, Percent=%d%%",
                         dev.name.c_str(), state_str, percent);
             }
         }
@@ -237,7 +237,7 @@ void DeviceManager::UpdateBatteryInfo(DeviceState &dev) {
                     if (leftState != SDL_POWERSTATE_NO_BATTERY) {
                         dev.battery_state_L   = leftState;
                         dev.battery_percent_L = leftPercent;
-                        SDL_Log("Battery L [%s]: Percent=%d%%", dev.name.c_str(), leftPercent);
+                        LOG_INFO("DeviceManager", "Battery L [%s]: Percent=%d%%", dev.name.c_str(), leftPercent);
                         SDL_CloseJoystick(joy);
                         break;
                     }
@@ -275,7 +275,7 @@ void DeviceManager::UpdateBatteryInfo(DeviceState &dev) {
             }
 
             if (dev.battery_state != SDL_POWERSTATE_NO_BATTERY && dev.battery_state != SDL_POWERSTATE_UNKNOWN) {
-                SDL_Log("Battery (Joystick) [%s]: State=%s, Percent=%d%%",
+                LOG_INFO("DeviceManager", "Battery (Joystick) [%s]: State=%s, Percent=%d%%",
                         dev.name.c_str(), state_str, percent);
             }
         }
@@ -302,7 +302,7 @@ bool DeviceManager::SetDeviceHidden(DeviceState& dev, bool hidden) {
                          ? dev.joystick
                          : (dev.gamepad ? SDL_GetGamepadJoystick(dev.gamepad) : nullptr);
     if (!joy) {
-        SDL_Log("DeviceManager::SetDeviceHidden: no joystick handle for '%s'.",
+        LOG_INFO("DeviceManager", "DeviceManager::SetDeviceHidden: no joystick handle for '%s'.",
                 dev.name.c_str());
         return false;
     }
@@ -312,7 +312,7 @@ bool DeviceManager::SetDeviceHidden(DeviceState& dev, bool hidden) {
     return ok;
 #else
     (void)dev; (void)hidden;
-    SDL_Log("DeviceManager::SetDeviceHidden: exclusive input support not compiled in.");
+    LOG_WARN("DeviceManager", "DeviceManager::SetDeviceHidden: exclusive input support not compiled in.");
     return false;
 #endif
 }

--- a/src/Devices/DeviceManager.cpp
+++ b/src/Devices/DeviceManager.cpp
@@ -302,7 +302,7 @@ bool DeviceManager::SetDeviceHidden(DeviceState& dev, bool hidden) {
                          ? dev.joystick
                          : (dev.gamepad ? SDL_GetGamepadJoystick(dev.gamepad) : nullptr);
     if (!joy) {
-        LOG_INFO("DeviceManager", "DeviceManager::SetDeviceHidden: no joystick handle for '%s'.",
+        LOG_INFO("DeviceManager", "SetDeviceHidden: no joystick handle for '%s'.",
                 dev.name.c_str());
         return false;
     }
@@ -312,7 +312,7 @@ bool DeviceManager::SetDeviceHidden(DeviceState& dev, bool hidden) {
     return ok;
 #else
     (void)dev; (void)hidden;
-    LOG_WARN("DeviceManager", "DeviceManager::SetDeviceHidden: exclusive input support not compiled in.");
+    LOG_WARN("DeviceManager", "SetDeviceHidden: exclusive input support not compiled in.");
     return false;
 #endif
 }

--- a/src/Devices/SensorReader.cpp
+++ b/src/Devices/SensorReader.cpp
@@ -1,3 +1,4 @@
+#include "App/Log.h"
 #include "SensorReader.h"
 #include <algorithm>
 

--- a/src/Devices/SensorReader.cpp
+++ b/src/Devices/SensorReader.cpp
@@ -1,4 +1,3 @@
-#include "App/Log.h"
 #include "SensorReader.h"
 #include <algorithm>
 

--- a/src/Devices/VirtualDeviceManager.cpp
+++ b/src/Devices/VirtualDeviceManager.cpp
@@ -1,5 +1,5 @@
+#include "App/Log.h"
 #include "VirtualDeviceManager.h"
-#include <SDL3/SDL_log.h>
 #include <algorithm>
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -132,14 +132,14 @@ SDL_JoystickID VirtualDeviceManager::AddDevice(VirtualDeviceType type,
 
     SDL_JoystickID id = SDL_AttachVirtualJoystick(&desc);
     if (id == 0) {
-        SDL_Log("VirtualDeviceManager: SDL_AttachVirtualJoystick failed: %s",
+        LOG_ERROR("VirtualDeviceManager", "VirtualDeviceManager: SDL_AttachVirtualJoystick failed: %s",
                 SDL_GetError());
         return 0;
     }
 
     SDL_Joystick* joystick = SDL_OpenJoystick(id);
     if (!joystick) {
-        SDL_Log("VirtualDeviceManager: SDL_OpenJoystick failed: %s", SDL_GetError());
+        LOG_ERROR("VirtualDeviceManager", "VirtualDeviceManager: SDL_OpenJoystick failed: %s", SDL_GetError());
         SDL_DetachVirtualJoystick(id);
         return 0;
     }
@@ -149,7 +149,7 @@ SDL_JoystickID VirtualDeviceManager::AddDevice(VirtualDeviceType type,
     // Push defaults immediately so SDL has a consistent initial state.
     PushState(id);
 
-    SDL_Log("VirtualDeviceManager: created '%s' (type=%d, id=%u)",
+    LOG_INFO("VirtualDeviceManager", "VirtualDeviceManager: created '%s' (type=%d, id=%u)",
             name.c_str(), static_cast<int>(type), static_cast<unsigned>(id));
     return id;
 }
@@ -170,7 +170,7 @@ void VirtualDeviceManager::RemoveDevice(SDL_JoystickID id) {
     SDL_DetachVirtualJoystick(id);
 
     m_Devices.erase(it);
-    SDL_Log("VirtualDeviceManager: removed virtual device id=%u",
+    LOG_INFO("VirtualDeviceManager", "VirtualDeviceManager: removed virtual device id=%u",
             static_cast<unsigned>(id));
 }
 

--- a/src/Devices/VirtualDeviceManager.cpp
+++ b/src/Devices/VirtualDeviceManager.cpp
@@ -132,14 +132,14 @@ SDL_JoystickID VirtualDeviceManager::AddDevice(VirtualDeviceType type,
 
     SDL_JoystickID id = SDL_AttachVirtualJoystick(&desc);
     if (id == 0) {
-        LOG_ERROR("VirtualDeviceManager", "VirtualDeviceManager: SDL_AttachVirtualJoystick failed: %s",
+        LOG_ERROR("VirtualDeviceManager", "SDL_AttachVirtualJoystick failed: %s",
                 SDL_GetError());
         return 0;
     }
 
     SDL_Joystick* joystick = SDL_OpenJoystick(id);
     if (!joystick) {
-        LOG_ERROR("VirtualDeviceManager", "VirtualDeviceManager: SDL_OpenJoystick failed: %s", SDL_GetError());
+        LOG_ERROR("VirtualDeviceManager", "SDL_OpenJoystick failed: %s", SDL_GetError());
         SDL_DetachVirtualJoystick(id);
         return 0;
     }
@@ -149,7 +149,7 @@ SDL_JoystickID VirtualDeviceManager::AddDevice(VirtualDeviceType type,
     // Push defaults immediately so SDL has a consistent initial state.
     PushState(id);
 
-    LOG_INFO("VirtualDeviceManager", "VirtualDeviceManager: created '%s' (type=%d, id=%u)",
+    LOG_INFO("VirtualDeviceManager", "created '%s' (type=%d, id=%u)",
             name.c_str(), static_cast<int>(type), static_cast<unsigned>(id));
     return id;
 }
@@ -170,7 +170,7 @@ void VirtualDeviceManager::RemoveDevice(SDL_JoystickID id) {
     SDL_DetachVirtualJoystick(id);
 
     m_Devices.erase(it);
-    LOG_INFO("VirtualDeviceManager", "VirtualDeviceManager: removed virtual device id=%u",
+    LOG_INFO("VirtualDeviceManager", "removed virtual device id=%u",
             static_cast<unsigned>(id));
 }
 

--- a/src/Haptics/DualSenseController.cpp
+++ b/src/Haptics/DualSenseController.cpp
@@ -7,6 +7,7 @@
  * @date 2026-02-14
  */
 
+#include "App/Log.h"
 #include "DualSenseController.h"
 #include "DualSenseTriggerEffectGenerator.h"
 #include <SDL3/SDL_gamepad.h>
@@ -55,7 +56,7 @@ InputBridge::Result<bool, InputBridge::HapticError> DualSenseController::Init() 
         m_connectionType = DetectConnectionType();
         m_connectionTypeDetected = true;
         
-        SDL_Log("DualSense initialized: Connection=%s", 
+        LOG_INFO("DualSense", "DualSense initialized: Connection=%s", 
                m_connectionType == DualSense::ConnectionType::USB ? "USB" : "Bluetooth");
     }
     
@@ -91,13 +92,13 @@ DualSense::ConnectionType DualSenseController::DetectConnectionType() const {
         
         // USB devices report as charging or charged
         if (state == SDL_POWERSTATE_CHARGING || state == SDL_POWERSTATE_CHARGED) {
-            SDL_Log("DualSense: USB detected via power state (charging/charged)");
+            LOG_INFO("DualSense", "DualSense: USB detected via power state (charging/charged)");
             return DualSense::ConnectionType::USB;
         }
         
         // Battery-powered means Bluetooth
         if (state == SDL_POWERSTATE_ON_BATTERY) {
-            SDL_Log("DualSense: Bluetooth detected via power state (on battery)");
+            LOG_INFO("DualSense", "DualSense: Bluetooth detected via power state (on battery)");
             return DualSense::ConnectionType::Bluetooth;
         }
     }
@@ -109,25 +110,25 @@ DualSense::ConnectionType DualSenseController::DetectConnectionType() const {
         std::transform(pathStr.begin(), pathStr.end(), pathStr.begin(),
                       [](unsigned char c) { return std::tolower(c); });
         
-        SDL_Log("DualSense: Checking path: %s", path);
+        LOG_INFO("DualSense", "DualSense: Checking path: %s", path);
         
         // Explicit USB indicators
         if (pathStr.find("usb") != std::string::npos) {
-            SDL_Log("DualSense: USB detected via path (contains 'usb')");
+            LOG_INFO("DualSense", "DualSense: USB detected via path (contains 'usb')");
             return DualSense::ConnectionType::USB;
         }
         
         // Explicit Bluetooth indicators
         if (pathStr.find("bluetooth") != std::string::npos ||
             pathStr.find("-bt-") != std::string::npos) {
-            SDL_Log("DualSense: Bluetooth detected via path (contains 'bluetooth'/'bt')");
+            LOG_INFO("DualSense", "DualSense: Bluetooth detected via path (contains 'bluetooth'/'bt')");
             return DualSense::ConnectionType::Bluetooth;
         }
         
         // On Linux: hidraw without Bluetooth indicators = USB
         #ifdef __linux__
         if (pathStr.find("hidraw") != std::string::npos) {
-            SDL_Log("DualSense: USB detected via Linux hidraw");
+            LOG_INFO("DualSense", "DualSense: USB detected via Linux hidraw");
             return DualSense::ConnectionType::USB;
         }
         #endif
@@ -138,7 +139,7 @@ DualSense::ConnectionType DualSenseController::DetectConnectionType() const {
     
     // Default to Bluetooth (more common for wireless play)
     // Note: Previous code defaulted to USB, but Bluetooth is more common
-    SDL_Log("DualSense: Defaulting to Bluetooth (could not determine definitively)");
+    LOG_INFO("DualSense", "DualSense: Defaulting to Bluetooth (could not determine definitively)");
     return DualSense::ConnectionType::Bluetooth;
 }
 
@@ -161,7 +162,7 @@ int DualSenseController::SetTriggerEffect(const std::string& trigger,
     const bool updateRight = (trigger == "right" || trigger == "both");
     
     if (!updateLeft && !updateRight) {
-        SDL_Log("DualSenseController::SetTriggerEffect - Invalid trigger: %s", trigger.c_str());
+        LOG_INFO("DualSense", "DualSenseController::SetTriggerEffect - Invalid trigger: %s", trigger.c_str());
         return -1;
     }
     
@@ -175,7 +176,7 @@ int DualSenseController::SetTriggerEffect(const std::string& trigger,
     }
     
     if (!success) {
-        SDL_Log("DualSenseController::SetTriggerEffect - Failed to apply effect");
+        LOG_INFO("DualSense", "DualSenseController::SetTriggerEffect - Failed to apply effect");
         return -1;
     }
     
@@ -242,7 +243,7 @@ bool DualSenseController::ApplyTriggerEffect(uint8_t* triggerData,
                                                         amplitudeA, amplitudeB, frequency, period);
     }
     else {
-        SDL_Log("DualSenseController: Unknown effect type '%s'", effectType.c_str());
+        LOG_INFO("DualSense", "DualSenseController: Unknown effect type '%s'", effectType.c_str());
         return ExtendInput::DataTools::DualSense::DualSenseTriggerEffectGenerator::Off(triggerData, 0);
     }
 }
@@ -292,7 +293,7 @@ void DualSenseController::ApplyOutputState() {
         }
         
         if (!success) {
-            SDL_Log("DualSenseController: Failed to send output state");
+            LOG_INFO("DualSense", "DualSenseController: Failed to send output state");
         }
     });
 }
@@ -349,18 +350,18 @@ bool DualSenseController::SendUSBOutput() {
     // LED brightness (offset 43)
     data[43] = m_outputState.ledBrightness;
     
-    SDL_Log("DualSense USB: Sending report, size=%zu", data.size());
-    SDL_Log("  Flags: [1]=0x%02X [2]=0x%02X", data[1], data[2]);
-    SDL_Log("  Rumble: L=%d R=%d", data[4], data[3]);
-    SDL_Log("  Triggers: R[0]=0x%02X L[0]=0x%02X", 
+    LOG_DEBUG("DualSense", "USB: Sending report, size=%zu", data.size());
+    LOG_DEBUG("DualSense", "  Flags: [1]=0x%02X [2]=0x%02X", data[1], data[2]);
+    LOG_DEBUG("DualSense", "  Rumble: L=%d R=%d", data[4], data[3]);
+    LOG_DEBUG("DualSense", "  Triggers: R[0]=0x%02X L[0]=0x%02X", 
            m_outputState.rightTriggerEffect[0], m_outputState.leftTriggerEffect[0]);
     
     if (!SDL_SendJoystickEffect(m_joystick, data.data(), data.size())) {
-        SDL_Log("DualSense USB: Send failed - %s", SDL_GetError());
+        LOG_INFO("DualSense", "DualSense USB: Send failed - %s", SDL_GetError());
         return false;
     }
     
-    SDL_Log("DualSense USB: Report sent successfully");
+    LOG_DEBUG("DualSense", "USB: Report sent successfully");
     return true;
 }
 
@@ -418,18 +419,18 @@ bool DualSenseController::SendBluetoothOutput() {
     // Player LEDs (offset 44)
     data[44] = m_outputState.playerLEDs;
     
-    SDL_Log("DualSense BT: Sending report, size=%zu, seq=%d", data.size(), m_bluetoothSequence);
-    SDL_Log("  Flags: [1]=0x%02X [2]=0x%02X [3]=0x%02X", data[1], data[2], data[3]);
-    SDL_Log("  Rumble: L=%d R=%d", data[5], data[4]);
-    SDL_Log("  Triggers: R[0]=0x%02X L[0]=0x%02X", 
+    LOG_DEBUG("DualSense", "BT: Sending report, size=%zu, seq=%d", data.size(), m_bluetoothSequence);
+    LOG_DEBUG("DualSense", "  Flags: [1]=0x%02X [2]=0x%02X [3]=0x%02X", data[1], data[2], data[3]);
+    LOG_DEBUG("DualSense", "  Rumble: L=%d R=%d", data[5], data[4]);
+    LOG_DEBUG("DualSense", "  Triggers: R[0]=0x%02X L[0]=0x%02X", 
            m_outputState.rightTriggerEffect[0], m_outputState.leftTriggerEffect[0]);
     
     // SDL handles CRC32 for Bluetooth automatically
     if (!SDL_SendJoystickEffect(m_joystick, data.data(), data.size())) {
-        SDL_Log("DualSense BT: Send failed - %s", SDL_GetError());
+        LOG_INFO("DualSense", "DualSense BT: Send failed - %s", SDL_GetError());
         return false;
     }
     
-    SDL_Log("DualSense BT: Report sent successfully");
+    LOG_DEBUG("DualSense", "BT: Report sent successfully");
     return true;
 }

--- a/src/Haptics/DualSenseController.cpp
+++ b/src/Haptics/DualSenseController.cpp
@@ -92,13 +92,13 @@ DualSense::ConnectionType DualSenseController::DetectConnectionType() const {
         
         // USB devices report as charging or charged
         if (state == SDL_POWERSTATE_CHARGING || state == SDL_POWERSTATE_CHARGED) {
-            LOG_INFO("DualSense", "DualSense: USB detected via power state (charging/charged)");
+            LOG_INFO("DualSense", "USB detected via power state (charging/charged)");
             return DualSense::ConnectionType::USB;
         }
         
         // Battery-powered means Bluetooth
         if (state == SDL_POWERSTATE_ON_BATTERY) {
-            LOG_INFO("DualSense", "DualSense: Bluetooth detected via power state (on battery)");
+            LOG_INFO("DualSense", "Bluetooth detected via power state (on battery)");
             return DualSense::ConnectionType::Bluetooth;
         }
     }
@@ -110,25 +110,25 @@ DualSense::ConnectionType DualSenseController::DetectConnectionType() const {
         std::transform(pathStr.begin(), pathStr.end(), pathStr.begin(),
                       [](unsigned char c) { return std::tolower(c); });
         
-        LOG_INFO("DualSense", "DualSense: Checking path: %s", path);
+        LOG_INFO("DualSense", "Checking path: %s", path);
         
         // Explicit USB indicators
         if (pathStr.find("usb") != std::string::npos) {
-            LOG_INFO("DualSense", "DualSense: USB detected via path (contains 'usb')");
+            LOG_INFO("DualSense", "USB detected via path (contains 'usb')");
             return DualSense::ConnectionType::USB;
         }
         
         // Explicit Bluetooth indicators
         if (pathStr.find("bluetooth") != std::string::npos ||
             pathStr.find("-bt-") != std::string::npos) {
-            LOG_INFO("DualSense", "DualSense: Bluetooth detected via path (contains 'bluetooth'/'bt')");
+            LOG_INFO("DualSense", "Bluetooth detected via path (contains 'bluetooth'/'bt')");
             return DualSense::ConnectionType::Bluetooth;
         }
         
         // On Linux: hidraw without Bluetooth indicators = USB
         #ifdef __linux__
         if (pathStr.find("hidraw") != std::string::npos) {
-            LOG_INFO("DualSense", "DualSense: USB detected via Linux hidraw");
+            LOG_INFO("DualSense", "USB detected via Linux hidraw");
             return DualSense::ConnectionType::USB;
         }
         #endif
@@ -139,7 +139,7 @@ DualSense::ConnectionType DualSenseController::DetectConnectionType() const {
     
     // Default to Bluetooth (more common for wireless play)
     // Note: Previous code defaulted to USB, but Bluetooth is more common
-    LOG_INFO("DualSense", "DualSense: Defaulting to Bluetooth (could not determine definitively)");
+    LOG_INFO("DualSense", "Defaulting to Bluetooth (could not determine definitively)");
     return DualSense::ConnectionType::Bluetooth;
 }
 
@@ -162,7 +162,7 @@ int DualSenseController::SetTriggerEffect(const std::string& trigger,
     const bool updateRight = (trigger == "right" || trigger == "both");
     
     if (!updateLeft && !updateRight) {
-        LOG_INFO("DualSense", "DualSenseController::SetTriggerEffect - Invalid trigger: %s", trigger.c_str());
+        LOG_INFO("DualSense", "SetTriggerEffect - Invalid trigger: %s", trigger.c_str());
         return -1;
     }
     
@@ -176,7 +176,7 @@ int DualSenseController::SetTriggerEffect(const std::string& trigger,
     }
     
     if (!success) {
-        LOG_INFO("DualSense", "DualSenseController::SetTriggerEffect - Failed to apply effect");
+        LOG_INFO("DualSense", "SetTriggerEffect - Failed to apply effect");
         return -1;
     }
     
@@ -243,7 +243,7 @@ bool DualSenseController::ApplyTriggerEffect(uint8_t* triggerData,
                                                         amplitudeA, amplitudeB, frequency, period);
     }
     else {
-        LOG_INFO("DualSense", "DualSenseController: Unknown effect type '%s'", effectType.c_str());
+        LOG_INFO("DualSense", "Unknown effect type '%s'", effectType.c_str());
         return ExtendInput::DataTools::DualSense::DualSenseTriggerEffectGenerator::Off(triggerData, 0);
     }
 }
@@ -293,7 +293,7 @@ void DualSenseController::ApplyOutputState() {
         }
         
         if (!success) {
-            LOG_INFO("DualSense", "DualSenseController: Failed to send output state");
+            LOG_INFO("DualSense", "Failed to send output state");
         }
     });
 }

--- a/src/Haptics/FlightStickHaptics.cpp
+++ b/src/Haptics/FlightStickHaptics.cpp
@@ -9,7 +9,7 @@
 int FlightStickHaptics::PlayConstant(int slot, float strength, uint32_t duration_ms) {
     RunAsync([this, slot, strength, duration_ms]() {
         if (!m_haptic) {
-            LOG_WARN("FlightStickHaptics", "FlightStickHaptics::PlayConstant - Haptic device not ready");
+            LOG_WARN("FlightStickHaptics", "PlayConstant - Haptic device not ready");
             return;
         }
 
@@ -35,7 +35,7 @@ int FlightStickHaptics::PlayConstant(int slot, float strength, uint32_t duration
             m_constantEffects[slot] = newId;
             if (created) {
                 if (!SDL_RunHapticEffect(m_haptic.Get(), newId, 1)) {
-                    LOG_ERROR("FlightStickHaptics", "FlightStickHaptics::PlayConstant - Run failed: %s", SDL_GetError());
+                    LOG_ERROR("FlightStickHaptics", "PlayConstant - Run failed: %s", SDL_GetError());
                 }
             }
             {
@@ -75,7 +75,7 @@ int FlightStickHaptics::PlayPeriodic(int slot, HapticPeriodicType wave_type, flo
                                      uint32_t duration_ms) {
     RunAsync([this, slot, wave_type, strength, period, magnitude, offset, phase, duration_ms]() {
         if (!m_haptic) {
-            LOG_WARN("FlightStickHaptics", "FlightStickHaptics::PlayPeriodic - Haptic device not ready");
+            LOG_WARN("FlightStickHaptics", "PlayPeriodic - Haptic device not ready");
             return;
         }
 
@@ -128,7 +128,7 @@ int FlightStickHaptics::PlayPeriodic(int slot, HapticPeriodicType wave_type, flo
             m_periodicEffects[slot] = newId;
             if (created) {
                 if (!SDL_RunHapticEffect(m_haptic.Get(), newId, 1)) {
-                    LOG_ERROR("FlightStickHaptics", "FlightStickHaptics::PlayPeriodic - Run failed: %s", SDL_GetError());
+                    LOG_ERROR("FlightStickHaptics", "PlayPeriodic - Run failed: %s", SDL_GetError());
                 }
             }
             {
@@ -190,14 +190,14 @@ int FlightStickHaptics::PlayCondition(int slot, HapticConditionType type,
     RunAsync([this, slot, type, right_sat, left_sat,
               right_coeff, left_coeff, deadband, center, duration_ms]() {
         if (!m_haptic) {
-            LOG_WARN("FlightStickHaptics", "FlightStickHaptics::PlayCondition - Haptic device not ready");
+            LOG_WARN("FlightStickHaptics", "PlayCondition - Haptic device not ready");
             return;
         }
 
         {
             int max_effects = SDL_GetMaxHapticEffects(m_haptic.Get());
             if (slot < 0 || slot >= max_effects) {
-                LOG_WARN("FlightStickHaptics", "FlightStickHaptics::PlayCondition - Invalid slot %d (max: %d)",
+                LOG_WARN("FlightStickHaptics", "PlayCondition - Invalid slot %d (max: %d)",
                         slot, max_effects);
                 return;
             }
@@ -234,7 +234,7 @@ int FlightStickHaptics::PlayCondition(int slot, HapticConditionType type,
             m_conditionEffects[slot] = newId;
             if (created) {
                 if (!SDL_RunHapticEffect(m_haptic.Get(), newId, 1)) {
-                    LOG_ERROR("FlightStickHaptics", "FlightStickHaptics::PlayCondition - Run failed for type %s: %s",
+                    LOG_ERROR("FlightStickHaptics", "PlayCondition - Run failed for type %s: %s",
                             ConditionTypeName(type), SDL_GetError());
                     std::lock_guard<std::mutex> lock(m_activeEffectsMutex);
                     m_activeConditions.erase(slot);

--- a/src/Haptics/FlightStickHaptics.cpp
+++ b/src/Haptics/FlightStickHaptics.cpp
@@ -1,3 +1,4 @@
+#include "App/Log.h"
 #include "FlightStickHaptics.h"
 #include <algorithm>
 
@@ -8,7 +9,7 @@
 int FlightStickHaptics::PlayConstant(int slot, float strength, uint32_t duration_ms) {
     RunAsync([this, slot, strength, duration_ms]() {
         if (!m_haptic) {
-            SDL_Log("FlightStickHaptics::PlayConstant - Haptic device not ready");
+            LOG_WARN("FlightStickHaptics", "FlightStickHaptics::PlayConstant - Haptic device not ready");
             return;
         }
 
@@ -34,7 +35,7 @@ int FlightStickHaptics::PlayConstant(int slot, float strength, uint32_t duration
             m_constantEffects[slot] = newId;
             if (created) {
                 if (!SDL_RunHapticEffect(m_haptic.Get(), newId, 1)) {
-                    SDL_Log("FlightStickHaptics::PlayConstant - Run failed: %s", SDL_GetError());
+                    LOG_ERROR("FlightStickHaptics", "FlightStickHaptics::PlayConstant - Run failed: %s", SDL_GetError());
                 }
             }
             {
@@ -74,7 +75,7 @@ int FlightStickHaptics::PlayPeriodic(int slot, HapticPeriodicType wave_type, flo
                                      uint32_t duration_ms) {
     RunAsync([this, slot, wave_type, strength, period, magnitude, offset, phase, duration_ms]() {
         if (!m_haptic) {
-            SDL_Log("FlightStickHaptics::PlayPeriodic - Haptic device not ready");
+            LOG_WARN("FlightStickHaptics", "FlightStickHaptics::PlayPeriodic - Haptic device not ready");
             return;
         }
 
@@ -127,7 +128,7 @@ int FlightStickHaptics::PlayPeriodic(int slot, HapticPeriodicType wave_type, flo
             m_periodicEffects[slot] = newId;
             if (created) {
                 if (!SDL_RunHapticEffect(m_haptic.Get(), newId, 1)) {
-                    SDL_Log("FlightStickHaptics::PlayPeriodic - Run failed: %s", SDL_GetError());
+                    LOG_ERROR("FlightStickHaptics", "FlightStickHaptics::PlayPeriodic - Run failed: %s", SDL_GetError());
                 }
             }
             {
@@ -189,14 +190,14 @@ int FlightStickHaptics::PlayCondition(int slot, HapticConditionType type,
     RunAsync([this, slot, type, right_sat, left_sat,
               right_coeff, left_coeff, deadband, center, duration_ms]() {
         if (!m_haptic) {
-            SDL_Log("FlightStickHaptics::PlayCondition - Haptic device not ready");
+            LOG_WARN("FlightStickHaptics", "FlightStickHaptics::PlayCondition - Haptic device not ready");
             return;
         }
 
         {
             int max_effects = SDL_GetMaxHapticEffects(m_haptic.Get());
             if (slot < 0 || slot >= max_effects) {
-                SDL_Log("FlightStickHaptics::PlayCondition - Invalid slot %d (max: %d)",
+                LOG_WARN("FlightStickHaptics", "FlightStickHaptics::PlayCondition - Invalid slot %d (max: %d)",
                         slot, max_effects);
                 return;
             }
@@ -233,7 +234,7 @@ int FlightStickHaptics::PlayCondition(int slot, HapticConditionType type,
             m_conditionEffects[slot] = newId;
             if (created) {
                 if (!SDL_RunHapticEffect(m_haptic.Get(), newId, 1)) {
-                    SDL_Log("FlightStickHaptics::PlayCondition - Run failed for type %s: %s",
+                    LOG_ERROR("FlightStickHaptics", "FlightStickHaptics::PlayCondition - Run failed for type %s: %s",
                             ConditionTypeName(type), SDL_GetError());
                     std::lock_guard<std::mutex> lock(m_activeEffectsMutex);
                     m_activeConditions.erase(slot);

--- a/src/Haptics/GamepadHaptics.cpp
+++ b/src/Haptics/GamepadHaptics.cpp
@@ -1,3 +1,4 @@
+#include "App/Log.h"
 #include "GamepadHaptics.h"
 #include <SDL3/SDL_gamepad.h>
 #include "Core/Result.h"
@@ -26,25 +27,25 @@ InputBridge::Result<bool, InputBridge::HapticError> GamepadHaptics::Init() {
     if (IsDualSense()) {
         m_dualSense = std::make_unique<DualSenseController>(m_joystick);
         m_dualSense->Init();
-        SDL_Log("GamepadHaptics: Initialized as DualSense");
+        LOG_INFO("GamepadHaptics", "GamepadHaptics: Initialized as DualSense");
     }
     else if (IsXboxController()) {
         m_xbox = std::make_unique<XboxController>(m_joystick);
         m_xbox->Init();
-        SDL_Log("GamepadHaptics: Initialized as Xbox");
+        LOG_INFO("GamepadHaptics", "GamepadHaptics: Initialized as Xbox");
     }
     else if (IsSteamControllerV1()) {
         // V1 haptic pulses are sent via SDL_SendGamepadEffect in SendSteamControllerHaptic(),
         // which routes through SDL's already-open HIDAPI handle.  No separate HID open needed.
-        SDL_Log("GamepadHaptics: Initialized as Steam Controller V1 (trackpad HID haptics)");
+        LOG_INFO("GamepadHaptics", "GamepadHaptics: Initialized as Steam Controller V1 (trackpad HID haptics)");
     }
     else if (IsSteamControllerV2()) {
         // V2 supports SDL_RumbleGamepad natively since SDL 3.4.10.
         // No special initialization required — the standard rumble path is used.
-        SDL_Log("GamepadHaptics: Initialized as Steam Controller V2 (SDL_RumbleGamepad)");
+        LOG_INFO("GamepadHaptics", "GamepadHaptics: Initialized as Steam Controller V2 (SDL_RumbleGamepad)");
     }
     else {
-        SDL_Log("GamepadHaptics: Initialized as generic gamepad");
+        LOG_INFO("GamepadHaptics", "GamepadHaptics: Initialized as generic gamepad");
     }
 
     return result;
@@ -160,7 +161,7 @@ int GamepadHaptics::PlayRumble(int slot, float largeMagnitude, float smallMagnit
         // name-based fallback and routed here by mistake.
         if (!IsSteamControllerV2() && IsSteamControllerV1()) {
             const float magnitude = (largeMagnitude + smallMagnitude) * 0.5f;
-            SDL_Log("GamepadHaptics::PlayRumble - Steam Controller V1: HID trackpad haptic (magnitude=%.2f, duration=%ums)",
+            LOG_INFO("GamepadHaptics", "GamepadHaptics::PlayRumble - Steam Controller V1: HID trackpad haptic (magnitude=%.2f, duration=%ums)",
                     magnitude, durationMs);
 
             SendSteamControllerHaptic(0, magnitude, durationMs); // left  trackpad
@@ -184,7 +185,7 @@ int GamepadHaptics::PlayRumble(int slot, float largeMagnitude, float smallMagnit
             const Uint16 highFreq = static_cast<Uint16>(smallMagnitude * 0xFFFF);
 
             if (!SDL_RumbleGamepad(m_gamepad, lowFreq, highFreq, durationMs)) {
-                SDL_Log("GamepadHaptics::PlayRumble - SDL_RumbleGamepad failed: %s", SDL_GetError());
+                LOG_INFO("GamepadHaptics", "GamepadHaptics::PlayRumble - SDL_RumbleGamepad failed: %s", SDL_GetError());
                 std::lock_guard<std::mutex> lock(m_activeEffectsMutex);
                 m_activeRumbles.erase(slot);
             } else {
@@ -195,11 +196,11 @@ int GamepadHaptics::PlayRumble(int slot, float largeMagnitude, float smallMagnit
                 info.small_magnitude = smallMagnitude;
                 info.duration_ms     = durationMs;
                 info.last_updated    = SDL_GetTicks();
-                SDL_Log("GamepadHaptics::PlayRumble - Success slot=%d (low=%u, high=%u, duration=%ums)",
+                LOG_INFO("GamepadHaptics", "GamepadHaptics::PlayRumble - Success slot=%d (low=%u, high=%u, duration=%ums)",
                         slot, lowFreq, highFreq, durationMs);
             }
         } else {
-            SDL_Log("GamepadHaptics::PlayRumble - No gamepad handle available");
+            LOG_INFO("GamepadHaptics", "GamepadHaptics::PlayRumble - No gamepad handle available");
         }
     });
 
@@ -272,7 +273,7 @@ void GamepadHaptics::SendSteamControllerHaptic(uint8_t pad, float magnitude, uin
     // report[10–11] = dBgain (Sint16) — 0 = default gain
     // report[12]    = priority flags — 0 = HAPTIC_PULSE_NORMAL
 
-    SDL_Log("SendSteamControllerHaptic - pad=%u magnitude=%.2f durationUs=%u periodUs=%u pulseCount=%u",
+    LOG_INFO("GamepadHaptics", "SendSteamControllerHaptic - pad=%u magnitude=%.2f durationUs=%u periodUs=%u pulseCount=%u",
             pad, magnitude, durationUs, periodUs, pulseCount);
 
     // Prefer the cached gamepad handle (SDL_SendGamepadEffect); fall back to
@@ -280,11 +281,11 @@ void GamepadHaptics::SendSteamControllerHaptic(uint8_t pad, float magnitude, uin
     // Both reach the same HIDAPI steam SendJoystickEffect handler.
     if (m_gamepad) {
         if (!SDL_SendGamepadEffect(m_gamepad, report, sizeof(report))) {
-            SDL_Log("SendSteamControllerHaptic - SDL_SendGamepadEffect failed: %s", SDL_GetError());
+            LOG_INFO("GamepadHaptics", "SendSteamControllerHaptic - SDL_SendGamepadEffect failed: %s", SDL_GetError());
         }
     } else {
         if (!SDL_SendJoystickEffect(m_joystick, report, sizeof(report))) {
-            SDL_Log("SendSteamControllerHaptic - SDL_SendJoystickEffect fallback failed: %s", SDL_GetError());
+            LOG_INFO("GamepadHaptics", "SendSteamControllerHaptic - SDL_SendJoystickEffect fallback failed: %s", SDL_GetError());
         }
     }
 }
@@ -301,7 +302,7 @@ int GamepadHaptics::PlayDualSenseTrigger(const std::string& trigger,
                                          const std::string& effect_type,
                                          const std::map<std::string, int>& params) {
     if (!m_dualSense) {
-        SDL_Log("GamepadHaptics::SendDualSenseTrigger - Not a DualSense controller");
+        LOG_INFO("GamepadHaptics", "GamepadHaptics::SendDualSenseTrigger - Not a DualSense controller");
         return -1;
     }
 
@@ -329,7 +330,7 @@ int GamepadHaptics::SendXboxImpulseTrigger(uint8_t leftIntensity,
                                            uint8_t rightIntensity,
                                            uint32_t durationMs) {
     if (!m_xbox) {
-        SDL_Log("GamepadHaptics::SendXboxImpulseTrigger - Not an Xbox controller");
+        LOG_INFO("GamepadHaptics", "GamepadHaptics::SendXboxImpulseTrigger - Not an Xbox controller");
         return -1;
     }
 

--- a/src/Haptics/GamepadHaptics.cpp
+++ b/src/Haptics/GamepadHaptics.cpp
@@ -27,25 +27,25 @@ InputBridge::Result<bool, InputBridge::HapticError> GamepadHaptics::Init() {
     if (IsDualSense()) {
         m_dualSense = std::make_unique<DualSenseController>(m_joystick);
         m_dualSense->Init();
-        LOG_INFO("GamepadHaptics", "GamepadHaptics: Initialized as DualSense");
+        LOG_INFO("GamepadHaptics", "Initialized as DualSense");
     }
     else if (IsXboxController()) {
         m_xbox = std::make_unique<XboxController>(m_joystick);
         m_xbox->Init();
-        LOG_INFO("GamepadHaptics", "GamepadHaptics: Initialized as Xbox");
+        LOG_INFO("GamepadHaptics", "Initialized as Xbox");
     }
     else if (IsSteamControllerV1()) {
         // V1 haptic pulses are sent via SDL_SendGamepadEffect in SendSteamControllerHaptic(),
         // which routes through SDL's already-open HIDAPI handle.  No separate HID open needed.
-        LOG_INFO("GamepadHaptics", "GamepadHaptics: Initialized as Steam Controller V1 (trackpad HID haptics)");
+        LOG_INFO("GamepadHaptics", "Initialized as Steam Controller V1 (trackpad HID haptics)");
     }
     else if (IsSteamControllerV2()) {
         // V2 supports SDL_RumbleGamepad natively since SDL 3.4.10.
         // No special initialization required — the standard rumble path is used.
-        LOG_INFO("GamepadHaptics", "GamepadHaptics: Initialized as Steam Controller V2 (SDL_RumbleGamepad)");
+        LOG_INFO("GamepadHaptics", "Initialized as Steam Controller V2 (SDL_RumbleGamepad)");
     }
     else {
-        LOG_INFO("GamepadHaptics", "GamepadHaptics: Initialized as generic gamepad");
+        LOG_INFO("GamepadHaptics", "Initialized as generic gamepad");
     }
 
     return result;
@@ -161,7 +161,7 @@ int GamepadHaptics::PlayRumble(int slot, float largeMagnitude, float smallMagnit
         // name-based fallback and routed here by mistake.
         if (!IsSteamControllerV2() && IsSteamControllerV1()) {
             const float magnitude = (largeMagnitude + smallMagnitude) * 0.5f;
-            LOG_INFO("GamepadHaptics", "GamepadHaptics::PlayRumble - Steam Controller V1: HID trackpad haptic (magnitude=%.2f, duration=%ums)",
+            LOG_INFO("GamepadHaptics", "PlayRumble - Steam Controller V1: HID trackpad haptic (magnitude=%.2f, duration=%ums)",
                     magnitude, durationMs);
 
             SendSteamControllerHaptic(0, magnitude, durationMs); // left  trackpad
@@ -185,7 +185,7 @@ int GamepadHaptics::PlayRumble(int slot, float largeMagnitude, float smallMagnit
             const Uint16 highFreq = static_cast<Uint16>(smallMagnitude * 0xFFFF);
 
             if (!SDL_RumbleGamepad(m_gamepad, lowFreq, highFreq, durationMs)) {
-                LOG_INFO("GamepadHaptics", "GamepadHaptics::PlayRumble - SDL_RumbleGamepad failed: %s", SDL_GetError());
+                LOG_INFO("GamepadHaptics", "PlayRumble - SDL_RumbleGamepad failed: %s", SDL_GetError());
                 std::lock_guard<std::mutex> lock(m_activeEffectsMutex);
                 m_activeRumbles.erase(slot);
             } else {
@@ -196,11 +196,11 @@ int GamepadHaptics::PlayRumble(int slot, float largeMagnitude, float smallMagnit
                 info.small_magnitude = smallMagnitude;
                 info.duration_ms     = durationMs;
                 info.last_updated    = SDL_GetTicks();
-                LOG_INFO("GamepadHaptics", "GamepadHaptics::PlayRumble - Success slot=%d (low=%u, high=%u, duration=%ums)",
+                LOG_INFO("GamepadHaptics", "PlayRumble - Success slot=%d (low=%u, high=%u, duration=%ums)",
                         slot, lowFreq, highFreq, durationMs);
             }
         } else {
-            LOG_INFO("GamepadHaptics", "GamepadHaptics::PlayRumble - No gamepad handle available");
+            LOG_INFO("GamepadHaptics", "PlayRumble - No gamepad handle available");
         }
     });
 
@@ -302,7 +302,7 @@ int GamepadHaptics::PlayDualSenseTrigger(const std::string& trigger,
                                          const std::string& effect_type,
                                          const std::map<std::string, int>& params) {
     if (!m_dualSense) {
-        LOG_INFO("GamepadHaptics", "GamepadHaptics::SendDualSenseTrigger - Not a DualSense controller");
+        LOG_INFO("GamepadHaptics", "SendDualSenseTrigger - Not a DualSense controller");
         return -1;
     }
 
@@ -330,7 +330,7 @@ int GamepadHaptics::SendXboxImpulseTrigger(uint8_t leftIntensity,
                                            uint8_t rightIntensity,
                                            uint32_t durationMs) {
     if (!m_xbox) {
-        LOG_INFO("GamepadHaptics", "GamepadHaptics::SendXboxImpulseTrigger - Not an Xbox controller");
+        LOG_INFO("GamepadHaptics", "SendXboxImpulseTrigger - Not an Xbox controller");
         return -1;
     }
 

--- a/src/Haptics/HapticDevice.cpp
+++ b/src/Haptics/HapticDevice.cpp
@@ -11,13 +11,13 @@ HapticDevice::~HapticDevice() {
 
 InputBridge::Result<bool, InputBridge::HapticError> HapticDevice::Init() {
     if (!m_joystick) {
-        LOG_ERROR("HapticDevice", "HapticDevice::Init - Failed: Device not found (joystick is null)");
+        LOG_ERROR("HapticDevice", "Init - Failed: Device not found (joystick is null)");
         return InputBridge::Result<bool, InputBridge::HapticError>::Err(InputBridge::HapticError::DeviceNotFound);
     }
 
     auto joystickID = SDL_GetJoystickID(m_joystick);
     bool isHaptic = SDL_IsJoystickHaptic(m_joystick);
-    LOG_INFO("HapticDevice", "HapticDevice::Init - Joystick ID %u, IsHaptic: %d", joystickID, isHaptic);
+    LOG_INFO("HapticDevice", "Init - Joystick ID %u, IsHaptic: %d", joystickID, isHaptic);
 
     if (isHaptic) {
         m_haptic.Reset(SDL_OpenHapticFromJoystick(m_joystick));
@@ -41,11 +41,11 @@ InputBridge::Result<bool, InputBridge::HapticError> HapticDevice::Init() {
     }
 
     if (m_haptic || SDL_IsGamepad(joystickID)) {
-        LOG_INFO("HapticDevice", "HapticDevice::Init - Success");
+        LOG_INFO("HapticDevice", "Init - Success");
         return InputBridge::Result<bool, InputBridge::HapticError>::Ok(true);
     }
 
-    LOG_ERROR("HapticDevice", "HapticDevice::Init - Failed: Unsupported device type");
+    LOG_ERROR("HapticDevice", "Init - Failed: Unsupported device type");
     return InputBridge::Result<bool, InputBridge::HapticError>::Err(InputBridge::HapticError::UnsupportedEffect);
 }
 
@@ -173,14 +173,14 @@ SDL_HapticEffectID HapticDevice::UploadEffect(const SDL_HapticEffect& effect, SD
             if (outCreated) *outCreated = false;
             return existingId;
         } else {
-            LOG_ERROR("HapticDevice", "HapticDevice::UploadEffect - Update failed for ID %d: %s. Recreating.", existingId, SDL_GetError());
+            LOG_ERROR("HapticDevice", "UploadEffect - Update failed for ID %d: %s. Recreating.", existingId, SDL_GetError());
         }
         SDL_DestroyHapticEffect(m_haptic.Get(), existingId);
     }
 
     SDL_HapticEffectID newId = SDL_CreateHapticEffect(m_haptic.Get(), &effect);
     if (newId == -1) {
-        LOG_ERROR("HapticDevice", "HapticDevice::UploadEffect - Create failed: %s", SDL_GetError());
+        LOG_ERROR("HapticDevice", "UploadEffect - Create failed: %s", SDL_GetError());
     }
     if (outCreated) *outCreated = (newId != -1);
     return newId;
@@ -234,7 +234,7 @@ std::map<std::string, ActiveDualSenseTriggerInfo> HapticDevice::GetActiveDualSen
 void HapticDevice::SetConstantForce(float level, float direction) {
     RunAsync([this, level, direction]() {
         if (!m_haptic) {
-            LOG_WARN("HapticDevice", "HapticDevice::SetConstantForce - Haptic device not ready");
+            LOG_WARN("HapticDevice", "SetConstantForce - Haptic device not ready");
             return;
         }
 
@@ -256,7 +256,7 @@ void HapticDevice::SetConstantForce(float level, float direction) {
             m_constantEffects[kInternalSlot] = newId;
             if (created) {
                 if (!SDL_RunHapticEffect(m_haptic.Get(), newId, 1)) {
-                    LOG_ERROR("HapticDevice", "HapticDevice::SetConstantForce - Run failed: %s", SDL_GetError());
+                    LOG_ERROR("HapticDevice", "SetConstantForce - Run failed: %s", SDL_GetError());
                 }
             }
         }
@@ -309,7 +309,7 @@ void HapticDevice::SetPeriodic(HapticPeriodicType type, float magnitude, int per
             m_periodicEffects[kInternalSlot] = newId;
             if (created) {
                 if (!SDL_RunHapticEffect(m_haptic.Get(), newId, 1)) {
-                    LOG_ERROR("HapticDevice", "HapticDevice::SetPeriodic - Run failed: %s", SDL_GetError());
+                    LOG_ERROR("HapticDevice", "SetPeriodic - Run failed: %s", SDL_GetError());
                 }
             }
         }
@@ -346,9 +346,9 @@ void HapticDevice::SetCondition(HapticConditionType type, float saturation, floa
         if (it != m_conditionEffects.end()) existing = it->second;
 
         if (existing == -1) {
-            LOG_WARN("HapticDevice", "HapticDevice::SetCondition - existingID -1");
+            LOG_WARN("HapticDevice", "SetCondition - existingID -1");
         } else {
-            LOG_INFO("HapticDevice", "HapticDevice::SetCondition - existingID %d", existing);
+            LOG_INFO("HapticDevice", "SetCondition - existingID %d", existing);
         }
 
         bool created = false;
@@ -357,7 +357,7 @@ void HapticDevice::SetCondition(HapticConditionType type, float saturation, floa
             m_conditionEffects[internalKey] = newId;
             if (created) {
                 if (!SDL_RunHapticEffect(m_haptic.Get(), newId, 1)) {
-                    LOG_ERROR("HapticDevice", "HapticDevice::SetCondition - Run failed: %s", SDL_GetError());
+                    LOG_ERROR("HapticDevice", "SetCondition - Run failed: %s", SDL_GetError());
                 }
             }
         }
@@ -385,7 +385,7 @@ void HapticDevice::SetRumble(float low_freq, float high_freq, Uint32 duration) {
             m_rumbleEffects[kInternalSlot] = newId;
             if (created) {
                 if (!SDL_RunHapticEffect(m_haptic.Get(), newId, 1)) {
-                    LOG_ERROR("HapticDevice", "HapticDevice::SetRumble - Run failed: %s", SDL_GetError());
+                    LOG_ERROR("HapticDevice", "SetRumble - Run failed: %s", SDL_GetError());
                 }
             }
         }

--- a/src/Haptics/HapticDevice.cpp
+++ b/src/Haptics/HapticDevice.cpp
@@ -1,3 +1,4 @@
+#include "App/Log.h"
 #include "HapticDevice.h"
 #include "SDL3/SDL_haptic.h"
 #include <algorithm>
@@ -10,23 +11,23 @@ HapticDevice::~HapticDevice() {
 
 InputBridge::Result<bool, InputBridge::HapticError> HapticDevice::Init() {
     if (!m_joystick) {
-        SDL_Log("HapticDevice::Init - Failed: Device not found (joystick is null)");
+        LOG_ERROR("HapticDevice", "HapticDevice::Init - Failed: Device not found (joystick is null)");
         return InputBridge::Result<bool, InputBridge::HapticError>::Err(InputBridge::HapticError::DeviceNotFound);
     }
 
     auto joystickID = SDL_GetJoystickID(m_joystick);
     bool isHaptic = SDL_IsJoystickHaptic(m_joystick);
-    SDL_Log("HapticDevice::Init - Joystick ID %u, IsHaptic: %d", joystickID, isHaptic);
+    LOG_INFO("HapticDevice", "HapticDevice::Init - Joystick ID %u, IsHaptic: %d", joystickID, isHaptic);
 
     if (isHaptic) {
         m_haptic.Reset(SDL_OpenHapticFromJoystick(m_joystick));
         if (!m_haptic) {
-            SDL_Log("Warning: SDL_OpenHapticFromJoystick failed: %s", SDL_GetError());
-            SDL_Log("Will continue - gamepad rumble fallback may still work, but advanced haptics will NOT work.");
+            LOG_WARN("HapticDevice", "Warning: SDL_OpenHapticFromJoystick failed: %s", SDL_GetError());
+            LOG_INFO("HapticDevice", "Will continue - gamepad rumble fallback may still work, but advanced haptics will NOT work.");
         } else {
             if (SDL_HapticRumbleSupported(m_haptic.Get())) {
                 if (!SDL_InitHapticRumble(m_haptic.Get())) {
-                    SDL_Log("Warning: SDL_InitHapticRumble failed: %s", SDL_GetError());
+                    LOG_WARN("HapticDevice", "Warning: SDL_InitHapticRumble failed: %s", SDL_GetError());
                 }
             }
             SDL_SetHapticGain(m_haptic.Get(), 100);
@@ -40,11 +41,11 @@ InputBridge::Result<bool, InputBridge::HapticError> HapticDevice::Init() {
     }
 
     if (m_haptic || SDL_IsGamepad(joystickID)) {
-        SDL_Log("HapticDevice::Init - Success");
+        LOG_INFO("HapticDevice", "HapticDevice::Init - Success");
         return InputBridge::Result<bool, InputBridge::HapticError>::Ok(true);
     }
 
-    SDL_Log("HapticDevice::Init - Failed: Unsupported device type");
+    LOG_ERROR("HapticDevice", "HapticDevice::Init - Failed: Unsupported device type");
     return InputBridge::Result<bool, InputBridge::HapticError>::Err(InputBridge::HapticError::UnsupportedEffect);
 }
 
@@ -172,14 +173,14 @@ SDL_HapticEffectID HapticDevice::UploadEffect(const SDL_HapticEffect& effect, SD
             if (outCreated) *outCreated = false;
             return existingId;
         } else {
-            SDL_Log("HapticDevice::UploadEffect - Update failed for ID %d: %s. Recreating.", existingId, SDL_GetError());
+            LOG_ERROR("HapticDevice", "HapticDevice::UploadEffect - Update failed for ID %d: %s. Recreating.", existingId, SDL_GetError());
         }
         SDL_DestroyHapticEffect(m_haptic.Get(), existingId);
     }
 
     SDL_HapticEffectID newId = SDL_CreateHapticEffect(m_haptic.Get(), &effect);
     if (newId == -1) {
-        SDL_Log("HapticDevice::UploadEffect - Create failed: %s", SDL_GetError());
+        LOG_ERROR("HapticDevice", "HapticDevice::UploadEffect - Create failed: %s", SDL_GetError());
     }
     if (outCreated) *outCreated = (newId != -1);
     return newId;
@@ -233,7 +234,7 @@ std::map<std::string, ActiveDualSenseTriggerInfo> HapticDevice::GetActiveDualSen
 void HapticDevice::SetConstantForce(float level, float direction) {
     RunAsync([this, level, direction]() {
         if (!m_haptic) {
-            SDL_Log("HapticDevice::SetConstantForce - Haptic device not ready");
+            LOG_WARN("HapticDevice", "HapticDevice::SetConstantForce - Haptic device not ready");
             return;
         }
 
@@ -255,7 +256,7 @@ void HapticDevice::SetConstantForce(float level, float direction) {
             m_constantEffects[kInternalSlot] = newId;
             if (created) {
                 if (!SDL_RunHapticEffect(m_haptic.Get(), newId, 1)) {
-                    SDL_Log("HapticDevice::SetConstantForce - Run failed: %s", SDL_GetError());
+                    LOG_ERROR("HapticDevice", "HapticDevice::SetConstantForce - Run failed: %s", SDL_GetError());
                 }
             }
         }
@@ -308,7 +309,7 @@ void HapticDevice::SetPeriodic(HapticPeriodicType type, float magnitude, int per
             m_periodicEffects[kInternalSlot] = newId;
             if (created) {
                 if (!SDL_RunHapticEffect(m_haptic.Get(), newId, 1)) {
-                    SDL_Log("HapticDevice::SetPeriodic - Run failed: %s", SDL_GetError());
+                    LOG_ERROR("HapticDevice", "HapticDevice::SetPeriodic - Run failed: %s", SDL_GetError());
                 }
             }
         }
@@ -345,9 +346,9 @@ void HapticDevice::SetCondition(HapticConditionType type, float saturation, floa
         if (it != m_conditionEffects.end()) existing = it->second;
 
         if (existing == -1) {
-            SDL_Log("HapticDevice::SetCondition - existingID -1");
+            LOG_WARN("HapticDevice", "HapticDevice::SetCondition - existingID -1");
         } else {
-            SDL_Log("HapticDevice::SetCondition - existingID %d", existing);
+            LOG_INFO("HapticDevice", "HapticDevice::SetCondition - existingID %d", existing);
         }
 
         bool created = false;
@@ -356,7 +357,7 @@ void HapticDevice::SetCondition(HapticConditionType type, float saturation, floa
             m_conditionEffects[internalKey] = newId;
             if (created) {
                 if (!SDL_RunHapticEffect(m_haptic.Get(), newId, 1)) {
-                    SDL_Log("HapticDevice::SetCondition - Run failed: %s", SDL_GetError());
+                    LOG_ERROR("HapticDevice", "HapticDevice::SetCondition - Run failed: %s", SDL_GetError());
                 }
             }
         }
@@ -384,7 +385,7 @@ void HapticDevice::SetRumble(float low_freq, float high_freq, Uint32 duration) {
             m_rumbleEffects[kInternalSlot] = newId;
             if (created) {
                 if (!SDL_RunHapticEffect(m_haptic.Get(), newId, 1)) {
-                    SDL_Log("HapticDevice::SetRumble - Run failed: %s", SDL_GetError());
+                    LOG_ERROR("HapticDevice", "HapticDevice::SetRumble - Run failed: %s", SDL_GetError());
                 }
             }
         }

--- a/src/Haptics/SteeringWheelHaptics.cpp
+++ b/src/Haptics/SteeringWheelHaptics.cpp
@@ -13,7 +13,7 @@ int SteeringWheelHaptics::SetGain(int gain) {
 int SteeringWheelHaptics::PlayConstant(int slot, float strength, uint32_t duration_ms) {
     RunAsync([this, slot, strength, duration_ms]() {
         if (!m_haptic) {
-            LOG_WARN("SteeringWheelHaptics", "SteeringWheelHaptics::PlayConstant - Haptic device not ready");
+            LOG_WARN("SteeringWheelHaptics", "PlayConstant - Haptic device not ready");
             return;
         }
 
@@ -37,7 +37,7 @@ int SteeringWheelHaptics::PlayConstant(int slot, float strength, uint32_t durati
             m_constantEffects[slot] = newId;
             if (created) {
                 if (!SDL_RunHapticEffect(m_haptic.Get(), newId, 1)) {
-                    LOG_ERROR("SteeringWheelHaptics", "SteeringWheelHaptics::PlayConstant - Run failed: %s", SDL_GetError());
+                    LOG_ERROR("SteeringWheelHaptics", "PlayConstant - Run failed: %s", SDL_GetError());
                 }
             }
             {
@@ -71,7 +71,7 @@ int SteeringWheelHaptics::StopConstant(int slot) {
 int SteeringWheelHaptics::PlayPeriodic(int slot, HapticPeriodicType wave_type, float strength, uint32_t period, float magnitude, float offset, uint32_t phase, uint32_t duration_ms) {
     RunAsync([this, slot, wave_type, strength, period, magnitude, offset, phase, duration_ms]() {
         if (!m_haptic) {
-            LOG_WARN("SteeringWheelHaptics", "SteeringWheelHaptics::PlayPeriodic - Haptic device not ready");
+            LOG_WARN("SteeringWheelHaptics", "PlayPeriodic - Haptic device not ready");
             return;
         }
 
@@ -96,7 +96,7 @@ int SteeringWheelHaptics::PlayPeriodic(int slot, HapticPeriodicType wave_type, f
             m_periodicEffects[slot] = newId;
             if (created) {
                 if (!SDL_RunHapticEffect(m_haptic.Get(), newId, 1)) {
-                    LOG_ERROR("SteeringWheelHaptics", "SteeringWheelHaptics::PlayPeriodic - Run failed: %s", SDL_GetError());
+                    LOG_ERROR("SteeringWheelHaptics", "PlayPeriodic - Run failed: %s", SDL_GetError());
                 }
             }
             {
@@ -145,14 +145,14 @@ int SteeringWheelHaptics::PlayRumble(int slot, float large_magnitude, float smal
 int SteeringWheelHaptics::PlayCondition(int slot, HapticConditionType type, float right_sat, float left_sat, float right_coeff, float left_coeff, float deadband, float center, uint32_t duration_ms) {
     RunAsync([this, slot, type, right_sat, left_sat, right_coeff, left_coeff, deadband, center, duration_ms]() {
         if (!m_haptic) {
-            LOG_WARN("SteeringWheelHaptics", "SteeringWheelHaptics::PlayCondition - Haptic device not ready");
+            LOG_WARN("SteeringWheelHaptics", "PlayCondition - Haptic device not ready");
             return;
         }
 
         {
             int max_effects = SDL_GetMaxHapticEffects(m_haptic.Get());
             if (slot < 0 || slot >= max_effects) {
-                LOG_WARN("SteeringWheelHaptics", "SteeringWheelHaptics::PlayCondition - Invalid slot %d (max: %d)", slot, max_effects);
+                LOG_WARN("SteeringWheelHaptics", "PlayCondition - Invalid slot %d (max: %d)", slot, max_effects);
                 return;
             }
         }
@@ -182,7 +182,7 @@ int SteeringWheelHaptics::PlayCondition(int slot, HapticConditionType type, floa
             m_conditionEffects[slot] = newId;
             if (created) {
                 if (!SDL_RunHapticEffect(m_haptic.Get(), newId, 1)) {
-                    LOG_ERROR("SteeringWheelHaptics", "SteeringWheelHaptics::PlayCondition - Run failed for type %s: %s",
+                    LOG_ERROR("SteeringWheelHaptics", "PlayCondition - Run failed for type %s: %s",
                             ConditionTypeName(type), SDL_GetError());
                     std::lock_guard<std::mutex> lock(m_activeEffectsMutex);
                     m_activeConditions.erase(slot);

--- a/src/Haptics/SteeringWheelHaptics.cpp
+++ b/src/Haptics/SteeringWheelHaptics.cpp
@@ -1,3 +1,4 @@
+#include "App/Log.h"
 #include "SteeringWheelHaptics.h"
 #include <algorithm>
 
@@ -12,7 +13,7 @@ int SteeringWheelHaptics::SetGain(int gain) {
 int SteeringWheelHaptics::PlayConstant(int slot, float strength, uint32_t duration_ms) {
     RunAsync([this, slot, strength, duration_ms]() {
         if (!m_haptic) {
-            SDL_Log("SteeringWheelHaptics::PlayConstant - Haptic device not ready");
+            LOG_WARN("SteeringWheelHaptics", "SteeringWheelHaptics::PlayConstant - Haptic device not ready");
             return;
         }
 
@@ -36,7 +37,7 @@ int SteeringWheelHaptics::PlayConstant(int slot, float strength, uint32_t durati
             m_constantEffects[slot] = newId;
             if (created) {
                 if (!SDL_RunHapticEffect(m_haptic.Get(), newId, 1)) {
-                    SDL_Log("SteeringWheelHaptics::PlayConstant - Run failed: %s", SDL_GetError());
+                    LOG_ERROR("SteeringWheelHaptics", "SteeringWheelHaptics::PlayConstant - Run failed: %s", SDL_GetError());
                 }
             }
             {
@@ -70,7 +71,7 @@ int SteeringWheelHaptics::StopConstant(int slot) {
 int SteeringWheelHaptics::PlayPeriodic(int slot, HapticPeriodicType wave_type, float strength, uint32_t period, float magnitude, float offset, uint32_t phase, uint32_t duration_ms) {
     RunAsync([this, slot, wave_type, strength, period, magnitude, offset, phase, duration_ms]() {
         if (!m_haptic) {
-            SDL_Log("SteeringWheelHaptics::PlayPeriodic - Haptic device not ready");
+            LOG_WARN("SteeringWheelHaptics", "SteeringWheelHaptics::PlayPeriodic - Haptic device not ready");
             return;
         }
 
@@ -95,7 +96,7 @@ int SteeringWheelHaptics::PlayPeriodic(int slot, HapticPeriodicType wave_type, f
             m_periodicEffects[slot] = newId;
             if (created) {
                 if (!SDL_RunHapticEffect(m_haptic.Get(), newId, 1)) {
-                    SDL_Log("SteeringWheelHaptics::PlayPeriodic - Run failed: %s", SDL_GetError());
+                    LOG_ERROR("SteeringWheelHaptics", "SteeringWheelHaptics::PlayPeriodic - Run failed: %s", SDL_GetError());
                 }
             }
             {
@@ -144,14 +145,14 @@ int SteeringWheelHaptics::PlayRumble(int slot, float large_magnitude, float smal
 int SteeringWheelHaptics::PlayCondition(int slot, HapticConditionType type, float right_sat, float left_sat, float right_coeff, float left_coeff, float deadband, float center, uint32_t duration_ms) {
     RunAsync([this, slot, type, right_sat, left_sat, right_coeff, left_coeff, deadband, center, duration_ms]() {
         if (!m_haptic) {
-            SDL_Log("SteeringWheelHaptics::PlayCondition - Haptic device not ready");
+            LOG_WARN("SteeringWheelHaptics", "SteeringWheelHaptics::PlayCondition - Haptic device not ready");
             return;
         }
 
         {
             int max_effects = SDL_GetMaxHapticEffects(m_haptic.Get());
             if (slot < 0 || slot >= max_effects) {
-                SDL_Log("SteeringWheelHaptics::PlayCondition - Invalid slot %d (max: %d)", slot, max_effects);
+                LOG_WARN("SteeringWheelHaptics", "SteeringWheelHaptics::PlayCondition - Invalid slot %d (max: %d)", slot, max_effects);
                 return;
             }
         }
@@ -181,7 +182,7 @@ int SteeringWheelHaptics::PlayCondition(int slot, HapticConditionType type, floa
             m_conditionEffects[slot] = newId;
             if (created) {
                 if (!SDL_RunHapticEffect(m_haptic.Get(), newId, 1)) {
-                    SDL_Log("SteeringWheelHaptics::PlayCondition - Run failed for type %s: %s",
+                    LOG_ERROR("SteeringWheelHaptics", "SteeringWheelHaptics::PlayCondition - Run failed for type %s: %s",
                             ConditionTypeName(type), SDL_GetError());
                     std::lock_guard<std::mutex> lock(m_activeEffectsMutex);
                     m_activeConditions.erase(slot);

--- a/src/Haptics/XboxController.cpp
+++ b/src/Haptics/XboxController.cpp
@@ -7,6 +7,7 @@
  * @date 2026-02-14
  */
 
+#include "App/Log.h"
 #include "XboxController.h"
 #include <SDL3/SDL_gamepad.h>
 #include <array>
@@ -69,7 +70,7 @@ int XboxController::SetImpulseTriggers(uint8_t leftIntensity,
                                        uint8_t rightIntensity,
                                        uint16_t durationMs) {
     if (!IsXboxController()) {
-        SDL_Log("XboxController::SetImpulseTriggers - Not an Xbox controller");
+        LOG_WARN("XboxController", "SetImpulseTriggers: Not an Xbox controller");
         return -1;
     }
     
@@ -80,7 +81,7 @@ int XboxController::SetImpulseTriggers(uint8_t leftIntensity,
         state.durationMs = durationMs;
         
         if (!SendImpulseTriggerCommand(state)) {
-            SDL_Log("XboxController::SetImpulseTriggers - Failed to send command");
+            LOG_ERROR("XboxController", "SetImpulseTriggers: Failed to send command");
         }
     });
     
@@ -121,14 +122,14 @@ bool XboxController::SendImpulseTriggerCommand(const Xbox::ImpulseTriggerState& 
     data[6] = static_cast<uint8_t>(state.durationMs & 0xFF);
     data[7] = static_cast<uint8_t>((state.durationMs >> 8) & 0xFF);
     
-    SDL_Log("Xbox Impulse: Report=0x%02X, L=%d, R=%d, Duration=%dms",
+    LOG_DEBUG("XboxController", "Impulse: Report=0x%02X, L=%d, R=%d, Duration=%dms",
            data[0], state.leftTriggerMotor, state.rightTriggerMotor, state.durationMs);
     
     if (!SDL_SendJoystickEffect(m_joystick, data.data(), data.size())) {
-        SDL_Log("Xbox Impulse: Send failed - %s", SDL_GetError());
+        LOG_ERROR("XboxController", "Impulse: Send failed - %s", SDL_GetError());
         return false;
     }
     
-    SDL_Log("Xbox Impulse: Report sent successfully");
+    LOG_DEBUG("XboxController", "Impulse: Report sent successfully");
     return true;
 }

--- a/src/Mappers/ButtonBinder.cpp
+++ b/src/Mappers/ButtonBinder.cpp
@@ -1,3 +1,4 @@
+#include "App/Log.h"
 #include "ButtonBinder.h"
 #include "Devices/DeviceManager.h" // For DeviceState
 
@@ -13,11 +14,11 @@ void ButtonBinder::StartBinding(const std::vector<struct DeviceState>& connected
                 states[i] = SDL_GetJoystickButton(dev.joystick, i);
             }
             m_baselineButtonStates[id] = states;
-            SDL_LogInfo(SDL_LOG_CATEGORY_INPUT, "ButtonBinder: Captured baseline for joystick '%s' (ID: %u).", SDL_GetJoystickName(dev.joystick), id);
+            LOG_INFO("ButtonBinder", "ButtonBinder: Captured baseline for joystick '%s' (ID: %u).", SDL_GetJoystickName(dev.joystick), id);
         }
     }
     m_isBinding = true;
-    SDL_LogInfo(SDL_LOG_CATEGORY_INPUT, "ButtonBinder: Started binding process for all connected joysticks.");
+    LOG_INFO("ButtonBinder", "ButtonBinder: Started binding process for all connected joysticks.");
 }
 
 std::optional<BoundButtonInfo> ButtonBinder::Update(const std::vector<struct DeviceState>& connectedDevices) {
@@ -40,7 +41,7 @@ std::optional<BoundButtonInfo> ButtonBinder::Update(const std::vector<struct Dev
         int numButtons = SDL_GetNumJoystickButtons(dev.joystick);
 
         if (joystickBaseline.size() != numButtons) {
-            SDL_LogWarn(SDL_LOG_CATEGORY_INPUT, "ButtonBinder: Joystick '%s' (ID: %u) button count changed or baseline mismatch. Re-snapshotting.", SDL_GetJoystickName(dev.joystick), id);
+            LOG_WARN("ButtonBinder", "ButtonBinder: Joystick '%s' (ID: %u) button count changed or baseline mismatch. Re-snapshotting.", SDL_GetJoystickName(dev.joystick), id);
             // Re-snapshot this specific joystick's baseline
             joystickBaseline.assign(numButtons, false);
             for (int i = 0; i < numButtons; ++i) joystickBaseline[i] = SDL_GetJoystickButton(dev.joystick, i);
@@ -53,7 +54,7 @@ std::optional<BoundButtonInfo> ButtonBinder::Update(const std::vector<struct Dev
 
             if (currentState != wasActiveAtStart) {
                 m_isBinding = false;
-                SDL_LogInfo(SDL_LOG_CATEGORY_INPUT, "ButtonBinder: Button %d change detected on joystick '%s' (ID: %u).", i, SDL_GetJoystickName(dev.joystick), id);
+                LOG_INFO("ButtonBinder", "ButtonBinder: Button %d change detected on joystick '%s' (ID: %u).", i, SDL_GetJoystickName(dev.joystick), id);
                 return BoundButtonInfo{id, i};
             }
         }
@@ -62,7 +63,7 @@ std::optional<BoundButtonInfo> ButtonBinder::Update(const std::vector<struct Dev
 }
 
 void ButtonBinder::Cancel() {
-    if (m_isBinding) SDL_LogInfo(SDL_LOG_CATEGORY_INPUT, "ButtonBinder: Binding process cancelled.");
+    if (m_isBinding) LOG_INFO("ButtonBinder", "ButtonBinder: Binding process cancelled.");
     m_isBinding = false;
     m_baselineButtonStates.clear();
 }

--- a/src/Mappers/ButtonBinder.cpp
+++ b/src/Mappers/ButtonBinder.cpp
@@ -14,11 +14,11 @@ void ButtonBinder::StartBinding(const std::vector<struct DeviceState>& connected
                 states[i] = SDL_GetJoystickButton(dev.joystick, i);
             }
             m_baselineButtonStates[id] = states;
-            LOG_INFO("ButtonBinder", "ButtonBinder: Captured baseline for joystick '%s' (ID: %u).", SDL_GetJoystickName(dev.joystick), id);
+            LOG_INFO("ButtonBinder", "Captured baseline for joystick '%s' (ID: %u).", SDL_GetJoystickName(dev.joystick), id);
         }
     }
     m_isBinding = true;
-    LOG_INFO("ButtonBinder", "ButtonBinder: Started binding process for all connected joysticks.");
+    LOG_INFO("ButtonBinder", "Started binding process for all connected joysticks.");
 }
 
 std::optional<BoundButtonInfo> ButtonBinder::Update(const std::vector<struct DeviceState>& connectedDevices) {
@@ -41,7 +41,7 @@ std::optional<BoundButtonInfo> ButtonBinder::Update(const std::vector<struct Dev
         int numButtons = SDL_GetNumJoystickButtons(dev.joystick);
 
         if (joystickBaseline.size() != numButtons) {
-            LOG_WARN("ButtonBinder", "ButtonBinder: Joystick '%s' (ID: %u) button count changed or baseline mismatch. Re-snapshotting.", SDL_GetJoystickName(dev.joystick), id);
+            LOG_WARN("ButtonBinder", "Joystick '%s' (ID: %u) button count changed or baseline mismatch. Re-snapshotting.", SDL_GetJoystickName(dev.joystick), id);
             // Re-snapshot this specific joystick's baseline
             joystickBaseline.assign(numButtons, false);
             for (int i = 0; i < numButtons; ++i) joystickBaseline[i] = SDL_GetJoystickButton(dev.joystick, i);
@@ -54,7 +54,7 @@ std::optional<BoundButtonInfo> ButtonBinder::Update(const std::vector<struct Dev
 
             if (currentState != wasActiveAtStart) {
                 m_isBinding = false;
-                LOG_INFO("ButtonBinder", "ButtonBinder: Button %d change detected on joystick '%s' (ID: %u).", i, SDL_GetJoystickName(dev.joystick), id);
+                LOG_INFO("ButtonBinder", "Button %d change detected on joystick '%s' (ID: %u).", i, SDL_GetJoystickName(dev.joystick), id);
                 return BoundButtonInfo{id, i};
             }
         }
@@ -63,7 +63,7 @@ std::optional<BoundButtonInfo> ButtonBinder::Update(const std::vector<struct Dev
 }
 
 void ButtonBinder::Cancel() {
-    if (m_isBinding) LOG_INFO("ButtonBinder", "ButtonBinder: Binding process cancelled.");
+    if (m_isBinding) LOG_INFO("ButtonBinder", "Binding process cancelled.");
     m_isBinding = false;
     m_baselineButtonStates.clear();
 }

--- a/src/Mappers/InputExclusiveMode.cpp
+++ b/src/Mappers/InputExclusiveMode.cpp
@@ -1,3 +1,4 @@
+#include "App/Log.h"
 #include "InputExclusiveMode.h"
 #include "InputExclusiveModeImpl.h"
 
@@ -16,7 +17,7 @@
 class DummyExclusiveMode : public InputExclusiveModeImpl {
 public:
     bool HideDevice(SDL_Joystick*) override {
-        SDL_Log("Device hide: not implemented on this platform or feature disabled.");
+        LOG_INFO("ExclusiveMode", "Device hide: not implemented on this platform or feature disabled.");
         return false;
     }
     bool UnhideDevice(SDL_Joystick*) override { return true; }

--- a/src/Mappers/InputMapper.cpp
+++ b/src/Mappers/InputMapper.cpp
@@ -1,3 +1,4 @@
+#include "App/Log.h"
 #include "InputMapper.h"
 #include "Devices/DeviceManager.h"
 #include "Devices/SensorReader.h"
@@ -244,7 +245,7 @@ void InputMapper::UpdateListening() {
             bool updated = false;
             const DeviceState* boundDeviceState = getDeviceState(boundButton->joystickID);
             if (!boundDeviceState) {
-                SDL_LogWarn(SDL_LOG_CATEGORY_INPUT, "InputMapper: Bound joystick (ID: %u) not found for button binding.", boundButton->joystickID);
+                LOG_WARN("InputMapper", "InputMapper: Bound joystick (ID: %u) not found for button binding.", boundButton->joystickID);
                 CancelListening();
                 return;
             }
@@ -2006,8 +2007,8 @@ void InputMapper::LoadProfiles() {
                             std::filesystem::copy_file(e.path(), dst,
                                 std::filesystem::copy_options::skip_existing, ec);
                             if (ec)
-                                std::cerr << "[InputMapper] Failed to seed preset profile "
-                                          << e.path().filename() << ": " << ec.message() << "\n";
+                                LOG_ERROR("InputMapper", "Failed to seed preset profile %s: %s",
+                                          e.path().filename().string().c_str(), ec.message().c_str());
                         }
                     }
                 }
@@ -2091,9 +2092,9 @@ void InputMapper::LoadProfiles() {
                 p.wsInputEnabled  = data.value("ws_input_enabled",  true);
 
                 m_Profiles.push_back(p);
-            } catch (const std::exception& ex) { SDL_Log("Failed to parse profile %s: %s",e.path().string().c_str(),ex.what()); }
+            } catch (const std::exception& ex) { LOG_INFO("InputMapper", "Failed to parse profile %s: %s",e.path().string().c_str(),ex.what()); }
         }
-    } catch (const std::exception& ex) { SDL_Log("Failed to load profiles: %s",ex.what()); }
+    } catch (const std::exception& ex) { LOG_INFO("InputMapper", "Failed to load profiles: %s",ex.what()); }
 }
 
 void InputMapper::SaveProfile(const MappingProfile &profile) const {
@@ -2150,7 +2151,7 @@ void InputMapper::SaveProfile(const MappingProfile &profile) const {
         data["ws_input_enabled"]  = profile.wsInputEnabled;
 
         std::ofstream o(path); if (o) o<<data.dump(4);
-    } catch (const std::exception& ex) { SDL_Log("Failed to save profile: %s",ex.what()); }
+    } catch (const std::exception& ex) { LOG_INFO("InputMapper", "Failed to save profile: %s",ex.what()); }
 }
 
 std::vector<HapticTarget>* InputMapper::GetCurrentHapticTargets() {

--- a/src/Mappers/InputMapper.cpp
+++ b/src/Mappers/InputMapper.cpp
@@ -245,7 +245,7 @@ void InputMapper::UpdateListening() {
             bool updated = false;
             const DeviceState* boundDeviceState = getDeviceState(boundButton->joystickID);
             if (!boundDeviceState) {
-                LOG_WARN("InputMapper", "InputMapper: Bound joystick (ID: %u) not found for button binding.", boundButton->joystickID);
+                LOG_WARN("InputMapper", "Bound joystick (ID: %u) not found for button binding.", boundButton->joystickID);
                 CancelListening();
                 return;
             }

--- a/src/Mappers/LinuxExclusiveMode.cpp
+++ b/src/Mappers/LinuxExclusiveMode.cpp
@@ -1,3 +1,4 @@
+#include "App/Log.h"
 #include "LinuxExclusiveMode.h"
 
 #ifdef __linux__
@@ -42,10 +43,10 @@ std::vector<std::string> LinuxExclusiveMode::FindAllInputDevicePaths(SDL_Joystic
 
     const char* sdlPath = SDL_GetJoystickPath(joystick);
     if (!sdlPath) {
-        SDL_Log("LinuxExclusiveMode: cannot get joystick path.");
+        LOG_ERROR("ExclusiveMode", "LinuxExclusiveMode: cannot get joystick path.");
         return result;
     }
-    SDL_Log("LinuxExclusiveMode: SDL reported path = %s", sdlPath);
+    LOG_INFO("ExclusiveMode", "LinuxExclusiveMode: SDL reported path = %s", sdlPath);
 
     // Collect both event* and js* leaves from a sysfs input directory.
     auto collectInputNodes = [&](const std::filesystem::path& dir) {
@@ -57,14 +58,14 @@ std::vector<std::string> LinuxExclusiveMode::FindAllInputDevicePaths(SDL_Joystic
                 && std::isdigit(static_cast<unsigned char>(fname[5])))
             {
                 result.push_back("/dev/input/" + fname);
-                SDL_Log("LinuxExclusiveMode:  + evdev  %s", result.back().c_str());
+                LOG_INFO("ExclusiveMode", "LinuxExclusiveMode:  + evdev  %s", result.back().c_str());
             }
             // jsN  (/dev/input/jsN)
             else if (fname.rfind("js", 0) == 0 && fname.size() > 2
                      && std::isdigit(static_cast<unsigned char>(fname[2])))
             {
                 result.push_back("/dev/input/" + fname);
-                SDL_Log("LinuxExclusiveMode:  + joydev %s", result.back().c_str());
+                LOG_INFO("ExclusiveMode", "LinuxExclusiveMode:  + joydev %s", result.back().c_str());
             }
         }
     };
@@ -79,13 +80,13 @@ std::vector<std::string> LinuxExclusiveMode::FindAllInputDevicePaths(SDL_Joystic
                 && std::isdigit(static_cast<unsigned char>(fname[5])))
             {
                 result.push_back("/dev/input/" + fname);
-                SDL_Log("LinuxExclusiveMode:  + evdev  %s", result.back().c_str());
+                LOG_INFO("ExclusiveMode", "LinuxExclusiveMode:  + evdev  %s", result.back().c_str());
             }
             else if (fname.rfind("js", 0) == 0 && fname.size() > 2
                      && std::isdigit(static_cast<unsigned char>(fname[2])))
             {
                 result.push_back("/dev/input/" + fname);
-                SDL_Log("LinuxExclusiveMode:  + joydev %s", result.back().c_str());
+                LOG_INFO("ExclusiveMode", "LinuxExclusiveMode:  + joydev %s", result.back().c_str());
             }
         }
     };
@@ -112,14 +113,14 @@ std::vector<std::string> LinuxExclusiveMode::FindAllInputDevicePaths(SDL_Joystic
             }
             collectInputNodes(devPath);
         } catch (const std::exception& ex) {
-            SDL_Log("LinuxExclusiveMode: hidraw sysfs walk error: %s", ex.what());
+            LOG_ERROR("ExclusiveMode", "LinuxExclusiveMode: hidraw sysfs walk error: %s", ex.what());
         }
     }
     // ── Case 2: legacy joydev path (/dev/input/jsN) ───────────────────────
     else if (strncmp(sdlPath, "/dev/input/js", 13) == 0) {
         // Add the js node itself first.
         result.push_back(sdlPath);
-        SDL_Log("LinuxExclusiveMode:  + joydev %s", sdlPath);
+        LOG_INFO("ExclusiveMode", "LinuxExclusiveMode:  + joydev %s", sdlPath);
 
         // Walk sysfs to find sibling eventN nodes.
         int num = std::atoi(sdlPath + 13);
@@ -129,14 +130,14 @@ std::vector<std::string> LinuxExclusiveMode::FindAllInputDevicePaths(SDL_Joystic
         try {
             collectInputNodes(sysPath);
         } catch (...) {
-            SDL_Log("LinuxExclusiveMode: js%d sysfs walk failed.", num);
+            LOG_ERROR("ExclusiveMode", "LinuxExclusiveMode: js%d sysfs walk failed.", num);
         }
     }
     // ── Case 3: evdev path (/dev/input/eventN) ────────────────────────────
     else if (strncmp(sdlPath, "/dev/input/event", 16) == 0) {
         // Add the event node itself.
         result.push_back(sdlPath);
-        SDL_Log("LinuxExclusiveMode:  + evdev  %s", sdlPath);
+        LOG_INFO("ExclusiveMode", "LinuxExclusiveMode:  + evdev  %s", sdlPath);
 
         // Walk sysfs backward to find sibling js* nodes.
         // /sys/class/input/eventN -> device -> input -> inputN -> js*, event*
@@ -150,10 +151,10 @@ std::vector<std::string> LinuxExclusiveMode::FindAllInputDevicePaths(SDL_Joystic
                 std::filesystem::path(sysEventPath).parent_path()
                 / std::filesystem::read_symlink(sysEventPath));
 
-            SDL_Log("LinuxExclusiveMode: resolved inputN = %s", inputN.c_str());
+            LOG_INFO("ExclusiveMode", "LinuxExclusiveMode: resolved inputN = %s", inputN.c_str());
             collectFromInputN(inputN);
         } catch (const std::exception& ex) {
-            SDL_Log("LinuxExclusiveMode: eventN sysfs walk error: %s", ex.what());
+            LOG_ERROR("ExclusiveMode", "LinuxExclusiveMode: eventN sysfs walk error: %s", ex.what());
         }
     }
 
@@ -172,7 +173,7 @@ bool LinuxExclusiveMode::HideDevice(SDL_Joystick* joystick) {
 
     auto paths = FindAllInputDevicePaths(joystick);
     if (paths.empty()) {
-        SDL_Log("LinuxExclusiveMode: no input nodes found for '%s'.",
+        LOG_INFO("ExclusiveMode", "LinuxExclusiveMode: no input nodes found for '%s'.",
                 SDL_GetJoystickName(joystick));
         return false;
     }
@@ -186,7 +187,7 @@ bool LinuxExclusiveMode::HideDevice(SDL_Joystick* joystick) {
             // to us (not other processes) once we also hold the evdev grab.
             fd = open(devPath.c_str(), O_RDONLY | O_NONBLOCK);
             if (fd < 0) {
-                SDL_Log("LinuxExclusiveMode: open(%s) failed: %s",
+                LOG_ERROR("ExclusiveMode", "LinuxExclusiveMode: open(%s) failed: %s",
                         devPath.c_str(), strerror(errno));
                 continue;
             }
@@ -200,23 +201,23 @@ bool LinuxExclusiveMode::HideDevice(SDL_Joystick* joystick) {
             if (errno != ENOTTY && errno != EINVAL) {
                 // Real error (e.g. EBUSY — another process already has an
                 // exclusive grab).
-                SDL_Log("LinuxExclusiveMode: EVIOCGRAB on %s failed: %s",
+                LOG_ERROR("ExclusiveMode", "LinuxExclusiveMode: EVIOCGRAB on %s failed: %s",
                         devPath.c_str(), strerror(errno));
             } else {
-                SDL_Log("LinuxExclusiveMode: EVIOCGRAB not supported on %s "
+                LOG_INFO("ExclusiveMode", "LinuxExclusiveMode: EVIOCGRAB not supported on %s "
                         "(joydev node — fd held open).", devPath.c_str());
             }
             // Keep the fd open regardless so we at least hold a reference.
         }
 
         grabbed.push_back({fd, devPath});
-        SDL_Log("LinuxExclusiveMode: holding %s", devPath.c_str());
+        LOG_INFO("ExclusiveMode", "LinuxExclusiveMode: holding %s", devPath.c_str());
     }
 
     if (grabbed.empty()) return false;
 
     m_GrabbedDevices[id] = std::move(grabbed);
-    SDL_Log("LinuxExclusiveMode: '%s' is now hidden (%zu node(s) grabbed).",
+    LOG_INFO("ExclusiveMode", "LinuxExclusiveMode: '%s' is now hidden (%zu node(s) grabbed).",
             SDL_GetJoystickName(joystick), m_GrabbedDevices[id].size());
     return true;
 }
@@ -226,7 +227,7 @@ bool LinuxExclusiveMode::HideDevice(SDL_Joystick* joystick) {
 bool LinuxExclusiveMode::UnhideDevice(SDL_Joystick* joystick) {
     SDL_JoystickID id = SDL_GetJoystickID(joystick);
     ReleaseInstance(id);
-    SDL_Log("LinuxExclusiveMode: '%s' unhidden.", SDL_GetJoystickName(joystick));
+    LOG_INFO("ExclusiveMode", "LinuxExclusiveMode: '%s' unhidden.", SDL_GetJoystickName(joystick));
     return true;
 }
 
@@ -237,7 +238,7 @@ void LinuxExclusiveMode::ReleaseInstance(SDL_JoystickID id) {
     for (auto& entry : it->second) {
         ioctl(entry.fd, EVIOCGRAB, 0); // no-op on js* fds but harmless
         close(entry.fd);
-        SDL_Log("LinuxExclusiveMode: released %s", entry.path.c_str());
+        LOG_INFO("ExclusiveMode", "LinuxExclusiveMode: released %s", entry.path.c_str());
     }
     m_GrabbedDevices.erase(it);
 }

--- a/src/Mappers/MacOSExclusiveMode.cpp
+++ b/src/Mappers/MacOSExclusiveMode.cpp
@@ -1,3 +1,4 @@
+#include "App/Log.h"
 #include "MacOSExclusiveMode.h"
 
 #ifdef __APPLE__
@@ -58,21 +59,21 @@ bool MacOSExclusiveMode::HideDevice(SDL_Joystick* joystick) {
 
     IOHIDDeviceRef dev = FindHIDDevice(vid, pid);
     if (!dev) {
-        SDL_Log("MacOSExclusiveMode: could not find IOHIDDevice for '%s' "
+        LOG_INFO("ExclusiveMode", "MacOSExclusiveMode: could not find IOHIDDevice for '%s' "
                 "(VID=%04X PID=%04X).", SDL_GetJoystickName(joystick), vid, pid);
         return false;
     }
 
     IOReturn ret = IOHIDDeviceOpen(dev, kIOHIDOptionsTypeSeizeDevice);
     if (ret != kIOReturnSuccess) {
-        SDL_Log("MacOSExclusiveMode: IOHIDDeviceOpen(seize) failed for '%s': 0x%x.",
+        LOG_ERROR("ExclusiveMode", "MacOSExclusiveMode: IOHIDDeviceOpen(seize) failed for '%s': 0x%x.",
                 SDL_GetJoystickName(joystick), ret);
         CFRelease(dev);
         return false;
     }
 
     m_SeizedDevices[id] = dev;
-    SDL_Log("MacOSExclusiveMode: '%s' is now hidden.", SDL_GetJoystickName(joystick));
+    LOG_INFO("ExclusiveMode", "MacOSExclusiveMode: '%s' is now hidden.", SDL_GetJoystickName(joystick));
     return true;
 }
 
@@ -86,7 +87,7 @@ bool MacOSExclusiveMode::UnhideDevice(SDL_Joystick* joystick) {
     IOHIDDeviceClose(it->second, kIOHIDOptionsTypeSeizeDevice);
     CFRelease(it->second);
     m_SeizedDevices.erase(it);
-    SDL_Log("MacOSExclusiveMode: '%s' is now visible.", SDL_GetJoystickName(joystick));
+    LOG_INFO("ExclusiveMode", "MacOSExclusiveMode: '%s' is now visible.", SDL_GetJoystickName(joystick));
     return true;
 }
 

--- a/src/Mappers/OutputMapper.cpp
+++ b/src/Mappers/OutputMapper.cpp
@@ -1,3 +1,4 @@
+#include "App/Log.h"
 #include "OutputMapper.h"
 #include "imgui.h"
 #include "InputMapper.h"
@@ -358,7 +359,7 @@ void OutputMapper::UpdateHapticDevice(HapticTarget& target) {
                 if (SDL_HapticRumbleSupported(target.haptic_device)) {
                     if (!SDL_InitHapticRumble(target.haptic_device)) {
                         target.status_message = std::string("Rumble Init Failed: ") + SDL_GetError();
-                        SDL_Log("Warning: SDL_InitHapticRumble failed: %s", SDL_GetError());
+                        LOG_ERROR("OutputMapper", "Warning: SDL_InitHapticRumble failed: %s", SDL_GetError());
                     }
                 }
                 SDL_SetHapticGain(target.haptic_device, 100);

--- a/src/Mappers/WindowsExclusiveMode.cpp
+++ b/src/Mappers/WindowsExclusiveMode.cpp
@@ -1,3 +1,4 @@
+#include "App/Log.h"
 #include "WindowsExclusiveMode.h"
 
 #ifdef _WIN32
@@ -100,12 +101,12 @@ bool WindowsExclusiveMode::EnsureWhitelisted(const std::wstring &own, const std:
     }
 
     if (changed && !SetAllowList(wl)) {
-        SDL_Log("HidHide: failed to add InputBridge to the allow-list.");
+        LOG_ERROR("ExclusiveMode", "HidHide: failed to add InputBridge to the allow-list.");
         return false;
     }
 
     selfWhitelistedFlag = true;
-    SDL_Log("HidHide: InputBridge added to allow-list.");
+    LOG_INFO("ExclusiveMode", "HidHide: InputBridge added to allow-list.");
     return true;
 }
 
@@ -121,7 +122,7 @@ bool WindowsExclusiveMode::HideDevice(SDL_Joystick *joystick) {
 
     auto paths = GetInstancePaths(joystick);
     if (paths.empty()) {
-        SDL_Log("HidHide: could not determine instance path for '%s'.", SDL_GetJoystickName(joystick));
+        LOG_INFO("ExclusiveMode", "HidHide: could not determine instance path for '%s'.", SDL_GetJoystickName(joystick));
         return false;
     }
 
@@ -131,7 +132,7 @@ bool WindowsExclusiveMode::HideDevice(SDL_Joystick *joystick) {
         if (bl.find(p) == bl.end()) {
             bl.insert(p);
             changed = true;
-            SDL_Log("HidHide: hiding device path '%ls'.", p.c_str());
+            LOG_INFO("ExclusiveMode", "HidHide: hiding device path '%ls'.", p.c_str());
         }
     }
 
@@ -139,7 +140,7 @@ bool WindowsExclusiveMode::HideDevice(SDL_Joystick *joystick) {
         return true; // already hidden
 
     if (!SetBlockList(bl)) {
-        SDL_Log("HidHide: failed to write block-list.");
+        LOG_ERROR("ExclusiveMode", "HidHide: failed to write block-list.");
         return false;
     }
 
@@ -152,7 +153,7 @@ bool WindowsExclusiveMode::HideDevice(SDL_Joystick *joystick) {
         CloseHandle(h);
     }
 
-    SDL_Log("HidHide: '%s' is now hidden.", SDL_GetJoystickName(joystick));
+    LOG_INFO("ExclusiveMode", "HidHide: '%s' is now hidden.", SDL_GetJoystickName(joystick));
     return true;
 }
 
@@ -173,7 +174,7 @@ bool WindowsExclusiveMode::UnhideDevice(SDL_Joystick *joystick) {
         if (it != bl.end()) {
             bl.erase(it);
             changed = true;
-            SDL_Log("HidHide: unhiding device path '%ls'.", p.c_str());
+            LOG_INFO("ExclusiveMode", "HidHide: unhiding device path '%ls'.", p.c_str());
         }
     }
 
@@ -181,11 +182,11 @@ bool WindowsExclusiveMode::UnhideDevice(SDL_Joystick *joystick) {
         return true;
 
     if (!SetBlockList(bl)) {
-        SDL_Log("HidHide: failed to write block-list on unhide.");
+        LOG_ERROR("ExclusiveMode", "HidHide: failed to write block-list on unhide.");
         return false;
     }
 
-    SDL_Log("HidHide: '%s' is now visible to all applications.", SDL_GetJoystickName(joystick));
+    LOG_INFO("ExclusiveMode", "HidHide: '%s' is now visible to all applications.", SDL_GetJoystickName(joystick));
     return true;
 }
 
@@ -195,7 +196,7 @@ HANDLE WindowsExclusiveMode::OpenControlDevice() const {
     HANDLE h = CreateFileW(kHidHideDevice, GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
     if (h == INVALID_HANDLE_VALUE) {
         // Driver not installed — this is expected on systems without HidHide.
-        SDL_Log("HidHide: control device not found (driver not installed?).");
+        LOG_WARN("ExclusiveMode", "HidHide: control device not found (driver not installed?).");
     }
     return h;
 }
@@ -327,7 +328,7 @@ std::vector<std::wstring> WindowsExclusiveMode::GetInstancePaths(SDL_Joystick *j
 
         if (ipLow.find(prefix) == 0) {
             result.push_back(ip);
-            SDL_Log("HidHide: matched instance path '%ls'.", ip.c_str());
+            LOG_INFO("ExclusiveMode", "HidHide: matched instance path '%ls'.", ip.c_str());
         }
     }
 

--- a/src/Network/OSCServer.cpp
+++ b/src/Network/OSCServer.cpp
@@ -10,7 +10,6 @@
 #include "Protocols/ProtocolRegistry.h"
 #include "Protocols/OSCBaseProtocol.h"
 #include <SDL3/SDL_timer.h>
-#include <iostream>
 #include <string>
 #include <cstdarg>
 #include <algorithm>

--- a/src/Network/OSCServer.cpp
+++ b/src/Network/OSCServer.cpp
@@ -1,3 +1,4 @@
+#include "App/Log.h"
 #include "Network/OSCServer.h"
 #include "Network/OSCSubchannel.h"
 #include "Network/HapticDispatcher.h"
@@ -211,7 +212,7 @@ bool OSCServer::Start(const std::string& send_host, int send_port, int recv_port
     // Setup sending address
     m_send_address = lo_address_new(send_host.c_str(), std::to_string(send_port).c_str());
     if (!m_send_address) {
-        std::cerr << "OSC Error: Could not create send address " << send_host << ":" << send_port << std::endl;
+        LOG_ERROR("OSCServer", "Could not create send address %s:%d", send_host.c_str(), send_port);
         return false;
     }
 
@@ -219,7 +220,7 @@ bool OSCServer::Start(const std::string& send_host, int send_port, int recv_port
     std::string recv_port_str = std::to_string(recv_port);
     m_server_thread = lo_server_thread_new_with_proto(recv_port_str.c_str(), LO_UDP, nullptr);
     if (!m_server_thread) {
-        std::cerr << "OSC Error: Could not create server on port " << recv_port << std::endl;
+        LOG_ERROR("OSCServer", "Could not create server on port %d", recv_port);
         lo_address_free(m_send_address);
         m_send_address = nullptr;
         return false;
@@ -249,8 +250,8 @@ bool OSCServer::Start(const std::string& send_host, int send_port, int recv_port
     if (!m_OutputMapper && m_savedOutputMapper)
         m_OutputMapper = m_savedOutputMapper;
 
-    std::cout << "OSC server started. Sending to " << send_host << ":" << send_port
-              << ", Listening on port " << recv_port << std::endl;
+    LOG_INFO("OSCServer", "Started — sending to %s:%d, listening on port %d",
+             send_host.c_str(), send_port, recv_port);
 
     m_logs.push_back({"OSC server started. Sending to " + send_host + ":" + std::to_string(send_port) + ", Listening on port " + std::to_string(recv_port), false});
     if (m_logs.size() > 100) m_logs.pop_front();
@@ -322,7 +323,7 @@ void OSCServer::Stop() {
                 lo_address_free(address_to_free);
             }
             std::lock_guard<std::mutex> lock(m_mutex);
-            std::cout << "OSC server stopped." << std::endl;
+            LOG_INFO("OSCServer", "Stopped");
             m_logs.push_back({"OSC server stopped.", false});
             if (m_logs.size() > 100) m_logs.pop_front();
         });

--- a/src/Protocols/ProtocolDefinition.h
+++ b/src/Protocols/ProtocolDefinition.h
@@ -26,6 +26,15 @@ struct ProtocolField {
     std::string oscPath;   // OSC: the actual address to use (may differ from default)
     std::string wsKey;     // WebSocket: JSON key to use
     bool        enabled = true;
+
+    // Optional inline field definition — present only for fields that are not
+    // in the built-in catalog.  When set, ImportDefinition auto-registers them
+    // as custom FieldDescriptors so they appear in the editor without requiring
+    // a pre-existing entry in input_fields.json.
+    std::string inlineLabel;     // human-readable label, e.g. "Left Flipper"
+    std::string inlineCategory;  // category string, e.g. "Pinball"
+    FieldType   inlineType = FieldType::DigitalButton;
+    bool        hasInlineDef = false;  // true when the above fields are populated
 };
 
 // ─── Protocol direction ─────────────────────────────────────────────────────

--- a/src/Protocols/ProtocolDefinition.h
+++ b/src/Protocols/ProtocolDefinition.h
@@ -70,5 +70,11 @@ struct ProtocolDefinition {
     // Enabled data fields and their address/key overrides
     std::vector<ProtocolField> fields;
 
+    // Per-protocol visibility exclusions.  Fields / categories listed here are
+    // hidden from this protocol's editor tab but remain in the global catalog
+    // and are still available to every other protocol.
+    std::vector<std::string> excludedFieldIds;
+    std::vector<std::string> excludedCategories;
+
     bool active = false; // whether the server is currently running this definition
 };

--- a/src/Protocols/ProtocolEditorWindow.cpp
+++ b/src/Protocols/ProtocolEditorWindow.cpp
@@ -1279,16 +1279,22 @@ void ProtocolEditorWindow::DrawFieldTable(ProtocolDefinition& def,
                     if (isOsc) {
                         char pathBuffer[128];
                         std::strncpy(pathBuffer, pf->oscPath.c_str(), sizeof(pathBuffer));
-                        ImGui::SetNextItemWidth(200);
-                        if (ImGui::InputText("OSC Path", pathBuffer, sizeof(pathBuffer))) {
+                        ImGui::AlignTextToFramePadding();
+                        ImGui::TextUnformatted("OSC Path:");
+                        ImGui::SameLine();
+                        ImGui::SetNextItemWidth(-FLT_MIN);
+                        if (ImGui::InputText("##oscPath", pathBuffer, sizeof(pathBuffer))) {
                             pf->oscPath = pathBuffer;
                             pendingSave = true;
                         }
                     } else {
                         char keyBuffer[128];
                         std::strncpy(keyBuffer, pf->wsKey.c_str(), sizeof(keyBuffer));
-                        ImGui::SetNextItemWidth(200);
-                        if (ImGui::InputText("WS Key", keyBuffer, sizeof(keyBuffer))) {
+                        ImGui::AlignTextToFramePadding();
+                        ImGui::TextUnformatted("WS Key:");
+                        ImGui::SameLine();
+                        ImGui::SetNextItemWidth(-FLT_MIN);
+                        if (ImGui::InputText("##wsKey", keyBuffer, sizeof(keyBuffer))) {
                             pf->wsKey = keyBuffer;
                             pendingSave = true;
                         }
@@ -1777,11 +1783,19 @@ void ProtocolEditorWindow::DrawCreateFieldModal() {
         ImGui::Combo("Type", &s_cfType, types, 2);
 
         // ── OSC Path ──────────────────────────────────────────────────────
-        if (ImGui::InputText("Default OSC Path", s_cfOsc, sizeof(s_cfOsc)))
+        ImGui::AlignTextToFramePadding();
+        ImGui::TextUnformatted("Default OSC Path:");
+        ImGui::SameLine();
+        ImGui::SetNextItemWidth(-FLT_MIN);
+        if (ImGui::InputText("##cfOsc", s_cfOsc, sizeof(s_cfOsc)))
             s_cfOscManuallyModified = true;
 
         // ── WS Key ────────────────────────────────────────────────────────
-        if (ImGui::InputText("Default WS Key", s_cfWs, sizeof(s_cfWs)))
+        ImGui::AlignTextToFramePadding();
+        ImGui::TextUnformatted("Default WS Key:");
+        ImGui::SameLine();
+        ImGui::SetNextItemWidth(-FLT_MIN);
+        if (ImGui::InputText("##cfWs", s_cfWs, sizeof(s_cfWs)))
             s_cfWsManuallyModified = true;
 
         ImGui::Separator();

--- a/src/Protocols/ProtocolEditorWindow.cpp
+++ b/src/Protocols/ProtocolEditorWindow.cpp
@@ -733,6 +733,7 @@ void ProtocolEditorWindow::DrawContent() {
     DrawRenameCategoryModal();
     DrawDeleteCategoryModal();
     DrawMergeCategoryModal();
+    DrawHideCategoryModal();
     DrawSaveTemplateModal();
     DrawLoadTemplateModal();
     DrawValidationResultModal();
@@ -971,6 +972,10 @@ void ProtocolEditorWindow::DrawOutputFieldPicker() {
         s_mergeTgtCat[0] = '\0';
     }
 
+    if (WrapButton("Hide / Show Categories")) {
+        s_showHideCatModal = true;
+    }
+
     if (WrapButton("Save as Template")) {
         s_showSaveTemplateModal = true;
         std::strncpy(s_templateName, "New Template", sizeof(s_templateName));
@@ -1012,6 +1017,10 @@ void ProtocolEditorWindow::DrawInputFieldPicker() {
         s_mergeTgtCat[0] = '\0';
     }
 
+    if (WrapButton("Hide / Show Categories")) {
+        s_showHideCatModal = true;
+    }
+
     // Search filter
     ImGui::InputText("Filter", s_fieldFilter, sizeof(s_fieldFilter));
 
@@ -1042,12 +1051,21 @@ void ProtocolEditorWindow::DrawFieldTable(ProtocolDefinition& def,
     bool fieldDeleted = false;
     for (const auto& category : categories) {
         if (fieldDeleted) break;
-        // Count fields in this category that match filter
+
+        // Skip entire categories hidden for this protocol.
+        bool catExcluded = std::find(def.excludedCategories.begin(),
+                                     def.excludedCategories.end(),
+                                     category) != def.excludedCategories.end();
+        if (catExcluded) continue;
+
+        // Count fields in this category that match filter (and are not individually hidden).
         int matchCount = 0;
         for (const auto& fd : catalog) {
-            if (fd.category == category && MatchesFilter(fd, filter)) {
-                matchCount++;
-            }
+            if (fd.category != category || !MatchesFilter(fd, filter)) continue;
+            bool fieldExcluded = std::find(def.excludedFieldIds.begin(),
+                                           def.excludedFieldIds.end(),
+                                           fd.id) != def.excludedFieldIds.end();
+            if (!fieldExcluded) matchCount++;
         }
 
         if (matchCount == 0) {
@@ -1057,6 +1075,12 @@ void ProtocolEditorWindow::DrawFieldTable(ProtocolDefinition& def,
         if (ImGui::TreeNode(category.c_str())) {
             for (const auto& fd : catalog) {
                 if (fd.category != category || !MatchesFilter(fd, filter)) {
+                    continue;
+                }
+                // Skip fields hidden for this specific protocol.
+                if (std::find(def.excludedFieldIds.begin(),
+                              def.excludedFieldIds.end(),
+                              fd.id) != def.excludedFieldIds.end()) {
                     continue;
                 }
 
@@ -2095,6 +2119,68 @@ void ProtocolEditorWindow::DrawMergeCategoryModal() {
         if (!canMerge) ImGui::EndDisabled();
         ImGui::SameLine();
         if (ImGui::Button("Cancel", ImVec2(120, 0))) ImGui::CloseCurrentPopup();
+        ImGui::EndPopup();
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Modal: Hide / Show Categories (per-protocol)
+// ═══════════════════════════════════════════════════════════════════════════
+
+void ProtocolEditorWindow::DrawHideCategoryModal() {
+    if (s_showHideCatModal) {
+        ImGui::OpenPopup("Hide / Show Categories##modal");
+        s_showHideCatModal = false;
+    }
+
+    bool open = true;
+    if (ImGui::BeginPopupModal("Hide / Show Categories##modal", &open,
+                               ImGuiWindowFlags_AlwaysAutoResize)) {
+        auto& registry   = ProtocolRegistry::GetInstance();
+        auto& definitions = registry.GetDefinitions();
+        if (s_selectedIndex < 0 || s_selectedIndex >= (int)definitions.size()) {
+            ImGui::CloseCurrentPopup();
+        } else {
+            ProtocolDefinition& def = definitions[s_selectedIndex];
+
+            ImGui::TextWrapped(
+                "Tick the categories you want to hide from this protocol's field list.\n"
+                "Hidden categories are still available to all other protocols.");
+            ImGui::Separator();
+
+            // Build the full category list for the relevant catalog.
+            bool isOutput = (def.direction == ProtocolDirection::Output);
+            const auto& catalog = isOutput ? registry.GetOutputFields()
+                                           : registry.GetInputFields();
+            std::vector<std::string> cats;
+            for (const auto& fd : catalog)
+                if (std::find(cats.begin(), cats.end(), fd.category) == cats.end())
+                    cats.push_back(fd.category);
+            std::sort(cats.begin(), cats.end());
+
+            bool changed = false;
+            for (const auto& cat : cats) {
+                bool hidden = std::find(def.excludedCategories.begin(),
+                                        def.excludedCategories.end(),
+                                        cat) != def.excludedCategories.end();
+                if (ImGui::Checkbox(cat.c_str(), &hidden)) {
+                    if (hidden) {
+                        def.excludedCategories.push_back(cat);
+                    } else {
+                        def.excludedCategories.erase(
+                            std::remove(def.excludedCategories.begin(),
+                                        def.excludedCategories.end(), cat),
+                            def.excludedCategories.end());
+                    }
+                    changed = true;
+                }
+            }
+
+            if (changed) registry.SaveDefinition(def);
+
+            ImGui::Separator();
+            if (ImGui::Button("Close", ImVec2(120, 0))) ImGui::CloseCurrentPopup();
+        }
         ImGui::EndPopup();
     }
 }

--- a/src/Protocols/ProtocolEditorWindow.cpp
+++ b/src/Protocols/ProtocolEditorWindow.cpp
@@ -675,16 +675,18 @@ void ProtocolEditorWindow::DrawContent() {
         ShowExportDialog();
     }
 
-    if (!s_undoManager.CanUndo()) ImGui::BeginDisabled();
+    const bool canUndo = s_undoManager.CanUndo();
+    if (!canUndo) ImGui::BeginDisabled();
     if (WrapButton("Undo")) s_undoManager.Undo();
-    if (!s_undoManager.CanUndo()) ImGui::EndDisabled();
-    if (ImGui::IsItemHovered() && s_undoManager.CanUndo())
+    if (!canUndo) ImGui::EndDisabled();
+    if (ImGui::IsItemHovered() && canUndo)
         ImGui::SetTooltip("Undo: %s", s_undoManager.GetUndoDescription().c_str());
 
-    if (!s_undoManager.CanRedo()) ImGui::BeginDisabled();
+    const bool canRedo = s_undoManager.CanRedo();
+    if (!canRedo) ImGui::BeginDisabled();
     if (WrapButton("Redo")) s_undoManager.Redo();
-    if (!s_undoManager.CanRedo()) ImGui::EndDisabled();
-    if (ImGui::IsItemHovered() && s_undoManager.CanRedo())
+    if (!canRedo) ImGui::EndDisabled();
+    if (ImGui::IsItemHovered() && canRedo)
         ImGui::SetTooltip("Redo: %s", s_undoManager.GetRedoDescription().c_str());
 
     if (WrapButton("Backups...")) s_showBackupModal = true;

--- a/src/Protocols/ProtocolEditorWindow.cpp
+++ b/src/Protocols/ProtocolEditorWindow.cpp
@@ -5,6 +5,7 @@
 #include "../Core/UndoRedo.h"
 #include "../Core/BackupManager.h"
 #include "../Core/ProtocolValidator.h"
+#include "UI/IconsFontAwesome6.h"
 #include "imgui.h"
 #include <algorithm>
 #include <chrono>
@@ -1119,6 +1120,12 @@ void ProtocolEditorWindow::DrawFieldTable(ProtocolDefinition& def,
                     pendingSave = true;
                 }
 
+                ImGui::SameLine();
+                // Field type icon: sliders = analog axis, wave-square = digital button
+                const bool isDigital = (fd.type == FieldType::DigitalButton);
+                ImGui::TextDisabled("%s", isDigital ? ICON_FA_WAVE_SQUARE : ICON_FA_SLIDERS);
+                if (ImGui::IsItemHovered())
+                    ImGui::SetTooltip("%s", isDigital ? "Digital Button" : "Analog Axis");
                 ImGui::SameLine();
                 ImGui::TextUnformatted(fd.label.c_str());
 

--- a/src/Protocols/ProtocolEditorWindow.cpp
+++ b/src/Protocols/ProtocolEditorWindow.cpp
@@ -941,13 +941,19 @@ void ProtocolEditorWindow::DrawOutputFieldPicker() {
 
     // Field management buttons
     if (WrapButton("+ Create Field")) {
-        s_showCreateFieldModal = true;
-        s_cfId[0] = '\0';
-        s_cfLabel[0] = '\0';
+        s_showCreateFieldModal    = true;
+        s_cfIsEditing             = false;
+        s_cfIsDuplicate           = false;
+        s_cfId[0]                 = '\0';
+        s_cfLabel[0]              = '\0';
         std::strncpy(s_cfCategory, "Custom", sizeof(s_cfCategory));
-        s_cfType = 0;
+        s_cfType                  = 0;
         std::strncpy(s_cfOsc, "/custom/", sizeof(s_cfOsc));
-        std::strncpy(s_cfWs, "custom_", sizeof(s_cfWs));
+        std::strncpy(s_cfWs,  "custom_",  sizeof(s_cfWs));
+        s_cfIdManuallyModified    = false;
+        s_cfLabelManuallyModified = false;
+        s_cfOscManuallyModified   = false;
+        s_cfWsManuallyModified    = false;
     }
 
     if (WrapButton("Save as Preset")) {
@@ -1196,6 +1202,52 @@ void ProtocolEditorWindow::DrawFieldTable(ProtocolDefinition& def,
                                 fd.label.c_str());
                         }
                     }
+
+                    // Edit button
+                    ImGui::SameLine();
+                    std::string editId = "Edit##edit_" + fd.id;
+                    if (ImGui::SmallButton(editId.c_str())) {
+                        s_showCreateFieldModal = true;
+                        s_cfIsEditing         = true;
+                        s_cfIsDuplicate       = false;
+                        std::strncpy(s_cfEditingId, fd.id.c_str(),       sizeof(s_cfEditingId));
+                        std::strncpy(s_cfId,        fd.id.c_str(),       sizeof(s_cfId));
+                        std::strncpy(s_cfLabel,     fd.label.c_str(),    sizeof(s_cfLabel));
+                        std::strncpy(s_cfCategory,  fd.category.c_str(), sizeof(s_cfCategory));
+                        std::strncpy(s_cfOsc,       fd.defaultOscPath.c_str(), sizeof(s_cfOsc));
+                        std::strncpy(s_cfWs,        fd.defaultWsKey.c_str(),   sizeof(s_cfWs));
+                        s_cfType                  = (fd.type == FieldType::DigitalButton) ? 1 : 0;
+                        s_cfIdManuallyModified    = true;  // Lock ID when editing
+                        s_cfLabelManuallyModified = true;
+                        s_cfOscManuallyModified   = true;  // Preserve existing paths
+                        s_cfWsManuallyModified    = true;
+                    }
+                    if (ImGui::IsItemHovered())
+                        ImGui::SetTooltip("Edit field '%s'", fd.label.c_str());
+
+                    // Duplicate button
+                    ImGui::SameLine();
+                    std::string dupId = "Dup##dup_" + fd.id;
+                    if (ImGui::SmallButton(dupId.c_str())) {
+                        s_showCreateFieldModal = true;
+                        s_cfIsEditing         = false;
+                        s_cfIsDuplicate       = true;
+                        s_cfEditingId[0]      = '\0';
+                        // Pre-fill from the source field; the user must give it a new ID.
+                        std::string newId = fd.id + "_copy";
+                        std::strncpy(s_cfId,       newId.c_str(),        sizeof(s_cfId));
+                        std::strncpy(s_cfLabel,    (fd.label + " Copy").c_str(), sizeof(s_cfLabel));
+                        std::strncpy(s_cfCategory, fd.category.c_str(),  sizeof(s_cfCategory));
+                        std::strncpy(s_cfOsc,      fd.defaultOscPath.c_str(), sizeof(s_cfOsc));
+                        std::strncpy(s_cfWs,       fd.defaultWsKey.c_str(),   sizeof(s_cfWs));
+                        s_cfType                  = (fd.type == FieldType::DigitalButton) ? 1 : 0;
+                        s_cfIdManuallyModified    = true;
+                        s_cfLabelManuallyModified = true;
+                        s_cfOscManuallyModified   = true;
+                        s_cfWsManuallyModified    = true;
+                    }
+                    if (ImGui::IsItemHovered())
+                        ImGui::SetTooltip("Duplicate field '%s'", fd.label.c_str());
                 }
 
                 // Show override controls if enabled
@@ -1546,141 +1598,177 @@ void ProtocolEditorWindow::DrawCreateFieldModal() {
     if (s_showCreateFieldModal) {
         ImGui::OpenPopup("Create/Edit Field##modal");
         s_showCreateFieldModal = false;
-        s_cfIdManuallyModified = false;
-        s_cfLabelManuallyModified = false;
+        // New field — clear everything when not pre-filled by edit/dup buttons.
+        if (!s_cfIsEditing && !s_cfIsDuplicate) {
+            s_cfId[0] = '\0';
+            s_cfLabel[0] = '\0';
+            std::strncpy(s_cfCategory, "Custom", sizeof(s_cfCategory));
+            s_cfType = 0;
+            std::strncpy(s_cfOsc, "/custom/", sizeof(s_cfOsc));
+            std::strncpy(s_cfWs,  "custom_",  sizeof(s_cfWs));
+            s_cfIdManuallyModified    = false;
+            s_cfLabelManuallyModified = false;
+            s_cfOscManuallyModified   = false;
+            s_cfWsManuallyModified    = false;
+        }
     }
 
-    bool open = true;
-    if (ImGui::BeginPopupModal("Create/Edit Field##modal", &open, ImGuiWindowFlags_AlwaysAutoResize)) {
-        bool idChanged = false;
+    // Helper: turn a string into a safe slug (lower-case, underscores).
+    auto slugify = [](const char* src) -> std::string {
+        std::string out;
+        for (const char* p = src; *p; ++p) {
+            char c = *p;
+            if (std::isalnum((unsigned char)c))
+                out += (char)std::tolower((unsigned char)c);
+            else if ((c == ' ' || c == '-' || c == '_') && !out.empty() && out.back() != '_')
+                out += '_';
+        }
+        // Trim trailing underscore
+        while (!out.empty() && out.back() == '_') out.pop_back();
+        return out;
+    };
 
-        if (ImGui::InputText("ID", s_cfId, sizeof(s_cfId))) {
-            s_cfIdManuallyModified = true;
-            idChanged = true;
-            if (!s_cfLabelManuallyModified) {
-                std::strncpy(s_cfLabel, s_cfId, sizeof(s_cfLabel));
+    // Derive the OSC / WS defaults from the current category slug.
+    auto updatePathDefaults = [&]() {
+        std::string slug = slugify(s_cfCategory);
+        if (slug.empty()) slug = "custom";
+        std::string idSlug = slugify(s_cfId);
+        if (!s_cfOscManuallyModified)
+            std::snprintf(s_cfOsc, sizeof(s_cfOsc), "/%s/%s", slug.c_str(), idSlug.c_str());
+        if (!s_cfWsManuallyModified)
+            std::snprintf(s_cfWs, sizeof(s_cfWs), "%s_%s", slug.c_str(), idSlug.c_str());
+    };
+
+    bool open = true;
+    const char* title = s_cfIsEditing ? "Edit Field##modal" : "Create/Edit Field##modal";
+    if (ImGui::BeginPopupModal(title, &open, ImGuiWindowFlags_AlwaysAutoResize)) {
+        auto& registry = ProtocolRegistry::GetInstance();
+
+        bool idChanged       = false;
+        bool categoryChanged = false;
+
+        // ── ID ────────────────────────────────────────────────────────────
+        if (s_cfIsEditing) {
+            // ID is immutable when editing an existing field.
+            ImGui::BeginDisabled();
+            ImGui::InputText("ID", s_cfId, sizeof(s_cfId));
+            ImGui::EndDisabled();
+        } else {
+            if (ImGui::InputText("ID", s_cfId, sizeof(s_cfId))) {
+                s_cfIdManuallyModified = true;
+                idChanged = true;
+                if (!s_cfLabelManuallyModified)
+                    std::strncpy(s_cfLabel, s_cfId, sizeof(s_cfLabel));
             }
         }
 
+        // ── Label ─────────────────────────────────────────────────────────
         if (ImGui::InputText("Label", s_cfLabel, sizeof(s_cfLabel))) {
             s_cfLabelManuallyModified = true;
-            if (!s_cfIdManuallyModified) {
+            if (!s_cfIdManuallyModified && !s_cfIsEditing) {
                 // Auto-generate ID from label
-                std::string slug;
-                for (char* p = s_cfLabel; *p; ++p) {
-                    char c = *p;
-                    if (std::isalnum((unsigned char)c)) {
-                        slug += (char)std::tolower((unsigned char)c);
-                    } else if (c == ' ' || c == '-' || c == '_') {
-                        if (!slug.empty() && slug.back() != '_') {
-                            slug += '_';
-                        }
-                    }
-                }
-                if (slug.length() >= sizeof(s_cfId)) {
-                    slug.resize(sizeof(s_cfId) - 1);
-                }
+                std::string slug = slugify(s_cfLabel);
+                if (slug.length() >= sizeof(s_cfId)) slug.resize(sizeof(s_cfId) - 1);
                 std::strncpy(s_cfId, slug.c_str(), sizeof(s_cfId));
                 idChanged = true;
             }
         }
 
-        if (idChanged) {
-            std::snprintf(s_cfOsc, sizeof(s_cfOsc), "/custom/%s", s_cfId);
-            std::snprintf(s_cfWs, sizeof(s_cfWs), "custom_%s", s_cfId);
-        }
+        if (idChanged) updatePathDefaults();
 
-        // Collect existing categories for dropdown
+        // ── Category ──────────────────────────────────────────────────────
         std::vector<std::string> categories;
-        auto& registry = ProtocolRegistry::GetInstance();
-
-        for (const auto& field : registry.GetOutputFields()) {
-            if (std::find(categories.begin(), categories.end(), field.category) == categories.end()) {
-                categories.push_back(field.category);
-            }
-        }
-        for (const auto& field : registry.GetInputFields()) {
-            if (std::find(categories.begin(), categories.end(), field.category) == categories.end()) {
-                categories.push_back(field.category);
-            }
-        }
+        for (const auto& f : registry.GetOutputFields())
+            if (std::find(categories.begin(), categories.end(), f.category) == categories.end())
+                categories.push_back(f.category);
+        for (const auto& f : registry.GetInputFields())
+            if (std::find(categories.begin(), categories.end(), f.category) == categories.end())
+                categories.push_back(f.category);
         std::sort(categories.begin(), categories.end());
 
-        // Category input with dropdown
-        float buttonSize = ImGui::GetFrameHeight();
+        float btnSize  = ImGui::GetFrameHeight();
         float itemWidth = ImGui::CalcItemWidth();
-        ImGui::SetNextItemWidth(itemWidth - buttonSize - ImGui::GetStyle().ItemInnerSpacing.x);
-        ImGui::InputText("##Category", s_cfCategory, sizeof(s_cfCategory));
+        ImGui::SetNextItemWidth(itemWidth - btnSize - ImGui::GetStyle().ItemInnerSpacing.x);
+        char prevCat[64];
+        std::strncpy(prevCat, s_cfCategory, sizeof(prevCat));
+        if (ImGui::InputText("##Category", s_cfCategory, sizeof(s_cfCategory))) {
+            categoryChanged = true;
+        }
         ImGui::SameLine(0, ImGui::GetStyle().ItemInnerSpacing.x);
-        ImGui::SetNextItemWidth(buttonSize);
+        ImGui::SetNextItemWidth(btnSize);
         if (ImGui::BeginCombo("Category", nullptr, ImGuiComboFlags_NoPreview)) {
-            for (const auto& category : categories) {
-                if (ImGui::Selectable(category.c_str())) {
-                    std::strncpy(s_cfCategory, category.c_str(), sizeof(s_cfCategory));
+            for (const auto& cat : categories) {
+                if (ImGui::Selectable(cat.c_str())) {
+                    std::strncpy(s_cfCategory, cat.c_str(), sizeof(s_cfCategory));
                     s_cfCategory[sizeof(s_cfCategory) - 1] = '\0';
+                    categoryChanged = true;
                 }
             }
             ImGui::EndCombo();
         }
+        if (categoryChanged) updatePathDefaults();
 
+        // ── Type ──────────────────────────────────────────────────────────
         const char* types[] = {"Analog Axis", "Digital Button"};
         ImGui::Combo("Type", &s_cfType, types, 2);
 
-        ImGui::InputText("Default OSC Path", s_cfOsc, sizeof(s_cfOsc));
-        ImGui::InputText("Default WS Key", s_cfWs, sizeof(s_cfWs));
+        // ── OSC Path ──────────────────────────────────────────────────────
+        if (ImGui::InputText("Default OSC Path", s_cfOsc, sizeof(s_cfOsc)))
+            s_cfOscManuallyModified = true;
+
+        // ── WS Key ────────────────────────────────────────────────────────
+        if (ImGui::InputText("Default WS Key", s_cfWs, sizeof(s_cfWs)))
+            s_cfWsManuallyModified = true;
 
         ImGui::Separator();
 
-        // Check if ID already exists
+        // ── Validation ────────────────────────────────────────────────────
         bool idExists = false;
-        for (const auto& field : registry.GetOutputFields()) {
-            if (field.id == s_cfId) {
-                idExists = true;
-                break;
-            }
-        }
-        if (!idExists) {
-            for (const auto& field : registry.GetInputFields()) {
-                if (field.id == s_cfId) {
-                    idExists = true;
-                    break;
-                }
-            }
-        }
-
-        if (idExists) {
-            ImGui::TextColored(ImVec4(1, 0.4f, 0.4f, 1), "ID already exists!");
+        if (!s_cfIsEditing) {
+            for (const auto& f : registry.GetOutputFields())
+                if (f.id == s_cfId) { idExists = true; break; }
+            if (!idExists)
+                for (const auto& f : registry.GetInputFields())
+                    if (f.id == s_cfId) { idExists = true; break; }
+            if (idExists)
+                ImGui::TextColored(ImVec4(1, 0.4f, 0.4f, 1), "ID already exists!");
         }
 
         bool canSave = (s_cfId[0] != '\0') && !idExists;
-        if (!canSave) {
-            ImGui::BeginDisabled();
-        }
+        if (!canSave) ImGui::BeginDisabled();
 
-        if (ImGui::Button("Save Field", ImVec2(120, 0))) {
-            if (s_cfLabel[0] == '\0') {
+        const char* saveLabel = s_cfIsEditing ? "Update Field" : "Save Field";
+        if (ImGui::Button(saveLabel, ImVec2(120, 0))) {
+            if (s_cfLabel[0] == '\0')
                 std::strncpy(s_cfLabel, s_cfId, sizeof(s_cfLabel));
-            }
 
             FieldDescriptor fd;
-            fd.id = s_cfId;
-            fd.label = s_cfLabel;
-            fd.category = s_cfCategory;
-            fd.type = (s_cfType == 1) ? FieldType::DigitalButton : FieldType::AnalogAxis;
+            fd.id             = s_cfId;
+            fd.label          = s_cfLabel;
+            fd.category       = s_cfCategory;
+            fd.type           = (s_cfType == 1) ? FieldType::DigitalButton : FieldType::AnalogAxis;
             fd.defaultOscPath = s_cfOsc;
-            fd.defaultWsKey = s_cfWs;
-            fd.isBuiltIn = false;
+            fd.defaultWsKey   = s_cfWs;
+            fd.isBuiltIn      = false;
 
-            registry.AddOutputField(fd);
+            if (s_cfIsEditing) {
+                registry.UpdateOutputField(s_cfEditingId, fd);
+            } else {
+                registry.AddOutputField(fd);
+            }
+
+            // Reset mode flags
+            s_cfIsEditing   = false;
+            s_cfIsDuplicate = false;
             ImGui::CloseCurrentPopup();
         }
 
-        if (!canSave) {
-            ImGui::EndDisabled();
-        }
+        if (!canSave) ImGui::EndDisabled();
 
         ImGui::SameLine();
         if (ImGui::Button("Cancel", ImVec2(120, 0))) {
+            s_cfIsEditing   = false;
+            s_cfIsDuplicate = false;
             ImGui::CloseCurrentPopup();
         }
 

--- a/src/Protocols/ProtocolEditorWindow.cpp
+++ b/src/Protocols/ProtocolEditorWindow.cpp
@@ -650,6 +650,12 @@ void ProtocolEditorWindow::DrawContent() {
         s_settingsLoaded = true;
     }
 
+    // ── Keyboard Shortcuts ───────────────────────────────────────────────────
+    if (ImGui::Shortcut(ImGuiMod_Shortcut | ImGuiKey_Z))
+        s_undoManager.Undo();
+    if (ImGui::Shortcut(ImGuiMod_Shortcut | ImGuiKey_Y) || ImGui::Shortcut(ImGuiMod_Shortcut | ImGuiMod_Shift | ImGuiKey_Z))
+        s_undoManager.Redo();
+
     // Handle drag-and-drop of .json files onto the window
     if (ImGui::BeginDragDropTarget()) {
         if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload("DND_FILE")) {
@@ -682,20 +688,22 @@ void ProtocolEditorWindow::DrawContent() {
     if (WrapButton("Export...")) {
         ShowExportDialog();
     }
+    
+    const char* modName = ImGui::GetIO().ConfigMacOSXBehaviors ? "Cmd" : "Ctrl";
 
     const bool canUndo = s_undoManager.CanUndo();
     if (!canUndo) ImGui::BeginDisabled();
     if (WrapButton("Undo")) s_undoManager.Undo();
     if (!canUndo) ImGui::EndDisabled();
     if (ImGui::IsItemHovered() && canUndo)
-        ImGui::SetTooltip("Undo: %s", s_undoManager.GetUndoDescription().c_str());
+        ImGui::SetTooltip("Undo: %s (%s+Z)", s_undoManager.GetUndoDescription().c_str(), modName);
 
     const bool canRedo = s_undoManager.CanRedo();
     if (!canRedo) ImGui::BeginDisabled();
     if (WrapButton("Redo")) s_undoManager.Redo();
     if (!canRedo) ImGui::EndDisabled();
     if (ImGui::IsItemHovered() && canRedo)
-        ImGui::SetTooltip("Redo: %s", s_undoManager.GetRedoDescription().c_str());
+        ImGui::SetTooltip("Redo: %s (%s+Y or %s+Shift+Z)", s_undoManager.GetRedoDescription().c_str(), modName, modName);
 
     if (WrapButton("Backups...")) s_showBackupModal = true;
 

--- a/src/Protocols/ProtocolEditorWindow.cpp
+++ b/src/Protocols/ProtocolEditorWindow.cpp
@@ -1,3 +1,4 @@
+#include "App/Log.h"
 #include "ProtocolEditorWindow.h"
 #include "ProtocolRegistry.h"
 #include "ProtocolDefinition.h"
@@ -97,7 +98,7 @@ void ProtocolEditorWindow::LoadSettings() {
         }
     } catch (const std::exception& e) {
         // Silently ignore settings load errors
-        fprintf(stderr, "Failed to load protocol editor settings: %s\n", e.what());
+        LOG_ERROR("ProtocolEditor", "Failed to load protocol editor settings: %s", e.what());
     }
 }
 
@@ -110,7 +111,7 @@ void ProtocolEditorWindow::SaveSettings() {
         std::ofstream outputFile(SETTINGS_FILE);
         outputFile << settingsJson.dump(4);
     } catch (const std::exception& e) {
-        fprintf(stderr, "Failed to save protocol editor settings: %s\n", e.what());
+        LOG_ERROR("ProtocolEditor", "Failed to save protocol editor settings: %s", e.what());
     }
 }
 
@@ -777,7 +778,7 @@ void ProtocolEditorWindow::HandleDroppedFile(const std::string& filePath) {
     }
 
     if (ValidateAndImportProtocol(filePath)) {
-        printf("Successfully imported protocol via drag-and-drop: %s\n", filePath.c_str());
+        LOG_INFO("ProtocolEditor", "Successfully imported protocol via drag-and-drop: %s", filePath.c_str());
     }
 }
 
@@ -1792,11 +1793,11 @@ void ProtocolEditorWindow::CreateBackupBeforeOperation(const std::string& operat
     std::string catalogPath = ProtocolRegistry::GetProtocolsDir() + "/input_fields.json";
     std::string backupPath  = s_backupManager.CreateBackup(catalogPath);
     if (!backupPath.empty())
-        printf("Created backup before %s: %s\n", operationName.c_str(), backupPath.c_str());
+        LOG_INFO("ProtocolEditor", "Created backup before %s: %s", operationName.c_str(), backupPath.c_str());
 
     std::string defsBackup = s_backupManager.CreateDirectoryBackup(ProtocolRegistry::GetDefsDir());
     if (!defsBackup.empty())
-        printf("Created definitions backup: %s\n", defsBackup.c_str());
+        LOG_INFO("ProtocolEditor", "Created definitions backup: %s", defsBackup.c_str());
 }
 
 bool ProtocolEditorWindow::ValidateAndImportProtocol(const std::string& filePath) {
@@ -2156,9 +2157,9 @@ void ProtocolEditorWindow::DrawSaveTemplateModal() {
 
                     std::ofstream out(templatePath);
                     out << j.dump(4);
-                    printf("Saved template: %s\n", templatePath.c_str());
+                    LOG_INFO("ProtocolEditor", "Saved template: %s", templatePath.c_str());
                 } catch (const std::exception& e) {
-                    fprintf(stderr, "Failed to save template: %s\n", e.what());
+                    LOG_ERROR("ProtocolEditor", "Failed to save template: %s", e.what());
                 }
             }
             ImGui::CloseCurrentPopup();
@@ -2268,7 +2269,7 @@ void ProtocolEditorWindow::DrawLoadTemplateModal() {
                     registry.SaveDefinition(def);
                 }
             } catch (const std::exception& e) {
-                fprintf(stderr, "Failed to load template: %s\n", e.what());
+                LOG_ERROR("ProtocolEditor", "Failed to load template: %s", e.what());
             }
             ImGui::CloseCurrentPopup();
         }

--- a/src/Protocols/ProtocolEditorWindow.cpp
+++ b/src/Protocols/ProtocolEditorWindow.cpp
@@ -636,6 +636,13 @@ static bool WrapButton(const char* label, ImVec2 size = ImVec2(0, 0)) {
     return ImGui::Button(label, size);
 }
 
+// Call once at the top of any BeginPopupModal block to close it with ESC.
+static void CloseModalOnEscape() {
+    if (ImGui::IsWindowFocused(ImGuiFocusedFlags_RootAndChildWindows) &&
+        ImGui::IsKeyPressed(ImGuiKey_Escape))
+        ImGui::CloseCurrentPopup();
+}
+
 void ProtocolEditorWindow::DrawContent() {
     if (!s_settingsLoaded) {
         LoadSettings();
@@ -1299,6 +1306,7 @@ void ProtocolEditorWindow::DrawNewProtocolModal() {
 
     bool open = true;
     if (ImGui::BeginPopupModal("New Protocol##modal", &open, ImGuiWindowFlags_AlwaysAutoResize)) {
+        CloseModalOnEscape();
         ImGui::InputText("Name", s_newName, sizeof(s_newName));
 
         const char* transports[] = {"OSC", "WebSocket"};
@@ -1387,6 +1395,7 @@ void ProtocolEditorWindow::DrawDuplicateProtocolModal() {
 
     bool open = true;
     if (ImGui::BeginPopupModal("Duplicate Protocol##modal", &open, ImGuiWindowFlags_AlwaysAutoResize)) {
+        CloseModalOnEscape();
         ImGui::InputText("New Name", s_dupName, sizeof(s_dupName));
 
         const char* transports[] = {"OSC", "WebSocket"};
@@ -1430,6 +1439,7 @@ void ProtocolEditorWindow::DrawRenameCategoryModal() {
 
     bool open = true;
     if (ImGui::BeginPopupModal("Rename Category##modal", &open, ImGuiWindowFlags_AlwaysAutoResize)) {
+        CloseModalOnEscape();
         ImGui::Text("Rename a category across all fields");
 
         // Collect existing categories
@@ -1509,6 +1519,7 @@ void ProtocolEditorWindow::DrawDeleteCategoryModal() {
 
     bool open = true;
     if (ImGui::BeginPopupModal("Delete Category##modal", &open, ImGuiWindowFlags_AlwaysAutoResize)) {
+        CloseModalOnEscape();
         ImGui::TextWrapped("Delete a category and all its fields");
         ImGui::TextColored(ImVec4(1, 0.4f, 0.4f, 1), "Warning: This cannot be undone!");
 
@@ -1644,6 +1655,7 @@ void ProtocolEditorWindow::DrawCreateFieldModal() {
     bool open = true;
     const char* title = s_cfIsEditing ? "Edit Field##modal" : "Create/Edit Field##modal";
     if (ImGui::BeginPopupModal(title, &open, ImGuiWindowFlags_AlwaysAutoResize)) {
+        CloseModalOnEscape();
         auto& registry = ProtocolRegistry::GetInstance();
 
         bool idChanged       = false;
@@ -1787,6 +1799,7 @@ void ProtocolEditorWindow::DrawExportProtocolModal() {
     bool open = true;
     ImGui::SetNextWindowSize(ImVec2(780, 540), ImGuiCond_FirstUseEver);
     if (ImGui::BeginPopupModal("Export Protocol##modal", &open)) {
+        CloseModalOnEscape();
 
         float footerH = ImGui::GetFrameHeightWithSpacing() * 2.0f + ImGui::GetStyle().ItemSpacing.y * 2;
         {
@@ -1843,6 +1856,7 @@ void ProtocolEditorWindow::DrawImportProtocolModal() {
     bool open = true;
     ImGui::SetNextWindowSize(ImVec2(780, 540), ImGuiCond_FirstUseEver);
     if (ImGui::BeginPopupModal("Import Protocol##modal", &open)) {
+        CloseModalOnEscape();
 
         float footerH = ImGui::GetFrameHeightWithSpacing() * 2.0f + ImGui::GetStyle().ItemSpacing.y * 2;
         {
@@ -1885,6 +1899,7 @@ void ProtocolEditorWindow::DrawSavePresetModal() {
 
     bool open = true;
     if (ImGui::BeginPopupModal("Save Preset##modal", &open, ImGuiWindowFlags_AlwaysAutoResize)) {
+        CloseModalOnEscape();
         ImGui::Text("Save current enabled fields as a preset");
         ImGui::InputText("Preset Name", s_presetName, sizeof(s_presetName));
 
@@ -2122,6 +2137,7 @@ void ProtocolEditorWindow::DrawLoadPresetModal() {
 
     bool open = true;
     if (ImGui::BeginPopupModal("Load Preset##modal", &open, ImGuiWindowFlags_AlwaysAutoResize)) {
+        CloseModalOnEscape();
         ImGui::Text("Apply a preset to the current protocol");
         ImGui::Separator();
 
@@ -2194,6 +2210,7 @@ void ProtocolEditorWindow::DrawMergeCategoryModal() {
 
     bool open = true;
     if (ImGui::BeginPopupModal("Merge Categories##modal", &open, ImGuiWindowFlags_AlwaysAutoResize)) {
+        CloseModalOnEscape();
         ImGui::TextWrapped("Move all fields from the source category into the target category, then remove the source.");
 
         auto categories = GetAllCategories();
@@ -2251,8 +2268,22 @@ void ProtocolEditorWindow::DrawHideCategoryModal() {
     }
 
     bool open = true;
+    ImGuiViewport* viewport = ImGui::GetMainViewport();
+
+    // Size: at least 320px wide, up to 40% of the main viewport width.
+    float vpWidth   = viewport->WorkSize.x;
+    float modalW    = std::clamp(vpWidth * 0.40f, 320.0f, 600.0f);
+
+    // Auto-center when opened or when the main window is resized.
+    static ImVec2 lastVpSize = { 0.0f, 0.0f };
+    bool vpResized = (viewport->WorkSize.x != lastVpSize.x || viewport->WorkSize.y != lastVpSize.y);
+    if (vpResized) { lastVpSize = viewport->WorkSize; }
+    ImGui::SetNextWindowPos(viewport->GetCenter(), vpResized ? ImGuiCond_Always : ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+
+    ImGui::SetNextWindowSizeConstraints(ImVec2(modalW, 0.0f), ImVec2(modalW, FLT_MAX));
     if (ImGui::BeginPopupModal("Hide / Show Categories##modal", &open,
                                ImGuiWindowFlags_AlwaysAutoResize)) {
+        CloseModalOnEscape();
         auto& registry   = ProtocolRegistry::GetInstance();
         auto& definitions = registry.GetDefinitions();
         if (s_selectedIndex < 0 || s_selectedIndex >= (int)definitions.size()) {
@@ -2314,6 +2345,7 @@ void ProtocolEditorWindow::DrawSaveTemplateModal() {
 
     bool open = true;
     if (ImGui::BeginPopupModal("Save Template##modal", &open, ImGuiWindowFlags_AlwaysAutoResize)) {
+        CloseModalOnEscape();
         ImGui::Text("Save the current protocol as a reusable template.");
         ImGui::Separator();
 
@@ -2396,6 +2428,7 @@ void ProtocolEditorWindow::DrawLoadTemplateModal() {
     bool open = true;
     ImGui::SetNextWindowSize(ImVec2(500, 340), ImGuiCond_FirstUseEver);
     if (ImGui::BeginPopupModal("Load Template##modal", &open)) {
+        CloseModalOnEscape();
         // Enumerate template files
         std::string templatesDir = ProtocolRegistry::GetProtocolsDir() + "/templates";
         std::vector<std::string> templatePaths;
@@ -2506,6 +2539,7 @@ void ProtocolEditorWindow::DrawValidationResultModal() {
     // allowing AlwaysAutoResize to size the height to the wrapped text.
     ImGui::SetNextWindowSizeConstraints(ImVec2(480, 0), ImVec2(FLT_MAX, FLT_MAX));
     if (ImGui::BeginPopupModal("Validation Result##modal", &open, ImGuiWindowFlags_AlwaysAutoResize)) {
+        CloseModalOnEscape();
         if (s_validationIsError)
             ImGui::TextColored(ImVec4(1.0f, 0.3f, 0.3f, 1.0f), "Validation Failed");
         else
@@ -2533,6 +2567,7 @@ void ProtocolEditorWindow::DrawBackupManagerModal() {
     bool open = true;
     ImGui::SetNextWindowSize(ImVec2(400, 220), ImGuiCond_FirstUseEver);
     if (ImGui::BeginPopupModal("Backup Manager##modal", &open)) {
+        CloseModalOnEscape();
         ImGui::Text("Automatic Backup System");
         ImGui::Separator();
 

--- a/src/Protocols/ProtocolEditorWindow.cpp
+++ b/src/Protocols/ProtocolEditorWindow.cpp
@@ -1114,40 +1114,56 @@ void ProtocolEditorWindow::DrawFieldTable(ProtocolDefinition& def,
                     ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.6f, 0.2f, 0.2f, 1.0f));
                     ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.8f, 0.2f, 0.2f, 1.0f));
                     ImGui::PushStyleColor(ImGuiCol_ButtonActive, ImVec4(0.5f, 0.1f, 0.1f, 1.0f));
-                    if (ImGui::Button("X")) {
-                        bool usedElsewhere = false;
-                        for (const auto& d : registry.GetDefinitions()) {
-                            if (d.id == def.id) continue;
-                            for (const auto& f : d.fields) {
-                                if (f.fieldId == fd.id) {
-                                    usedElsewhere = true;
-                                    break;
-                                }
-                            }
-                            if (usedElsewhere) break;
+
+                    // Pre-compute before the button so the result is also
+                    // available for the tooltip rendered after the button.
+                    bool usedElsewhere = false;
+                    for (const auto& d : registry.GetDefinitions()) {
+                        if (d.id == def.id) continue;
+                        for (const auto& f : d.fields) {
+                            if (f.fieldId == fd.id) { usedElsewhere = true; break; }
                         }
+                        if (usedElsewhere) break;
+                    }
+
+                    if (ImGui::Button("X")) {
 
                         if (usedElsewhere) {
+                            // Field is still used by other protocols so we
+                            // cannot remove it from the global catalog.
+                            // Instead: remove it from this protocol's active
+                            // field list AND add it to the per-protocol
+                            // exclusion list so it is hidden from the picker.
                             if (pf) {
-                                CreateBackupBeforeOperation("remove field '" + fd.id + "' from protocol");
+                                CreateBackupBeforeOperation("hide field '" + fd.id + "' from protocol");
                                 ProtocolField fieldCopy = *pf;
                                 std::string defId = def.id;
                                 std::string fieldId = fd.id;
                                 s_undoManager.ExecuteCommand(std::make_unique<LambdaCommand>(
-                                    "Remove field '" + fd.label + "'",
+                                    "Hide field '" + fd.label + "' from protocol",
                                     [&registry, defId, fieldId]() {
                                         if (auto* d = registry.FindById(defId)) {
                                             auto it = std::remove_if(d->fields.begin(), d->fields.end(),
                                                 [&](const ProtocolField& f) { return f.fieldId == fieldId; });
                                             if (it != d->fields.end()) {
                                                 d->fields.erase(it, d->fields.end());
-                                                registry.SaveDefinition(*d);
                                             }
+                                            // Hide from this protocol's picker.
+                                            if (std::find(d->excludedFieldIds.begin(),
+                                                          d->excludedFieldIds.end(),
+                                                          fieldId) == d->excludedFieldIds.end()) {
+                                                d->excludedFieldIds.push_back(fieldId);
+                                            }
+                                            registry.SaveDefinition(*d);
                                         }
                                     },
-                                    [&registry, defId, fieldCopy]() {
+                                    [&registry, defId, fieldId, fieldCopy]() {
                                         if (auto* d = registry.FindById(defId)) {
                                             d->fields.push_back(fieldCopy);
+                                            d->excludedFieldIds.erase(
+                                                std::remove(d->excludedFieldIds.begin(),
+                                                            d->excludedFieldIds.end(), fieldId),
+                                                d->excludedFieldIds.end());
                                             registry.SaveDefinition(*d);
                                         }
                                     }
@@ -1167,7 +1183,18 @@ void ProtocolEditorWindow::DrawFieldTable(ProtocolDefinition& def,
                     }
                     ImGui::PopStyleColor(3);
                     if (ImGui::IsItemHovered()) {
-                        ImGui::SetTooltip("Delete custom field '%s'.\nIf unused by other protocols, it will be removed from the catalog.\nOtherwise, it is only removed from this protocol.", fd.label.c_str());
+                        if (usedElsewhere) {
+                            ImGui::SetTooltip(
+                                "'%s' is still used by other protocols.\n"
+                                "It will be hidden from this protocol only.\n"
+                                "To delete it entirely, remove it from all other protocols first.",
+                                fd.label.c_str());
+                        } else {
+                            ImGui::SetTooltip(
+                                "Delete custom field '%s' and remove it from the catalog.\n"
+                                "This cannot be undone once saved.",
+                                fd.label.c_str());
+                        }
                     }
                 }
 

--- a/src/Protocols/ProtocolEditorWindow.cpp
+++ b/src/Protocols/ProtocolEditorWindow.cpp
@@ -733,6 +733,7 @@ void ProtocolEditorWindow::DrawContent() {
 
     // ── Modals ───────────────────────────────────────────────────────────────
     DrawNewProtocolModal();
+    DrawDeleteProtocolModal();
     DrawDuplicateProtocolModal();
     DrawCreateFieldModal();
     DrawSavePresetModal();
@@ -841,12 +842,9 @@ void ProtocolEditorWindow::DrawProtocolList() {
         // Context menu for protocol actions
         if (ImGui::BeginPopupContextItem(definition.id.c_str())) {
             if (ImGui::MenuItem("Delete")) {
-                registry.DeleteDefinition(definition.id);
-                if (s_selectedIndex >= (int)registry.GetDefinitions().size()) {
-                    s_selectedIndex = (int)registry.GetDefinitions().size() - 1;
-                }
-                ImGui::EndPopup();
-                break; // List invalidated
+                s_showDeleteProtocolModal = true;
+                s_deleteProtocolId   = definition.id;
+                s_deleteProtocolName = definition.name;
             }
 
             if (ImGui::MenuItem("Duplicate")) {
@@ -1380,6 +1378,44 @@ void ProtocolEditorWindow::DrawNewProtocolModal() {
         ImGui::SameLine();
 
         if (ImGui::Button("Cancel", ImVec2(120, 0))) {
+            ImGui::CloseCurrentPopup();
+        }
+
+        ImGui::EndPopup();
+    }
+}
+
+void ProtocolEditorWindow::DrawDeleteProtocolModal() {
+    if (s_showDeleteProtocolModal) {
+        ImGui::OpenPopup("Delete Protocol##modal");
+        s_showDeleteProtocolModal = false;
+    }
+
+    bool open = true;
+    if (ImGui::BeginPopupModal("Delete Protocol##modal", &open, ImGuiWindowFlags_AlwaysAutoResize)) {
+        CloseModalOnEscape();
+
+        ImGui::Text("Are you sure you want to delete this protocol?");
+        ImGui::Spacing();
+        ImGui::TextColored(ImVec4(1.0f, 0.8f, 0.2f, 1.0f), "%s", s_deleteProtocolName.c_str());
+        ImGui::Spacing();
+        ImGui::TextDisabled("This action cannot be undone.");
+        ImGui::Separator();
+
+        if (ImGui::Button("Delete", ImVec2(120, 0))) {
+            auto& registry = ProtocolRegistry::GetInstance();
+            registry.DeleteDefinition(s_deleteProtocolId);
+            if (s_selectedIndex >= (int)registry.GetDefinitions().size())
+                s_selectedIndex = (int)registry.GetDefinitions().size() - 1;
+            s_deleteProtocolId.clear();
+            s_deleteProtocolName.clear();
+            ImGui::CloseCurrentPopup();
+        }
+
+        ImGui::SameLine();
+        if (ImGui::Button("Cancel", ImVec2(120, 0))) {
+            s_deleteProtocolId.clear();
+            s_deleteProtocolName.clear();
             ImGui::CloseCurrentPopup();
         }
 

--- a/src/Protocols/ProtocolEditorWindow.cpp
+++ b/src/Protocols/ProtocolEditorWindow.cpp
@@ -445,6 +445,13 @@ bool ProtocolEditorWindow::DrawFileBrowser(std::string& currentDir,
             bool isFile = de.is_regular_file();
             if (!isDir && !isFile) continue;
 
+            // Only show folders and compatible protocol files (.json).
+            if (isFile) {
+                std::string ext = de.path().extension().string();
+                std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
+                if (ext != ".json") continue;
+            }
+
             // Apply search filter
             if (s_fbSearch[0] != '\0') {
                 std::string lname = fname, lsearch = s_fbSearch;

--- a/src/Protocols/ProtocolEditorWindow.cpp
+++ b/src/Protocols/ProtocolEditorWindow.cpp
@@ -1653,8 +1653,7 @@ void ProtocolEditorWindow::DrawCreateFieldModal() {
     };
 
     bool open = true;
-    const char* title = s_cfIsEditing ? "Edit Field##modal" : "Create/Edit Field##modal";
-    if (ImGui::BeginPopupModal(title, &open, ImGuiWindowFlags_AlwaysAutoResize)) {
+    if (ImGui::BeginPopupModal("Create/Edit Field##modal", &open, ImGuiWindowFlags_AlwaysAutoResize)) {
         CloseModalOnEscape();
         auto& registry = ProtocolRegistry::GetInstance();
 

--- a/src/Protocols/ProtocolEditorWindow.cpp
+++ b/src/Protocols/ProtocolEditorWindow.cpp
@@ -631,7 +631,7 @@ static bool WrapButton(const char* label, ImVec2 size = ImVec2(0, 0)) {
                      + ImGui::GetStyle().ItemSpacing.x
                      + buttonW;
 
-    if (nextEndX <= regionRightX)
+    if (nextEndX <= regionRightX - 4.0f)
         ImGui::SameLine();
 
     return ImGui::Button(label, size);
@@ -732,7 +732,9 @@ void ProtocolEditorWindow::DrawContent() {
     if (ImGui::IsItemHovered() || ImGui::IsItemActive())
         ImGui::SetMouseCursor(ImGuiMouseCursor_ResizeEW);
 
-    s_splitWidth = std::clamp(s_splitWidth, 100.0f, totalWidth - splitterW - 100.0f);
+    const float minSplit = 100.0f;
+    const float maxSplit = std::max(minSplit, totalWidth - splitterW - 100.0f);
+    s_splitWidth = std::clamp(s_splitWidth, minSplit, maxSplit);
 
     ImGui::SameLine(0, 0);
 
@@ -895,7 +897,11 @@ void ProtocolEditorWindow::DrawEditor() {
 
     char nameBuffer[128];
     std::strncpy(nameBuffer, definition.name.c_str(), sizeof(nameBuffer));
-    if (ImGui::InputText("Name", nameBuffer, sizeof(nameBuffer))) {
+    ImGui::AlignTextToFramePadding();
+    ImGui::TextUnformatted("Name:");
+    if (ImGui::GetContentRegionAvail().x > 300.0f) ImGui::SameLine();
+    ImGui::SetNextItemWidth(-FLT_MIN);
+    if (ImGui::InputText("##Name", nameBuffer, sizeof(nameBuffer))) {
         definition.name = nameBuffer;
         needsSave = true;
     }
@@ -909,22 +915,38 @@ void ProtocolEditorWindow::DrawEditor() {
     if (definition.transport == ProtocolTransport::OSC) {
         char hostBuffer[128];
         std::strncpy(hostBuffer, definition.oscHost.c_str(), sizeof(hostBuffer));
-        if (ImGui::InputText("Host", hostBuffer, sizeof(hostBuffer))) {
+        ImGui::AlignTextToFramePadding();
+        ImGui::TextUnformatted("Host:");
+        if (ImGui::GetContentRegionAvail().x > 300.0f) ImGui::SameLine();
+        ImGui::SetNextItemWidth(-FLT_MIN);
+        if (ImGui::InputText("##Host", hostBuffer, sizeof(hostBuffer))) {
             definition.oscHost = hostBuffer;
             needsSave = true;
         }
 
         if (definition.direction == ProtocolDirection::Output) {
-            if (ImGui::InputInt("Send Port", &definition.oscSendPort)) {
+            ImGui::AlignTextToFramePadding();
+            ImGui::TextUnformatted("Send Port:");
+            if (ImGui::GetContentRegionAvail().x > 300.0f) ImGui::SameLine();
+            ImGui::SetNextItemWidth(-FLT_MIN);
+            if (ImGui::InputInt("##SendPort", &definition.oscSendPort)) {
                 needsSave = true;
             }
         } else {
-            if (ImGui::InputInt("Receive Port", &definition.oscRecvPort)) {
+            ImGui::AlignTextToFramePadding();
+            ImGui::TextUnformatted("Receive Port:");
+            if (ImGui::GetContentRegionAvail().x > 300.0f) ImGui::SameLine();
+            ImGui::SetNextItemWidth(-FLT_MIN);
+            if (ImGui::InputInt("##RecvPort", &definition.oscRecvPort)) {
                 needsSave = true;
             }
         }
     } else { // WebSocket
-        if (ImGui::InputInt("Port", &definition.wssPort)) {
+        ImGui::AlignTextToFramePadding();
+        ImGui::TextUnformatted("Port:");
+        if (ImGui::GetContentRegionAvail().x > 300.0f) ImGui::SameLine();
+        ImGui::SetNextItemWidth(-FLT_MIN);
+        if (ImGui::InputInt("##WSPort", &definition.wssPort)) {
             needsSave = true;
         }
     }
@@ -1005,7 +1027,11 @@ void ProtocolEditorWindow::DrawOutputFieldPicker() {
     }
 
     // Search filter
-    ImGui::InputText("Filter", s_fieldFilter, sizeof(s_fieldFilter));
+    ImGui::AlignTextToFramePadding();
+    ImGui::TextUnformatted("Filter:");
+    if (ImGui::GetContentRegionAvail().x > 300.0f) ImGui::SameLine();
+    ImGui::SetNextItemWidth(-FLT_MIN);
+    ImGui::InputText("##Filter", s_fieldFilter, sizeof(s_fieldFilter));
 
     ImGui::Separator();
     DrawFieldTable(definition, catalog, isOsc, s_fieldFilter, s_pendingSave);
@@ -1044,7 +1070,11 @@ void ProtocolEditorWindow::DrawInputFieldPicker() {
     }
 
     // Search filter
-    ImGui::InputText("Filter", s_fieldFilter, sizeof(s_fieldFilter));
+    ImGui::AlignTextToFramePadding();
+    ImGui::TextUnformatted("Filter:");
+    if (ImGui::GetContentRegionAvail().x > 300.0f) ImGui::SameLine();
+    ImGui::SetNextItemWidth(-FLT_MIN);
+    ImGui::InputText("##Filter", s_fieldFilter, sizeof(s_fieldFilter));
 
     ImGui::Separator();
     DrawFieldTable(definition, catalog, isOsc, s_fieldFilter, s_pendingSave);
@@ -1281,7 +1311,7 @@ void ProtocolEditorWindow::DrawFieldTable(ProtocolDefinition& def,
                         std::strncpy(pathBuffer, pf->oscPath.c_str(), sizeof(pathBuffer));
                         ImGui::AlignTextToFramePadding();
                         ImGui::TextUnformatted("OSC Path:");
-                        ImGui::SameLine();
+                        if (ImGui::GetContentRegionAvail().x > 300.0f) ImGui::SameLine();
                         ImGui::SetNextItemWidth(-FLT_MIN);
                         if (ImGui::InputText("##oscPath", pathBuffer, sizeof(pathBuffer))) {
                             pf->oscPath = pathBuffer;
@@ -1292,7 +1322,7 @@ void ProtocolEditorWindow::DrawFieldTable(ProtocolDefinition& def,
                         std::strncpy(keyBuffer, pf->wsKey.c_str(), sizeof(keyBuffer));
                         ImGui::AlignTextToFramePadding();
                         ImGui::TextUnformatted("WS Key:");
-                        ImGui::SameLine();
+                        if (ImGui::GetContentRegionAvail().x > 300.0f) ImGui::SameLine();
                         ImGui::SetNextItemWidth(-FLT_MIN);
                         if (ImGui::InputText("##wsKey", keyBuffer, sizeof(keyBuffer))) {
                             pf->wsKey = keyBuffer;
@@ -1721,10 +1751,18 @@ void ProtocolEditorWindow::DrawCreateFieldModal() {
         if (s_cfIsEditing) {
             // ID is immutable when editing an existing field.
             ImGui::BeginDisabled();
-            ImGui::InputText("ID", s_cfId, sizeof(s_cfId));
+            ImGui::AlignTextToFramePadding();
+            ImGui::TextUnformatted("ID:");
+            if (ImGui::GetContentRegionAvail().x > 300.0f) ImGui::SameLine();
+            ImGui::SetNextItemWidth(-FLT_MIN);
+            ImGui::InputText("##cfId", s_cfId, sizeof(s_cfId));
             ImGui::EndDisabled();
         } else {
-            if (ImGui::InputText("ID", s_cfId, sizeof(s_cfId))) {
+            ImGui::AlignTextToFramePadding();
+            ImGui::TextUnformatted("ID:");
+            if (ImGui::GetContentRegionAvail().x > 300.0f) ImGui::SameLine();
+            ImGui::SetNextItemWidth(-FLT_MIN);
+            if (ImGui::InputText("##cfId", s_cfId, sizeof(s_cfId))) {
                 s_cfIdManuallyModified = true;
                 idChanged = true;
                 if (!s_cfLabelManuallyModified)
@@ -1733,7 +1771,11 @@ void ProtocolEditorWindow::DrawCreateFieldModal() {
         }
 
         // ── Label ─────────────────────────────────────────────────────────
-        if (ImGui::InputText("Label", s_cfLabel, sizeof(s_cfLabel))) {
+        ImGui::AlignTextToFramePadding();
+        ImGui::TextUnformatted("Label:");
+        if (ImGui::GetContentRegionAvail().x > 300.0f) ImGui::SameLine();
+        ImGui::SetNextItemWidth(-FLT_MIN);
+        if (ImGui::InputText("##cfLabel", s_cfLabel, sizeof(s_cfLabel))) {
             s_cfLabelManuallyModified = true;
             if (!s_cfIdManuallyModified && !s_cfIsEditing) {
                 // Auto-generate ID from label
@@ -1757,16 +1799,19 @@ void ProtocolEditorWindow::DrawCreateFieldModal() {
         std::sort(categories.begin(), categories.end());
 
         float btnSize  = ImGui::GetFrameHeight();
-        float itemWidth = ImGui::CalcItemWidth();
+        ImGui::AlignTextToFramePadding();
+        ImGui::TextUnformatted("Category:");
+        if (ImGui::GetContentRegionAvail().x > 300.0f) ImGui::SameLine();
+        float itemWidth = ImGui::GetContentRegionAvail().x;
         ImGui::SetNextItemWidth(itemWidth - btnSize - ImGui::GetStyle().ItemInnerSpacing.x);
         char prevCat[64];
         std::strncpy(prevCat, s_cfCategory, sizeof(prevCat));
-        if (ImGui::InputText("##Category", s_cfCategory, sizeof(s_cfCategory))) {
+        if (ImGui::InputText("##cfCategory", s_cfCategory, sizeof(s_cfCategory))) {
             categoryChanged = true;
         }
         ImGui::SameLine(0, ImGui::GetStyle().ItemInnerSpacing.x);
         ImGui::SetNextItemWidth(btnSize);
-        if (ImGui::BeginCombo("Category", nullptr, ImGuiComboFlags_NoPreview)) {
+        if (ImGui::BeginCombo("##cfCatList", nullptr, ImGuiComboFlags_NoPreview)) {
             for (const auto& cat : categories) {
                 if (ImGui::Selectable(cat.c_str())) {
                     std::strncpy(s_cfCategory, cat.c_str(), sizeof(s_cfCategory));
@@ -1780,12 +1825,16 @@ void ProtocolEditorWindow::DrawCreateFieldModal() {
 
         // ── Type ──────────────────────────────────────────────────────────
         const char* types[] = {"Analog Axis", "Digital Button"};
-        ImGui::Combo("Type", &s_cfType, types, 2);
+        ImGui::AlignTextToFramePadding();
+        ImGui::TextUnformatted("Type:");
+        if (ImGui::GetContentRegionAvail().x > 300.0f) ImGui::SameLine();
+        ImGui::SetNextItemWidth(-FLT_MIN);
+        ImGui::Combo("##cfType", &s_cfType, types, 2);
 
         // ── OSC Path ──────────────────────────────────────────────────────
         ImGui::AlignTextToFramePadding();
         ImGui::TextUnformatted("Default OSC Path:");
-        ImGui::SameLine();
+        if (ImGui::GetContentRegionAvail().x > 300.0f) ImGui::SameLine();
         ImGui::SetNextItemWidth(-FLT_MIN);
         if (ImGui::InputText("##cfOsc", s_cfOsc, sizeof(s_cfOsc)))
             s_cfOscManuallyModified = true;
@@ -1793,7 +1842,7 @@ void ProtocolEditorWindow::DrawCreateFieldModal() {
         // ── WS Key ────────────────────────────────────────────────────────
         ImGui::AlignTextToFramePadding();
         ImGui::TextUnformatted("Default WS Key:");
-        ImGui::SameLine();
+        if (ImGui::GetContentRegionAvail().x > 300.0f) ImGui::SameLine();
         ImGui::SetNextItemWidth(-FLT_MIN);
         if (ImGui::InputText("##cfWs", s_cfWs, sizeof(s_cfWs)))
             s_cfWsManuallyModified = true;

--- a/src/Protocols/ProtocolEditorWindow.h
+++ b/src/Protocols/ProtocolEditorWindow.h
@@ -79,6 +79,7 @@ private:
     static void DrawRenameCategoryModal();
     static void DrawDeleteCategoryModal();
     static void DrawMergeCategoryModal();
+    static void DrawHideCategoryModal();
     static void DrawSaveTemplateModal();
     static void DrawLoadPresetModal();
     static void DrawLoadTemplateModal();
@@ -147,6 +148,9 @@ private:
     static inline bool  s_showMergeCatModal = false;
     static inline char  s_mergeSrcCat[64]   = "";
     static inline char  s_mergeTgtCat[64]   = "";
+
+    // Hide / show categories per-protocol modal state
+    static inline bool  s_showHideCatModal  = false;
 
     // Validation result modal state
     static inline bool        s_showValidationModal = false;

--- a/src/Protocols/ProtocolEditorWindow.h
+++ b/src/Protocols/ProtocolEditorWindow.h
@@ -71,6 +71,7 @@ private:
 
     // ── Modals ───────────────────────────────────────────────────────────────
     static void DrawNewProtocolModal();
+    static void DrawDeleteProtocolModal();
     static void DrawDuplicateProtocolModal();
     static void DrawCreateFieldModal();
     static void DrawSavePresetModal();
@@ -117,6 +118,11 @@ private:
     static inline int   s_newTransport     = 0; // 0=OSC, 1=WebSocket
     static inline int   s_newDirection     = 0; // 0=Output, 1=Input
     static inline int   s_newPresetIdx     = 0; // 0=None
+
+    // Delete protocol modal state
+    static inline bool        s_showDeleteProtocolModal = false;
+    static inline std::string s_deleteProtocolId;
+    static inline std::string s_deleteProtocolName;
 
     // Duplicate protocol modal state
     static inline bool  s_showDupModal     = false;

--- a/src/Protocols/ProtocolEditorWindow.h
+++ b/src/Protocols/ProtocolEditorWindow.h
@@ -134,6 +134,15 @@ private:
     static inline char  s_cfWs[128] = "custom_";
     static inline bool  s_cfIdManuallyModified = false;
     static inline bool  s_cfLabelManuallyModified = false;
+    // Editing vs creating
+    static inline bool  s_cfIsEditing = false;       // true when opened from an existing field
+    static inline char  s_cfEditingId[64] = "";      // original ID so we can look up & update
+    // OSC/WS override tracking — if the user has typed a custom value,
+    // label/category changes should not overwrite it.
+    static inline bool  s_cfOscManuallyModified = false;
+    static inline bool  s_cfWsManuallyModified  = false;
+    // Duplicate — set before opening the modal to pre-fill from an existing field
+    static inline bool  s_cfIsDuplicate = false;
 
     // Rename category modal state
     static inline bool  s_showRenameCatModal = false;

--- a/src/Protocols/ProtocolRegistry.cpp
+++ b/src/Protocols/ProtocolRegistry.cpp
@@ -186,12 +186,27 @@ bool ProtocolRegistry::ExportDefinition(const std::string& id, const std::string
     j["ws"]["port"]      = def->wssPort;
 
     json fieldsArr = json::array();
+    const auto& outFields = m_outputFields;
+    const auto& inFields  = m_inputFields;
     for (const auto& f : def->fields) {
         json fj;
         fj["fieldId"] = f.fieldId;
         fj["oscPath"] = f.oscPath;
         fj["wsKey"]   = f.wsKey;
         fj["enabled"] = f.enabled;
+
+        // Embed inline field definition for any field that is not a built-in.
+        // This makes exported files self-describing so recipients can import
+        // them without pre-populating their own input_fields.json.
+        const FieldDescriptor* desc = nullptr;
+        for (const auto& fd : outFields) if (fd.id == f.fieldId) { desc = &fd; break; }
+        if (!desc) for (const auto& fd : inFields) if (fd.id == f.fieldId) { desc = &fd; break; }
+        if (desc && !desc->isBuiltIn) {
+            fj["label"]    = desc->label;
+            fj["category"] = desc->category;
+            fj["type"]     = (desc->type == FieldType::DigitalButton) ? "digital" : "analog";
+        }
+
         fieldsArr.push_back(fj);
     }
     j["fields"] = fieldsArr;
@@ -235,8 +250,54 @@ std::string ProtocolRegistry::ImportDefinition(const std::string& path) {
                 f.oscPath = fj.value("oscPath",  "");
                 f.wsKey   = fj.value("wsKey",    "");
                 f.enabled = fj.value("enabled",  true);
-                if (!f.fieldId.empty())
-                    def.fields.push_back(f);
+                if (f.fieldId.empty())
+                    continue;
+
+                // Read optional inline field definition.
+                // These keys are written by ExportDefinition for any field that
+                // is not a built-in, so the file is self-describing.
+                bool hasInline = fj.contains("label") || fj.contains("category") || fj.contains("type");
+                if (hasInline) {
+                    f.hasInlineDef   = true;
+                    f.inlineLabel    = fj.value("label",    f.fieldId);
+                    f.inlineCategory = fj.value("category", "Custom");
+                    std::string typeStr = fj.value("type", "digital");
+                    f.inlineType = (typeStr == "analog") ? FieldType::AnalogAxis : FieldType::DigitalButton;
+                }
+
+                def.fields.push_back(f);
+
+                // Auto-register the field in the catalog when it is unknown so
+                // that the editor can display and manipulate it without requiring
+                // a matching entry in input_fields.json.
+                auto& catalog = (def.direction == ProtocolDirection::Output)
+                                 ? m_outputFields : m_inputFields;
+
+                bool knownInCatalog = false;
+                for (const auto& desc : catalog)
+                    if (desc.id == f.fieldId) { knownInCatalog = true; break; }
+
+                if (!knownInCatalog) {
+                    FieldDescriptor fd;
+                    fd.id          = f.fieldId;
+                    fd.isBuiltIn   = false;
+                    if (f.hasInlineDef) {
+                        fd.label          = f.inlineLabel;
+                        fd.category       = f.inlineCategory;
+                        fd.type           = f.inlineType;
+                    } else {
+                        // No inline metadata — synthesise sensible defaults so
+                        // the field at least appears in the editor.
+                        fd.label    = f.fieldId;
+                        fd.category = "Custom (imported)";
+                        fd.type     = FieldType::DigitalButton;
+                    }
+                    fd.defaultOscPath = f.oscPath.empty() ? ("/" + f.fieldId) : f.oscPath;
+                    fd.defaultWsKey   = f.wsKey.empty()   ? f.fieldId         : f.wsKey;
+                    catalog.push_back(fd);
+                    // Persist so the field survives across restarts.
+                    SaveFieldCatalog();
+                }
             }
         }
         m_definitions.push_back(def);
@@ -280,6 +341,18 @@ void ProtocolRegistry::SaveDefinition(const ProtocolDefinition& def) {
         fj["oscPath"] = f.oscPath;
         fj["wsKey"]   = f.wsKey;
         fj["enabled"] = f.enabled;
+
+        // Embed inline field definition for non-built-in fields so that the
+        // stored definition file is self-describing.
+        const FieldDescriptor* desc = nullptr;
+        for (const auto& fd : m_outputFields) if (fd.id == f.fieldId) { desc = &fd; break; }
+        if (!desc) for (const auto& fd : m_inputFields) if (fd.id == f.fieldId) { desc = &fd; break; }
+        if (desc && !desc->isBuiltIn) {
+            fj["label"]    = desc->label;
+            fj["category"] = desc->category;
+            fj["type"]     = (desc->type == FieldType::DigitalButton) ? "digital" : "analog";
+        }
+
         fieldsArr.push_back(fj);
     }
     j["fields"] = fieldsArr;
@@ -511,8 +584,42 @@ void ProtocolRegistry::LoadDefinitionFiles() {
                     f.oscPath = fj.value("oscPath",  "");
                     f.wsKey   = fj.value("wsKey",    "");
                     f.enabled = fj.value("enabled",  true);
-                    if (!f.fieldId.empty())
-                        def.fields.push_back(f);
+                    if (f.fieldId.empty())
+                        continue;
+
+                    bool hasInline = fj.contains("label") || fj.contains("category") || fj.contains("type");
+                    if (hasInline) {
+                        f.hasInlineDef   = true;
+                        f.inlineLabel    = fj.value("label",    f.fieldId);
+                        f.inlineCategory = fj.value("category", "Custom");
+                        std::string typeStr = fj.value("type", "digital");
+                        f.inlineType = (typeStr == "analog") ? FieldType::AnalogAxis : FieldType::DigitalButton;
+                    }
+
+                    def.fields.push_back(f);
+
+                    // Auto-register unknown fields so the editor shows them.
+                    auto& catalog = (def.direction == ProtocolDirection::Output)
+                                     ? m_outputFields : m_inputFields;
+                    bool known = false;
+                    for (const auto& fd : catalog) if (fd.id == f.fieldId) { known = true; break; }
+                    if (!known) {
+                        FieldDescriptor fd;
+                        fd.id        = f.fieldId;
+                        fd.isBuiltIn = false;
+                        if (f.hasInlineDef) {
+                            fd.label    = f.inlineLabel;
+                            fd.category = f.inlineCategory;
+                            fd.type     = f.inlineType;
+                        } else {
+                            fd.label    = f.fieldId;
+                            fd.category = "Custom (imported)";
+                            fd.type     = FieldType::DigitalButton;
+                        }
+                        fd.defaultOscPath = f.oscPath.empty() ? ("/" + f.fieldId) : f.oscPath;
+                        fd.defaultWsKey   = f.wsKey.empty()   ? f.fieldId         : f.wsKey;
+                        catalog.push_back(fd);
+                    }
                 }
             }
             m_definitions.push_back(def);

--- a/src/Protocols/ProtocolRegistry.cpp
+++ b/src/Protocols/ProtocolRegistry.cpp
@@ -76,6 +76,13 @@ void ProtocolRegistry::SaveFieldCatalog() {
     json arr = json::array();
     for (const auto& fd : m_outputFields) {
         if (fd.isBuiltIn) continue;
+        // Skip entries whose ID is already registered in the input catalog —
+        // those were misplaced by an older code path and should not be
+        // persisted regardless of which category name they carry.
+        bool duplicateInOtherCatalog = false;
+        for (const auto& other : m_inputFields)
+            if (other.id == fd.id) { duplicateInOtherCatalog = true; break; }
+        if (duplicateInOtherCatalog) continue;
         json item;
         item["id"] = fd.id;
         item["label"] = fd.label;
@@ -644,6 +651,40 @@ void ProtocolRegistry::LoadDefinitionFiles() {
                     for (const auto& fd : m_outputFields) if (fd.id == f.fieldId) { known = true; break; }
                     if (!known)
                         for (const auto& fd : m_inputFields) if (fd.id == f.fieldId) { known = true; break; }
+
+                    // Sanitise stale entries written by older code paths. If
+                    // the field resolves to a real descriptor in either catalog,
+                    // evict every duplicate from both catalogs so the correct
+                    // category is always shown after a restart.
+                    if (known) {
+                        const FieldDescriptor* real = nullptr;
+                        for (const auto& fd : m_outputFields) if (fd.id == f.fieldId) { real = &fd; break; }
+                        if (!real)
+                            for (const auto& fd : m_inputFields) if (fd.id == f.fieldId) { real = &fd; break; }
+
+                        // Count total occurrences across both catalogs.
+                        int count = 0;
+                        for (const auto& fd : m_outputFields) if (fd.id == f.fieldId) count++;
+                        for (const auto& fd : m_inputFields)  if (fd.id == f.fieldId) count++;
+
+                        if (count > 1) {
+                            // More than one entry for this ID — keep only the
+                            // first real (non-stale) one and remove the rest.
+                            bool kept = false;
+                            auto dedup = [&](std::vector<FieldDescriptor>& cat) {
+                                cat.erase(std::remove_if(cat.begin(), cat.end(),
+                                    [&](const FieldDescriptor& d) {
+                                        if (d.id != f.fieldId) return false;
+                                        if (!kept) { kept = true; return false; }
+                                        return true;
+                                    }), cat.end());
+                            };
+                            dedup(m_outputFields);
+                            dedup(m_inputFields);
+                            known = false; // fall through to re-register correctly below
+                        }
+                    }
+
                     if (!known) {
                         FieldDescriptor fd;
                         fd.id        = f.fieldId;

--- a/src/Protocols/ProtocolRegistry.cpp
+++ b/src/Protocols/ProtocolRegistry.cpp
@@ -65,6 +65,16 @@ void ProtocolRegistry::AddOutputField(const FieldDescriptor& fd) {
     SaveFieldCatalog();
 }
 
+void ProtocolRegistry::UpdateOutputField(const std::string& originalId, const FieldDescriptor& fd) {
+    for (auto& f : m_outputFields) {
+        if (f.id == originalId) {
+            f = fd;
+            SaveFieldCatalog();
+            return;
+        }
+    }
+}
+
 void ProtocolRegistry::DeleteOutputField(const std::string& id) {
     auto it = std::remove_if(m_outputFields.begin(), m_outputFields.end(),
                              [&](const FieldDescriptor& fd) { return fd.id == id && !fd.isBuiltIn; });

--- a/src/Protocols/ProtocolRegistry.cpp
+++ b/src/Protocols/ProtocolRegistry.cpp
@@ -1,3 +1,4 @@
+#include "App/Log.h"
 #include "ProtocolRegistry.h"
 #include "Utils/XdgDirs.h"
 #include <nlohmann/json.hpp>
@@ -361,7 +362,7 @@ void ProtocolRegistry::SaveDefinition(const ProtocolDefinition& def) {
     if (ofs) {
         ofs << j.dump(4);
     } else {
-        std::cerr << "[ProtocolRegistry] Failed to write " << path << "\n";
+    LOG_ERROR("ProtocolRegistry", "Failed to write %s", path.c_str());
     }
 }
 
@@ -426,8 +427,8 @@ static void BootstrapFromInstallDir(const std::string& prefProtocolsDir) {
                 fs::copy_file(entry.path(), dstFile,
                               fs::copy_options::skip_existing, ec);
                 if (ec)
-                    std::cerr << "[ProtocolRegistry] Bootstrap copy failed for "
-                              << entry.path() << ": " << ec.message() << "\n";
+                    LOG_ERROR("ProtocolRegistry", "Bootstrap copy failed for %s: %s",
+                              entry.path().string().c_str(), ec.message().c_str());
             }
         }
     };
@@ -504,7 +505,7 @@ void ProtocolRegistry::LoadFieldCatalog() {
             }
         }
     } catch (const std::exception& e) {
-        std::cerr << "[ProtocolRegistry] Failed to parse input_fields.json: " << e.what() << "\n";
+    LOG_ERROR("ProtocolRegistry", "Failed to parse input_fields.json: %s", e.what());
     }
 }
 
@@ -624,8 +625,8 @@ void ProtocolRegistry::LoadDefinitionFiles() {
             }
             m_definitions.push_back(def);
         } catch (const std::exception& e) {
-            std::cerr << "[ProtocolRegistry] Failed to parse "
-                      << entry.path() << ": " << e.what() << "\n";
+            LOG_ERROR("ProtocolRegistry", "Failed to parse %s: %s",
+                      entry.path().string().c_str(), e.what());
         }
     }
 }
@@ -709,7 +710,7 @@ void ProtocolRegistry::LoadBuiltinCatalog() {
             }
         }
     } catch (const std::exception& e) {
-        std::cerr << "[ProtocolRegistry] Failed to parse builtin_fields.json: " << e.what() << "\n";
+    LOG_ERROR("ProtocolRegistry", "Failed to parse builtin_fields.json: %s", e.what());
     }
 }
 

--- a/src/Protocols/ProtocolRegistry.cpp
+++ b/src/Protocols/ProtocolRegistry.cpp
@@ -31,6 +31,9 @@ ProtocolRegistry::ProtocolRegistry() {
 void ProtocolRegistry::LoadAll() {
     EnsureDirectories();
     LoadFieldCatalog();
+    // Re-save immediately so any stale entries that were blocked by the
+    // updated exists-check are purged from input_fields.json on disk.
+    SaveFieldCatalog();
     LoadPresets();
     LoadDefinitionFiles();
 }
@@ -518,10 +521,16 @@ void ProtocolRegistry::LoadFieldCatalog() {
                 fd.defaultWsKey   = item.value("wsKey",    fd.id);
                 fd.isBuiltIn      = false;
 
-                // Only add if not already present (built-ins take precedence by id)
+                // Skip if already present in either catalog — a field that
+                // belongs in m_inputFields (e.g. a built-in sensor or button)
+                // must not be duplicated into m_outputFields regardless of
+                // what was written to input_fields.json by an older code path.
                 bool exists = false;
                 for (const auto& existing : m_outputFields)
                     if (existing.id == fd.id) { exists = true; break; }
+                if (!exists)
+                    for (const auto& existing : m_inputFields)
+                        if (existing.id == fd.id) { exists = true; break; }
                 if (!exists && !fd.id.empty())
                     m_outputFields.push_back(fd);
             }

--- a/src/Protocols/ProtocolRegistry.cpp
+++ b/src/Protocols/ProtocolRegistry.cpp
@@ -206,6 +206,13 @@ bool ProtocolRegistry::ExportDefinition(const std::string& id, const std::string
             fj["label"]    = desc->label;
             fj["category"] = desc->category;
             fj["type"]     = (desc->type == FieldType::DigitalButton) ? "digital" : "analog";
+        } else if (!desc && f.hasInlineDef) {
+            // Catalog entry absent (e.g. field not yet persisted) but the
+            // ProtocolField still carries its own inline metadata — use it so
+            // the exported file stays self-describing.
+            fj["label"]    = f.inlineLabel;
+            fj["category"] = f.inlineCategory;
+            fj["type"]     = (f.inlineType == FieldType::DigitalButton) ? "digital" : "analog";
         }
 
         fieldsArr.push_back(fj);
@@ -309,6 +316,14 @@ std::string ProtocolRegistry::ImportDefinition(const std::string& path) {
                 }
             }
         }
+        // Load per-protocol exclusion lists.
+        if (j.contains("excluded_fields") && j["excluded_fields"].is_array())
+            for (const auto& v : j["excluded_fields"])
+                if (v.is_string()) def.excludedFieldIds.push_back(v.get<std::string>());
+        if (j.contains("excluded_categories") && j["excluded_categories"].is_array())
+            for (const auto& v : j["excluded_categories"])
+                if (v.is_string()) def.excludedCategories.push_back(v.get<std::string>());
+
         m_definitions.push_back(def);
         SaveDefinition(def);
         return def.id;
@@ -365,6 +380,19 @@ void ProtocolRegistry::SaveDefinition(const ProtocolDefinition& def) {
         fieldsArr.push_back(fj);
     }
     j["fields"] = fieldsArr;
+
+    // Per-protocol exclusions — only write the keys when non-empty so that
+    // the vast majority of definition files stay clean.
+    if (!def.excludedFieldIds.empty()) {
+        json arr = json::array();
+        for (const auto& s : def.excludedFieldIds) arr.push_back(s);
+        j["excluded_fields"] = arr;
+    }
+    if (!def.excludedCategories.empty()) {
+        json arr = json::array();
+        for (const auto& s : def.excludedCategories) arr.push_back(s);
+        j["excluded_categories"] = arr;
+    }
 
     std::ofstream ofs(path);
     if (ofs) {
@@ -635,6 +663,14 @@ void ProtocolRegistry::LoadDefinitionFiles() {
                     }
                 }
             }
+            // Load per-protocol exclusion lists.
+            if (j.contains("excluded_fields") && j["excluded_fields"].is_array())
+                for (const auto& v : j["excluded_fields"])
+                    if (v.is_string()) def.excludedFieldIds.push_back(v.get<std::string>());
+            if (j.contains("excluded_categories") && j["excluded_categories"].is_array())
+                for (const auto& v : j["excluded_categories"])
+                    if (v.is_string()) def.excludedCategories.push_back(v.get<std::string>());
+
             m_definitions.push_back(def);
         } catch (const std::exception& e) {
             LOG_ERROR("ProtocolRegistry", "Failed to parse %s: %s",

--- a/src/Protocols/ProtocolRegistry.cpp
+++ b/src/Protocols/ProtocolRegistry.cpp
@@ -274,9 +274,17 @@ std::string ProtocolRegistry::ImportDefinition(const std::string& path) {
                 auto& catalog = (def.direction == ProtocolDirection::Output)
                                  ? m_outputFields : m_inputFields;
 
+                // Check both catalogs: a field may legitimately live in the
+                // opposite catalog (e.g. a sensor/button field referenced by an
+                // output-direction definition). Registering it a second time in
+                // the wrong catalog would create a duplicate "Custom (imported)"
+                // entry and break the category grouping in the editor.
                 bool knownInCatalog = false;
-                for (const auto& desc : catalog)
+                for (const auto& desc : m_outputFields)
                     if (desc.id == f.fieldId) { knownInCatalog = true; break; }
+                if (!knownInCatalog)
+                    for (const auto& desc : m_inputFields)
+                        if (desc.id == f.fieldId) { knownInCatalog = true; break; }
 
                 if (!knownInCatalog) {
                     FieldDescriptor fd;
@@ -602,8 +610,12 @@ void ProtocolRegistry::LoadDefinitionFiles() {
                     // Auto-register unknown fields so the editor shows them.
                     auto& catalog = (def.direction == ProtocolDirection::Output)
                                      ? m_outputFields : m_inputFields;
+                    // Check both catalogs before synthesising an entry; the
+                    // field may already be registered on the opposite side.
                     bool known = false;
-                    for (const auto& fd : catalog) if (fd.id == f.fieldId) { known = true; break; }
+                    for (const auto& fd : m_outputFields) if (fd.id == f.fieldId) { known = true; break; }
+                    if (!known)
+                        for (const auto& fd : m_inputFields) if (fd.id == f.fieldId) { known = true; break; }
                     if (!known) {
                         FieldDescriptor fd;
                         fd.id        = f.fieldId;

--- a/src/Protocols/ProtocolRegistry.h
+++ b/src/Protocols/ProtocolRegistry.h
@@ -32,6 +32,7 @@ public:
     void ReloadFieldCatalog(); // re-read input_fields.json without touching definitions
 
     void AddOutputField(const FieldDescriptor& fd);
+    void UpdateOutputField(const std::string& originalId, const FieldDescriptor& fd);
     void DeleteOutputField(const std::string& id);
     void SaveFieldCatalog();
 

--- a/src/UI/DevicePanel.cpp
+++ b/src/UI/DevicePanel.cpp
@@ -1,3 +1,4 @@
+#include "App/Log.h"
 #include "DevicePanel.h"
 
 #define IMGUI_DEFINE_MATH_OPERATORS
@@ -190,7 +191,7 @@ static void DrawDeviceHideControls(DeviceState& dev, DeviceManager& deviceManage
 
     if (ImGui::Checkbox("Hide from other applications", &hidden)) {
         if (!deviceManager.SetDeviceHidden(dev, hidden)) {
-            SDL_Log("DevicePanel: SetDeviceHidden failed for '%s'.", dev.name.c_str());
+            LOG_INFO("DevicePanel", "DevicePanel: SetDeviceHidden failed for '%s'.", dev.name.c_str());
         }
     }
 

--- a/src/UI/DevicePanel.cpp
+++ b/src/UI/DevicePanel.cpp
@@ -191,7 +191,7 @@ static void DrawDeviceHideControls(DeviceState& dev, DeviceManager& deviceManage
 
     if (ImGui::Checkbox("Hide from other applications", &hidden)) {
         if (!deviceManager.SetDeviceHidden(dev, hidden)) {
-            LOG_INFO("DevicePanel", "DevicePanel: SetDeviceHidden failed for '%s'.", dev.name.c_str());
+            LOG_INFO("DevicePanel", "SetDeviceHidden failed for '%s'.", dev.name.c_str());
         }
     }
 

--- a/src/UI/FontManager.cpp
+++ b/src/UI/FontManager.cpp
@@ -1,3 +1,4 @@
+#include "App/Log.h"
 #include "FontManager.h"
 
 #define IMGUI_DEFINE_MATH_OPERATORS
@@ -59,7 +60,7 @@ void RebuildFontAtlas()
         base_font = io.Fonts->AddFontFromFileTTF(fontPath.c_str(), themeFontSize);
         loaded_theme_font = (base_font != nullptr);
         if (!loaded_theme_font)
-            SDL_Log("[Font] Failed to load '%s' — falling back to default.",
+            LOG_INFO("FontManager", "[Font] Failed to load '%s' — falling back to default.",
                     fontPath.c_str());
     }
     if (!loaded_theme_font)
@@ -96,7 +97,7 @@ void RebuildFontAtlas()
             iconFontPath.c_str(), merge_size, &cfg, icon_ranges);
 
         if (!icons)
-            SDL_Log("[Font] FA6 not found at '%s' — icon glyphs will be missing.",
+            LOG_INFO("FontManager", "[Font] FA6 not found at '%s' — icon glyphs will be missing.",
                     iconFontPath.c_str());
     }
 

--- a/src/UI/FontManager.cpp
+++ b/src/UI/FontManager.cpp
@@ -60,7 +60,7 @@ void RebuildFontAtlas()
         base_font = io.Fonts->AddFontFromFileTTF(fontPath.c_str(), themeFontSize);
         loaded_theme_font = (base_font != nullptr);
         if (!loaded_theme_font)
-            LOG_INFO("FontManager", "[Font] Failed to load '%s' — falling back to default.",
+            LOG_INFO("FontManager", "Font: Failed to load '%s' — falling back to default.",
                     fontPath.c_str());
     }
     if (!loaded_theme_font)
@@ -97,7 +97,7 @@ void RebuildFontAtlas()
             iconFontPath.c_str(), merge_size, &cfg, icon_ranges);
 
         if (!icons)
-            LOG_INFO("FontManager", "[Font] FA6 not found at '%s' — icon glyphs will be missing.",
+            LOG_INFO("FontManager", "Font: FA6 not found at '%s' — icon glyphs will be missing.",
                     iconFontPath.c_str());
     }
 

--- a/src/UI/IconsFontAwesome6.h
+++ b/src/UI/IconsFontAwesome6.h
@@ -32,7 +32,8 @@
 //  U+F188  →  \xEF\x86\x88   bug  (Debug Log)
 
 #define ICON_FA_GAMEPAD       "\xEF\x84\x9B"   // Devices
-#define ICON_FA_SLIDERS       "\xEF\x87\x9E"   // Input Mapper
+#define ICON_FA_SLIDERS       "\xEF\x87\x9E"   // Input Mapper / Analog axis
+#define ICON_FA_WAVE_SQUARE   "\xEF\xA0\xBE"   // Digital button (square wave)
 #define ICON_FA_BOLT          "\xEF\x83\xA7"   // Output Mapper
 #define ICON_FA_WIFI          "\xEF\x87\xAB"   // Network
 #define ICON_FA_FILE_CODE     "\xEF\x87\x89"   // Protocol Editor

--- a/src/UI/ThemeManager.cpp
+++ b/src/UI/ThemeManager.cpp
@@ -30,7 +30,7 @@ void ThemeManager::ScanThemesDirectory(const std::string& basePath) {
 
     fs::path themesDir = fs::path(basePath) / "themes";
     if (!fs::exists(themesDir) || !fs::is_directory(themesDir)) {
-        LOG_INFO("ThemeManager", "[ThemeManager] Themes directory not found: %s", themesDir.string().c_str());
+        LOG_INFO("ThemeManager", "Themes directory not found: %s", themesDir.string().c_str());
         return;
     }
 
@@ -48,12 +48,12 @@ void ThemeManager::ScanThemesDirectory(const std::string& basePath) {
         if (te.displayName.empty())
             te.displayName = p.stem().string();
         m_entries.push_back(std::move(te));
-        LOG_INFO("ThemeManager", "[ThemeManager] Found theme: %s (%s)",
+        LOG_INFO("ThemeManager", "Found theme: %s (%s)",
                 m_entries.back().displayName.c_str(),
                 m_entries.back().path.c_str());
     }
 
-    LOG_INFO("ThemeManager", "[ThemeManager] Scanned %d theme(s) from %s",
+    LOG_INFO("ThemeManager", "Scanned %d theme(s) from %s",
             (int)m_entries.size(), themesDir.string().c_str());
 
     // Refresh the index pointer if the active theme is still present.
@@ -89,11 +89,11 @@ void ThemeManager::ResolveFontPath(const ThemeData& data) {
     if (fs::exists(resolved) && fs::is_regular_file(resolved)) {
         m_resolvedFontPath = resolved.string();
         m_fontSize         = data.fontSize > 0.f ? data.fontSize : 16.f;
-        LOG_INFO("ThemeManager", "[ThemeManager] Font resolved: %s @ %.1fpx",
+        LOG_INFO("ThemeManager", "Font resolved: %s @ %.1fpx",
                 m_resolvedFontPath.c_str(), m_fontSize);
     } else {
         // File not found — fall back to ImGui default silently.
-        LOG_INFO("ThemeManager", "[ThemeManager] Font file not found (%s) — using default font.",
+        LOG_INFO("ThemeManager", "Font file not found (%s) — using default font.",
                 resolved.string().c_str());
         m_resolvedFontPath.clear();
         m_fontSize = 16.f;
@@ -108,7 +108,7 @@ Result<bool, std::string> ThemeManager::LoadFromFile(const std::string& path) {
     auto result = ParseFile(path);
     if (result.IsErr()) {
         m_lastError = result.Error();
-        LOG_INFO("ThemeManager", "[ThemeManager] Failed to load theme '%s': %s",
+        LOG_INFO("ThemeManager", "Failed to load theme '%s': %s",
                 path.c_str(), m_lastError.c_str());
         return Result<bool, std::string>::Err(m_lastError);
     }
@@ -131,7 +131,7 @@ Result<bool, std::string> ThemeManager::LoadFromFile(const std::string& path) {
     ResolveFontPath(m_current);
     m_pendingFontChange = true;
 
-    LOG_INFO("ThemeManager", "[ThemeManager] Applied theme '%s' from '%s'",
+    LOG_INFO("ThemeManager", "Applied theme '%s' from '%s'",
             m_themeName.c_str(), path.c_str());
     return Result<bool, std::string>::Ok(true);
 }
@@ -229,7 +229,7 @@ void ThemeManager::LoadFromPreferences(PreferencesManager& prefs) {
             if (fs::exists(resonitePath)) {
                 auto result = LoadFromFile(resonitePath.string());
                 if (result.IsOk()) {
-                    LOG_INFO("ThemeManager", "[ThemeManager] No saved theme — applied Resonite as default.");
+                    LOG_INFO("ThemeManager", "No saved theme — applied Resonite as default.");
                     return;
                 }
             }
@@ -244,7 +244,7 @@ void ThemeManager::LoadFromPreferences(PreferencesManager& prefs) {
 
     auto result = LoadFromFile(path);
     if (result.IsErr()) {
-        LOG_INFO("ThemeManager", "[ThemeManager] Saved theme could not be restored: %s — using default.",
+        LOG_INFO("ThemeManager", "Saved theme could not be restored: %s — using default.",
                 result.Error().c_str());
         prefs.DeleteKey("Theme", "ThemePath");
     }

--- a/src/UI/ThemeManager.cpp
+++ b/src/UI/ThemeManager.cpp
@@ -1,3 +1,4 @@
+#include "App/Log.h"
 #include "ThemeManager.h"
 
 #include <nlohmann/json.hpp>
@@ -5,7 +6,6 @@
 #include <fstream>
 #include <algorithm>
 #include <unordered_map>
-#include <SDL3/SDL_log.h>
 
 using json = nlohmann::json;
 namespace fs = std::filesystem;
@@ -30,7 +30,7 @@ void ThemeManager::ScanThemesDirectory(const std::string& basePath) {
 
     fs::path themesDir = fs::path(basePath) / "themes";
     if (!fs::exists(themesDir) || !fs::is_directory(themesDir)) {
-        SDL_Log("[ThemeManager] Themes directory not found: %s", themesDir.string().c_str());
+        LOG_INFO("ThemeManager", "[ThemeManager] Themes directory not found: %s", themesDir.string().c_str());
         return;
     }
 
@@ -48,12 +48,12 @@ void ThemeManager::ScanThemesDirectory(const std::string& basePath) {
         if (te.displayName.empty())
             te.displayName = p.stem().string();
         m_entries.push_back(std::move(te));
-        SDL_Log("[ThemeManager] Found theme: %s (%s)",
+        LOG_INFO("ThemeManager", "[ThemeManager] Found theme: %s (%s)",
                 m_entries.back().displayName.c_str(),
                 m_entries.back().path.c_str());
     }
 
-    SDL_Log("[ThemeManager] Scanned %d theme(s) from %s",
+    LOG_INFO("ThemeManager", "[ThemeManager] Scanned %d theme(s) from %s",
             (int)m_entries.size(), themesDir.string().c_str());
 
     // Refresh the index pointer if the active theme is still present.
@@ -89,11 +89,11 @@ void ThemeManager::ResolveFontPath(const ThemeData& data) {
     if (fs::exists(resolved) && fs::is_regular_file(resolved)) {
         m_resolvedFontPath = resolved.string();
         m_fontSize         = data.fontSize > 0.f ? data.fontSize : 16.f;
-        SDL_Log("[ThemeManager] Font resolved: %s @ %.1fpx",
+        LOG_INFO("ThemeManager", "[ThemeManager] Font resolved: %s @ %.1fpx",
                 m_resolvedFontPath.c_str(), m_fontSize);
     } else {
         // File not found — fall back to ImGui default silently.
-        SDL_Log("[ThemeManager] Font file not found (%s) — using default font.",
+        LOG_INFO("ThemeManager", "[ThemeManager] Font file not found (%s) — using default font.",
                 resolved.string().c_str());
         m_resolvedFontPath.clear();
         m_fontSize = 16.f;
@@ -108,7 +108,7 @@ Result<bool, std::string> ThemeManager::LoadFromFile(const std::string& path) {
     auto result = ParseFile(path);
     if (result.IsErr()) {
         m_lastError = result.Error();
-        SDL_Log("[ThemeManager] Failed to load theme '%s': %s",
+        LOG_INFO("ThemeManager", "[ThemeManager] Failed to load theme '%s': %s",
                 path.c_str(), m_lastError.c_str());
         return Result<bool, std::string>::Err(m_lastError);
     }
@@ -131,7 +131,7 @@ Result<bool, std::string> ThemeManager::LoadFromFile(const std::string& path) {
     ResolveFontPath(m_current);
     m_pendingFontChange = true;
 
-    SDL_Log("[ThemeManager] Applied theme '%s' from '%s'",
+    LOG_INFO("ThemeManager", "[ThemeManager] Applied theme '%s' from '%s'",
             m_themeName.c_str(), path.c_str());
     return Result<bool, std::string>::Ok(true);
 }
@@ -229,7 +229,7 @@ void ThemeManager::LoadFromPreferences(PreferencesManager& prefs) {
             if (fs::exists(resonitePath)) {
                 auto result = LoadFromFile(resonitePath.string());
                 if (result.IsOk()) {
-                    SDL_Log("[ThemeManager] No saved theme — applied Resonite as default.");
+                    LOG_INFO("ThemeManager", "[ThemeManager] No saved theme — applied Resonite as default.");
                     return;
                 }
             }
@@ -244,7 +244,7 @@ void ThemeManager::LoadFromPreferences(PreferencesManager& prefs) {
 
     auto result = LoadFromFile(path);
     if (result.IsErr()) {
-        SDL_Log("[ThemeManager] Saved theme could not be restored: %s — using default.",
+        LOG_INFO("ThemeManager", "[ThemeManager] Saved theme could not be restored: %s — using default.",
                 result.Error().c_str());
         prefs.DeleteKey("Theme", "ThemePath");
     }

--- a/src/Utils/SDLHandles.h
+++ b/src/Utils/SDLHandles.h
@@ -1,5 +1,4 @@
 #pragma once
-#include "App/Log.h"
 #include <SDL3/SDL.h>
 #include <memory>
 

--- a/src/Utils/SDLHandles.h
+++ b/src/Utils/SDLHandles.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "App/Log.h"
 #include <SDL3/SDL.h>
 #include <memory>
 
@@ -168,7 +169,7 @@ public:
             m_haptic.Reset(SDL_OpenHapticFromJoystick(m_joystick));
             
             if (!m_haptic) {
-                SDL_Log("Failed to open haptic: %s", SDL_GetError());
+                LOG_INFO("SDLHandles", "Failed to open haptic: %s", SDL_GetError());
                 return false;
             }
             

--- a/src/Visualizers/GamepadHapticsVisualizer.cpp
+++ b/src/Visualizers/GamepadHapticsVisualizer.cpp
@@ -143,7 +143,9 @@ void GamepadHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager& devic
             isDualSense = gamepadHaptics->IsDualSense();
     }
 
-    /*
+    /***
+     * TODO: Add adaptive trigger support later down the line again
+     *
     if (isDualSense) {
         ImGui::Separator();
         ImGui::Text("DualSense Adaptive Triggers");

--- a/src/Visualizers/GamepadHapticsVisualizer.cpp
+++ b/src/Visualizers/GamepadHapticsVisualizer.cpp
@@ -1,3 +1,4 @@
+#include "App/Log.h"
 #include "GamepadHapticsVisualizer.h"
 #include "imgui.h"
 #include "Haptics/GamepadHaptics.h"
@@ -250,7 +251,7 @@ void GamepadHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager& devic
                 }
                 
                 int result = gamepadHaptics->PlayDualSenseTrigger("left", leftEffectName, leftParams);
-                SDL_Log("Left trigger effect '%s' result: %d", leftEffectName.c_str(), result);
+                LOG_DEBUG("GamepadHapticsViz", "Left trigger effect '%s' result: %d", leftEffectName.c_str(), result);
                 
                 // Send right trigger effect
                 std::map<std::string, int> rightParams;
@@ -295,7 +296,7 @@ void GamepadHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager& devic
                 }
                 
                 result = gamepadHaptics->PlayDualSenseTrigger("right", rightEffectName, rightParams);
-                SDL_Log("Right trigger effect '%s' result: %d", rightEffectName.c_str(), result);
+                LOG_DEBUG("GamepadHapticsViz", "Right trigger effect '%s' result: %d", rightEffectName.c_str(), result);
             }
         }
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,7 +55,7 @@ add_executable(test_protocol_validator
     ${IB_SRC}/Core/ProtocolValidator.cpp
 )
 target_include_directories(test_protocol_validator PRIVATE ${IB_SRC} ${IB_JSON})
-target_link_libraries(test_protocol_validator PRIVATE GTest::gtest_main)
+target_link_libraries(test_protocol_validator PRIVATE GTest::gtest_main SDL3::SDL3)
 gtest_discover_tests(test_protocol_validator)
 
 # 4. test_undo_redo ────────────────────────────────────────────────────────────
@@ -73,7 +73,7 @@ add_executable(test_backup_manager
     ${IB_SRC}/Core/BackupManager.cpp
 )
 target_include_directories(test_backup_manager PRIVATE ${IB_SRC})
-target_link_libraries(test_backup_manager PRIVATE GTest::gtest_main)
+target_link_libraries(test_backup_manager PRIVATE GTest::gtest_main SDL3::SDL3)
 gtest_discover_tests(test_backup_manager)
 
 # 6. test_dualsense_trigger ────────────────────────────────────────────────────


### PR DESCRIPTION
- Improved protocol import validation
- Better handling of unknown imported protocol fields
- Added extra validation for imported protocols
- Added JSON filter to import dialog
- Removed duplicate log categories
- Fixed custom protocol import catalog lookup
- Fixed export of field metadata when catalog entries are missing
- Added excluded fields and categories support
- Save and load excluded fields/categories
- Hide excluded fields and categories in tables
- Added category hide/show controls to field pickers
- Clean up duplicate catalog entries on load/save
- Block stale cross-catalog entries on load
- Exclude shared hidden fields from pickers with tooltip
- Added custom field editing and duplication
- Added category-based OSC/WS defaults
- Preserve manual path overrides
- ESC now closes protocol editor modals
- Auto-center and resize category modals
- Fixed field edit button in protocol editor
- Added protocol deletion warning
- Added icons for digital and analog fields
- Added experimental undo/redo shortcuts
- Improved OSC/WS field layout and sizing
- Fixed window resize crash at small widths