### PR TITLE
Thrustmaster t150 ffb issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -263,6 +263,7 @@ add_executable(InputBridge
     src/Mappers/InputMapper.cpp
     src/Mappers/OutputMapper.cpp
     # WebSocket and OSC protocols
+    src/Protocols/OscValidation.h
     src/Protocols/OSCProtocol.cpp
     src/Protocols/ProtocolManager.cpp
     src/Protocols/WebSocketProtocol.cpp

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -34,6 +34,8 @@
 #include <filesystem>
 #include <string>
 
+static constexpr const char* kTag = "Application";
+
 // ── RegisterProtocols ─────────────────────────────────────────────────────────
 
 void Application::RegisterProtocols()
@@ -187,17 +189,17 @@ void Application::MigrateUserData()
         std::error_code ec;
         fs::create_directories(dst.parent_path(), ec);
         if (ec) {
-            LOG_WARN("Application", "Migration: Could not create directory %s: %s",
+            LOG_WARN(kTag, "Migration: Could not create directory %s: %s",
                     dst.parent_path().string().c_str(), ec.message().c_str());
             return false;
         }
         fs::copy_file(src, dst, fs::copy_options::skip_existing, ec);
         if (ec) {
-            LOG_WARN("Application", "Migration: Could not copy %s → %s: %s",
+            LOG_WARN(kTag, "Migration: Could not copy %s → %s: %s",
                     src.string().c_str(), dst.string().c_str(), ec.message().c_str());
             return false;
         }
-        LOG_INFO("Application", "Migration: %s → %s", src.string().c_str(), dst.string().c_str());
+        LOG_INFO(kTag, "Migration: %s → %s", src.string().c_str(), dst.string().c_str());
         return true;
     };
 
@@ -227,10 +229,10 @@ void Application::MigrateUserData()
     total += migrateDir(oldRoot / "protocols", newData / "protocols");
 
     if (total > 0)
-        LOG_INFO("Application", "Migration: Migrated %d file(s) from legacy path %s",
+        LOG_INFO(kTag, "Migration: Migrated %d file(s) from legacy path %s",
                 total, oldRoot.string().c_str());
     else
-        LOG_INFO("Application", "Migration: Legacy path %s exists but all files already migrated.",
+        LOG_INFO(kTag, "Migration: Legacy path %s exists but all files already migrated.",
                 oldRoot.string().c_str());
 #endif
 }

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -187,13 +187,13 @@ void Application::MigrateUserData()
         std::error_code ec;
         fs::create_directories(dst.parent_path(), ec);
         if (ec) {
-            LOG_INFO("Application", "Migration: Could not create directory %s: %s",
+            LOG_WARN("Application", "Migration: Could not create directory %s: %s",
                     dst.parent_path().string().c_str(), ec.message().c_str());
             return false;
         }
         fs::copy_file(src, dst, fs::copy_options::skip_existing, ec);
         if (ec) {
-            LOG_INFO("Application", "Migration: Could not copy %s → %s: %s",
+            LOG_WARN("Application", "Migration: Could not copy %s → %s: %s",
                     src.string().c_str(), dst.string().c_str(), ec.message().c_str());
             return false;
         }

--- a/src/App/Log.h
+++ b/src/App/Log.h
@@ -7,18 +7,13 @@
  * std::cout logging with these macros.  Every call is routed through SDL's
  * logging system so AppLog captures it automatically with the correct level.
  *
- * Usage with a string literal tag (zero runtime overhead):
- *   LOG_INFO ("OSCServer", "Listening on port %d", port);
- *   LOG_WARN ("HapticDevice", "Rumble init failed: %s", SDL_GetError());
- *   LOG_ERROR("ProtocolRegistry", "Cannot write %s", path.c_str());
+ * Usage — tag may be a string literal or any const char* (e.g. kTag):
+ *   static constexpr const char* kTag = "OSCServer";
+ *   LOG_INFO (kTag, "Listening on port %d", port);
+ *   LOG_WARN (kTag, "Rumble init failed: %s", SDL_GetError());
+ *   LOG_ERROR(kTag, "Cannot write %s", path.c_str());
  *
- * Usage with a const std::string tag (avoids duplicate string storage):
- *   static const std::string kTag = "OSCServer";
- *   LOG_INFO_S (kTag, "Listening on port %d", port);
- *   LOG_WARN_S (kTag, "Rumble init failed: %s", SDL_GetError());
- *   LOG_ERROR_S(kTag, "Cannot write %s", path.c_str());
- *
- * The category string appears as a prefix inside the message so the existing
+ * The category string appears as a "[tag] " prefix inside the message so the
  * AppLog UI text-filter can match on it (e.g. filter "OSCServer").
  *
  * SDL log categories used:
@@ -26,68 +21,43 @@
  *   SDL_LOG_CATEGORY_INPUT        — devices, haptics, sensors
  *   SDL_LOG_CATEGORY_SYSTEM       — network (OSC / WebSocket)
  *
- * If you need finer per-category SDL filtering you can switch the second
+ * If you need finer per-category SDL filtering you can switch the category
  * argument of SDL_LogMessage to any SDL_LOG_CATEGORY_* constant; the text
  * prefix makes it identifiable in the AppLog UI regardless.
  */
 
 #include <SDL3/SDL_log.h>
-#include <string>
-
-// ── Helper: pick an SDL category from the subsystem tag ──────────────────────
-// This keeps SDL's own category-level filtering meaningful while still letting
-// every message land in AppLog via the single shared callback.
 
 // clang-format off
-#define _LOG_SDL_CAT(tag) SDL_LOG_CATEGORY_APPLICATION
 
-// ── Public macros — literal tag variants ─────────────────────────────────────
-// tag must be a string literal; the "[tag] " prefix is composed at compile time.
+// ── Macros ───────────────────────────────────────────────────────────────────
+// tag may be a string literal or a const char* variable (e.g. a file-scope
+// static constexpr const char* kTag).  SDL_LogMessage is used instead of the
+// SDL_LogXxx helpers so the format string can embed the tag at runtime via
+// "[%s] " without requiring compile-time string concatenation.
 
 /// Noisy per-frame or repeated diagnostic messages — hidden by default in the UI.
 #define LOG_VERBOSE(tag, fmt, ...) \
-    SDL_LogVerbose(_LOG_SDL_CAT(tag), "[" tag "] " fmt, ##__VA_ARGS__)
+    SDL_LogMessage(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_VERBOSE,  "[%s] " fmt, tag, ##__VA_ARGS__)
 
 /// Internal state tracing useful during development.
 #define LOG_DEBUG(tag, fmt, ...) \
-    SDL_LogDebug(_LOG_SDL_CAT(tag), "[" tag "] " fmt, ##__VA_ARGS__)
+    SDL_LogMessage(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_DEBUG,    "[%s] " fmt, tag, ##__VA_ARGS__)
 
 /// Normal operational events (startup, device connect/disconnect, etc.).
 #define LOG_INFO(tag, fmt, ...) \
-    SDL_LogInfo(_LOG_SDL_CAT(tag), "[" tag "] " fmt, ##__VA_ARGS__)
+    SDL_LogMessage(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_INFO,     "[%s] " fmt, tag, ##__VA_ARGS__)
 
 /// Unexpected but recoverable situations.
 #define LOG_WARN(tag, fmt, ...) \
-    SDL_LogWarn(_LOG_SDL_CAT(tag), "[" tag "] " fmt, ##__VA_ARGS__)
+    SDL_LogMessage(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_WARN,     "[%s] " fmt, tag, ##__VA_ARGS__)
 
 /// Failures that affect functionality but don't require a shutdown.
 #define LOG_ERROR(tag, fmt, ...) \
-    SDL_LogError(_LOG_SDL_CAT(tag), "[" tag "] " fmt, ##__VA_ARGS__)
+    SDL_LogMessage(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_ERROR,    "[%s] " fmt, tag, ##__VA_ARGS__)
 
 /// Unrecoverable errors — application integrity may be compromised.
 #define LOG_CRITICAL(tag, fmt, ...) \
-    SDL_LogCritical(_LOG_SDL_CAT(tag), "[" tag "] " fmt, ##__VA_ARGS__)
+    SDL_LogMessage(SDL_LOG_CATEGORY_APPLICATION, SDL_LOG_PRIORITY_CRITICAL, "[%s] " fmt, tag, ##__VA_ARGS__)
 
-// ── Public macros — std::string tag variants ─────────────────────────────────
-// Use these when the tag is stored as a const std::string (e.g. a class member
-// or static constant) to avoid duplicating the string as a literal.
-// The tag value is prepended at runtime; all other behaviour is identical.
-
-#define LOG_VERBOSE_S(stag, fmt, ...) \
-    SDL_LogVerbose(SDL_LOG_CATEGORY_APPLICATION, ("[" + (stag) + "] " fmt).c_str(), ##__VA_ARGS__)
-
-#define LOG_DEBUG_S(stag, fmt, ...) \
-    SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION, ("[" + (stag) + "] " fmt).c_str(), ##__VA_ARGS__)
-
-#define LOG_INFO_S(stag, fmt, ...) \
-    SDL_LogInfo(SDL_LOG_CATEGORY_APPLICATION, ("[" + (stag) + "] " fmt).c_str(), ##__VA_ARGS__)
-
-#define LOG_WARN_S(stag, fmt, ...) \
-    SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, ("[" + (stag) + "] " fmt).c_str(), ##__VA_ARGS__)
-
-#define LOG_ERROR_S(stag, fmt, ...) \
-    SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, ("[" + (stag) + "] " fmt).c_str(), ##__VA_ARGS__)
-
-#define LOG_CRITICAL_S(stag, fmt, ...) \
-    SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION, ("[" + (stag) + "] " fmt).c_str(), ##__VA_ARGS__)
 // clang-format on

--- a/src/Core/BackupManager.cpp
+++ b/src/Core/BackupManager.cpp
@@ -7,6 +7,8 @@
 #include <system_error>
 #include <cstdio>
 
+static constexpr const char* kTag = "BackupManager";
+
 namespace fs = std::filesystem;
 BackupManager::BackupManager(const std::string& backupDir, size_t maxBackups)
     : m_backupDir(backupDir)
@@ -36,7 +38,7 @@ std::string BackupManager::CreateBackup(const std::string& filePath) {
 
         return backupPath.string();
     } catch (const std::exception& e) {
-        LOG_ERROR("BackupManager", "Failed to create backup: %s", e.what());
+        LOG_ERROR(kTag, "Failed to create backup: %s", e.what());
         return "";
     }
 }
@@ -59,7 +61,7 @@ std::string BackupManager::CreateDirectoryBackup(const std::string& dirPath) {
 
         return backupPath.string();
     } catch (const std::exception& e) {
-        LOG_ERROR("BackupManager", "Failed to create directory backup: %s", e.what());
+        LOG_ERROR(kTag, "Failed to create directory backup: %s", e.what());
         return "";
     }
 }
@@ -88,7 +90,7 @@ bool BackupManager::RestoreBackup(const std::string& backupPath,
 
         return true;
     } catch (const std::exception& e) {
-        LOG_ERROR("BackupManager", "Failed to restore backup: %s", e.what());
+        LOG_ERROR(kTag, "Failed to restore backup: %s", e.what());
         return false;
     }
 }
@@ -134,7 +136,7 @@ std::vector<std::string> BackupManager::ListBackups(const std::string& filePath)
                      return tA > tB;
                  });
     } catch (const std::exception& e) {
-        LOG_ERROR("BackupManager", "Failed to list backups: %s", e.what());
+        LOG_ERROR(kTag, "Failed to list backups: %s", e.what());
     }
 
     return backups;
@@ -179,7 +181,7 @@ void BackupManager::CleanupOldBackups(const std::string& filePath) {
                 allBackups.erase(allBackups.begin());
             }
         } catch (const std::exception& e) {
-            LOG_ERROR("BackupManager", "Failed to cleanup backups: %s", e.what());
+            LOG_ERROR(kTag, "Failed to cleanup backups: %s", e.what());
         }
     } else {
         // Cleanup backups for specific file
@@ -214,7 +216,7 @@ size_t BackupManager::GetTotalBackupSize() const {
             }
         }
     } catch (const std::exception& e) {
-        LOG_ERROR("BackupManager", "Failed to calculate backup size: %s", e.what());
+        LOG_ERROR(kTag, "Failed to calculate backup size: %s", e.what());
     }
 
     return totalSize;
@@ -229,7 +231,7 @@ void BackupManager::ClearAllBackups() {
         fs::remove_all(m_backupDir);
         EnsureBackupDirectoryExists();
     } catch (const std::exception& e) {
-        LOG_ERROR("BackupManager", "Failed to clear backups: %s", e.what());
+        LOG_ERROR(kTag, "Failed to clear backups: %s", e.what());
     }
 }
 
@@ -267,7 +269,7 @@ bool BackupManager::EnsureBackupDirectoryExists() {
         }
         return fs::is_directory(m_backupDir);
     } catch (const std::exception& e) {
-        LOG_ERROR("BackupManager", "Failed to create backup directory: %s", e.what());
+        LOG_ERROR(kTag, "Failed to create backup directory: %s", e.what());
         return false;
     }
 }

--- a/src/Devices/DeviceFactory.cpp
+++ b/src/Devices/DeviceFactory.cpp
@@ -145,31 +145,6 @@ std::unique_ptr<HapticDevice> DeviceFactory::CreateHapticDevice(SDL_Joystick* jo
         return nullptr;
     }
 
-    // Thrustmaster T150 (and potentially other Thrustmaster wheels) only
-    // honour the lower 16 bits of the DirectInput/HID effect-length field.
-    // SDL_HAPTIC_INFINITY (0xFFFF'FFFF) is therefore silently truncated to
-    // 0xFFFF = 65 535 ms, causing all infinite effects to stop after ~65 s.
-    // Enabling the keepalive causes the haptic thread to re-upload every
-    // INFINITY effect every 30 s, which keeps it alive on affected hardware
-    // while being a near-no-op on wheels that handle INFINITY correctly.
-    if (haptic) {
-        const char* name = SDL_GetJoystickName(joystick);
-        uint16_t vid = SDL_GetJoystickVendor(joystick);
-        uint16_t pid = SDL_GetJoystickProduct(joystick);
-        // Thrustmaster VID: 0x044F
-        // T150: PID 0xB677 (PS3/PC) / 0xB67A (PS4/PC)
-        // Enable keepalive for all Thrustmaster wheels as a safe fallback;
-        // on unaffected models the extra SDL_UpdateHapticEffect calls are harmless.
-        const bool isThrustmaster = (vid == 0x044F);
-        if (isThrustmaster) {
-            LOG_INFO(kTag,
-                     "Enabling INFINITY-effect keepalive for Thrustmaster device "
-                     "\"%s\" (VID=0x%04X PID=0x%04X)",
-                     name ? name : "unknown", vid, pid);
-            haptic->EnableKeepalive(true);
-        }
-    }
-
     return haptic;
 }
 

--- a/src/Devices/DeviceFactory.cpp
+++ b/src/Devices/DeviceFactory.cpp
@@ -134,7 +134,7 @@ std::unique_ptr<HapticDevice> DeviceFactory::CreateHapticDevice(SDL_Joystick* jo
             break;
             
         default:
-            LOG_INFO("DeviceFactory", "Unknown haptic device type: %d", static_cast<int>(device_type));
+            LOG_WARN("DeviceFactory", "Unknown haptic device type: %d", static_cast<int>(device_type));
             return nullptr;
     }
     

--- a/src/Devices/DeviceFactory.cpp
+++ b/src/Devices/DeviceFactory.cpp
@@ -4,6 +4,8 @@
 #include "Haptics/SteeringWheelHaptics.h"
 #include "Haptics/FlightStickHaptics.h"
 
+static constexpr const char* kTag = "DeviceFactory";
+
 namespace InputBridge {
 
 std::optional<DeviceCreationResult> DeviceFactory::CreateDevice(SDL_JoystickID instance_id) {
@@ -24,7 +26,7 @@ std::optional<DeviceCreationResult> DeviceFactory::CreateDevice(SDL_JoystickID i
 std::optional<DeviceCreationResult> DeviceFactory::CreateWheelDevice(SDL_JoystickID instance_id) {
     SDL_Joystick* joystick = SDL_OpenJoystick(instance_id);
     if (!joystick) {
-        LOG_ERROR("DeviceFactory", "Failed to open steering wheel device %d: %s", instance_id, SDL_GetError());
+        LOG_ERROR(kTag, "Failed to open steering wheel device %d: %s", instance_id, SDL_GetError());
         return std::nullopt;
     }
     
@@ -41,13 +43,13 @@ std::optional<DeviceCreationResult> DeviceFactory::CreateWheelDevice(SDL_Joystic
 std::optional<DeviceCreationResult> DeviceFactory::CreateGamepadDevice(SDL_JoystickID instance_id) {
     SDL_Gamepad* gamepad = SDL_OpenGamepad(instance_id);
     if (!gamepad) {
-        LOG_ERROR("DeviceFactory", "Failed to open gamepad device %d: %s", instance_id, SDL_GetError());
+        LOG_ERROR(kTag, "Failed to open gamepad device %d: %s", instance_id, SDL_GetError());
         return std::nullopt;
     }
     
     SDL_Joystick* joystick = SDL_GetGamepadJoystick(gamepad);
     if (!joystick) {
-        LOG_ERROR("DeviceFactory", "Failed to get joystick from gamepad %d", instance_id);
+        LOG_ERROR(kTag, "Failed to get joystick from gamepad %d", instance_id);
         SDL_CloseGamepad(gamepad);
         return std::nullopt;
     }
@@ -75,7 +77,7 @@ std::optional<DeviceCreationResult> DeviceFactory::CreateGamepadDevice(SDL_Joyst
 std::optional<DeviceCreationResult> DeviceFactory::CreateGenericDevice(SDL_JoystickID instance_id) {
     SDL_Joystick* joystick = SDL_OpenJoystick(instance_id);
     if (!joystick) {
-        LOG_ERROR("DeviceFactory", "Failed to open generic device %d: %s", instance_id, SDL_GetError());
+        LOG_ERROR(kTag, "Failed to open generic device %d: %s", instance_id, SDL_GetError());
         return std::nullopt;
     }
     
@@ -110,7 +112,7 @@ std::unique_ptr<HapticDevice> DeviceFactory::CreateHapticDevice(SDL_Joystick* jo
     if (device_type == SDL_JOYSTICK_TYPE_GAMEPAD) {
         auto haptic = std::make_unique<GamepadHaptics>(joystick);
         if (haptic && !haptic->Init()) {
-            LOG_ERROR("DeviceFactory", "Failed to initialize gamepad haptics");
+            LOG_ERROR(kTag, "Failed to initialize gamepad haptics");
             return nullptr;
         }
         return haptic;
@@ -134,12 +136,12 @@ std::unique_ptr<HapticDevice> DeviceFactory::CreateHapticDevice(SDL_Joystick* jo
             break;
             
         default:
-            LOG_WARN("DeviceFactory", "Unknown haptic device type: %d", static_cast<int>(device_type));
+            LOG_WARN(kTag, "Unknown haptic device type: %d", static_cast<int>(device_type));
             return nullptr;
     }
     
     if (haptic && !haptic->Init()) {
-        LOG_ERROR("DeviceFactory", "Failed to initialize haptic device");
+        LOG_ERROR(kTag, "Failed to initialize haptic device");
         return nullptr;
     }
 
@@ -160,7 +162,7 @@ std::unique_ptr<HapticDevice> DeviceFactory::CreateHapticDevice(SDL_Joystick* jo
         // on unaffected models the extra SDL_UpdateHapticEffect calls are harmless.
         const bool isThrustmaster = (vid == 0x044F);
         if (isThrustmaster) {
-            LOG_INFO("DeviceFactory",
+            LOG_INFO(kTag,
                      "Enabling INFINITY-effect keepalive for Thrustmaster device "
                      "\"%s\" (VID=0x%04X PID=0x%04X)",
                      name ? name : "unknown", vid, pid);

--- a/src/Devices/DeviceFactory.cpp
+++ b/src/Devices/DeviceFactory.cpp
@@ -134,7 +134,32 @@ std::unique_ptr<HapticDevice> DeviceFactory::CreateHapticDevice(SDL_Joystick* jo
         LOG_ERROR("DeviceFactory", "Failed to initialize haptic device");
         return nullptr;
     }
-    
+
+    // Thrustmaster T150 (and potentially other Thrustmaster wheels) only
+    // honour the lower 16 bits of the DirectInput/HID effect-length field.
+    // SDL_HAPTIC_INFINITY (0xFFFF'FFFF) is therefore silently truncated to
+    // 0xFFFF = 65 535 ms, causing all infinite effects to stop after ~65 s.
+    // Enabling the keepalive causes the haptic thread to re-upload every
+    // INFINITY effect every 30 s, which keeps it alive on affected hardware
+    // while being a near-no-op on wheels that handle INFINITY correctly.
+    if (haptic) {
+        const char* name = SDL_GetJoystickName(joystick);
+        uint16_t vid = SDL_GetJoystickVendor(joystick);
+        uint16_t pid = SDL_GetJoystickProduct(joystick);
+        // Thrustmaster VID: 0x044F
+        // T150: PID 0xB677 (PS3/PC) / 0xB67A (PS4/PC)
+        // Enable keepalive for all Thrustmaster wheels as a safe fallback;
+        // on unaffected models the extra SDL_UpdateHapticEffect calls are harmless.
+        const bool isThrustmaster = (vid == 0x044F);
+        if (isThrustmaster) {
+            LOG_INFO("DeviceFactory",
+                     "Enabling INFINITY-effect keepalive for Thrustmaster device "
+                     "\"%s\" (VID=0x%04X PID=0x%04X)",
+                     name ? name : "unknown", vid, pid);
+            haptic->EnableKeepalive(true);
+        }
+    }
+
     return haptic;
 }
 

--- a/src/Devices/DeviceFactory.cpp
+++ b/src/Devices/DeviceFactory.cpp
@@ -60,7 +60,15 @@ std::optional<DeviceCreationResult> DeviceFactory::CreateGamepadDevice(SDL_Joyst
     state.name = gamepad_name ? gamepad_name : state.name; // Override with gamepad name if available
     
     auto haptic = CreateHapticDevice(joystick, SDL_JOYSTICK_TYPE_GAMEPAD);
-    
+
+    // SDL reports both Steam Controller generations as "Steam Controller", with
+    // no variant in the name. Now that the haptic device exists and has already
+    // detected the PID, we can ask it for the precise type and update the name.
+    if (auto* gh = dynamic_cast<GamepadHaptics*>(haptic.get())) {
+        if (gh->IsSteamController())
+            state.name = gh->GetControllerTypeName();
+    }
+
     return DeviceCreationResult{std::move(state), std::move(haptic)};
 }
 

--- a/src/Devices/DeviceManager.cpp
+++ b/src/Devices/DeviceManager.cpp
@@ -198,11 +198,11 @@ void DeviceManager::UpdateBatteryInfo(DeviceState &dev) {
             }
 
             if (dev.battery_state == SDL_POWERSTATE_UNKNOWN) {
-                LOG_INFO("DeviceManager", "Battery [%s]: State=%s (battery info not available)",
+                LOG_WARN("DeviceManager", "Battery [%s]: State=%s (battery info not available)",
                         dev.name.c_str(), state_str);
-                LOG_INFO("DeviceManager", "Possible causes: hid_playstation not loaded, missing udev rules, or SDL can't read battery");
+                LOG_WARN("DeviceManager", "Possible causes: hid_playstation not loaded, missing udev rules, or SDL can't read battery");
             } else if (dev.battery_state != SDL_POWERSTATE_NO_BATTERY) {
-                LOG_INFO("DeviceManager", "Battery [%s]: State=%s, Percent=%d%%",
+                LOG_DEBUG("DeviceManager", "Battery [%s]: State=%s, Percent=%d%%",
                         dev.name.c_str(), state_str, percent);
             }
         }
@@ -237,7 +237,7 @@ void DeviceManager::UpdateBatteryInfo(DeviceState &dev) {
                     if (leftState != SDL_POWERSTATE_NO_BATTERY) {
                         dev.battery_state_L   = leftState;
                         dev.battery_percent_L = leftPercent;
-                        LOG_INFO("DeviceManager", "Battery L [%s]: Percent=%d%%", dev.name.c_str(), leftPercent);
+                        LOG_DEBUG("DeviceManager", "Battery L [%s]: Percent=%d%%", dev.name.c_str(), leftPercent);
                         SDL_CloseJoystick(joy);
                         break;
                     }
@@ -275,7 +275,7 @@ void DeviceManager::UpdateBatteryInfo(DeviceState &dev) {
             }
 
             if (dev.battery_state != SDL_POWERSTATE_NO_BATTERY && dev.battery_state != SDL_POWERSTATE_UNKNOWN) {
-                LOG_INFO("DeviceManager", "Battery (Joystick) [%s]: State=%s, Percent=%d%%",
+                LOG_DEBUG("DeviceManager", "Battery (Joystick) [%s]: State=%s, Percent=%d%%",
                         dev.name.c_str(), state_str, percent);
             }
         }
@@ -302,7 +302,7 @@ bool DeviceManager::SetDeviceHidden(DeviceState& dev, bool hidden) {
                          ? dev.joystick
                          : (dev.gamepad ? SDL_GetGamepadJoystick(dev.gamepad) : nullptr);
     if (!joy) {
-        LOG_INFO("DeviceManager", "SetDeviceHidden: no joystick handle for '%s'.",
+        LOG_WARN("DeviceManager", "SetDeviceHidden: no joystick handle for '%s'.",
                 dev.name.c_str());
         return false;
     }

--- a/src/Devices/DeviceManager.cpp
+++ b/src/Devices/DeviceManager.cpp
@@ -172,6 +172,11 @@ HapticDevice *DeviceManager::GetHapticDevice(SDL_JoystickID instance_id) const {
     return nullptr;
 }
 
+void DeviceManager::SetDeviceKeepalive(SDL_JoystickID instance_id, bool enable) {
+    HapticDevice* haptic = GetHapticDevice(instance_id);
+    if (haptic) haptic->EnableKeepalive(enable);
+}
+
 void DeviceManager::UpdateBatteryInfo(DeviceState &dev) {
     SDL_PowerState old_state = dev.battery_state;
     int old_percent = dev.battery_percent;

--- a/src/Devices/DeviceManager.cpp
+++ b/src/Devices/DeviceManager.cpp
@@ -6,6 +6,8 @@
 #include <algorithm>
 #include <cstdlib>
 
+static constexpr const char* kTag = "DeviceManager";
+
 DeviceManager &DeviceManager::GetInstance() {
     static DeviceManager instance;
     return instance;
@@ -33,7 +35,7 @@ std::string DeviceManager::GetDeviceGUIDString(const DeviceState &dev) {
 void DeviceManager::HandleDeviceAdded(SDL_JoystickID instance_id) {
     auto result = InputBridge::DeviceFactory::CreateDevice(instance_id);
     if (!result) {
-        LOG_ERROR("DeviceManager", "Failed to create device %d", instance_id);
+        LOG_ERROR(kTag, "Failed to create device %d", instance_id);
         return;
     }
     
@@ -153,7 +155,7 @@ void DeviceManager::Update(bool isMinimized) {
 
 void DeviceManager::ScanWheelRPMDevices() {
     m_WheelRPMDevices = wheel::WheelManager::scan();
-    LOG_INFO("DeviceManager", "WheelRPM scan complete: %zu device(s) found",
+    LOG_INFO(kTag, "WheelRPM scan complete: %zu device(s) found",
             m_WheelRPMDevices.size());
 }
 
@@ -198,11 +200,11 @@ void DeviceManager::UpdateBatteryInfo(DeviceState &dev) {
             }
 
             if (dev.battery_state == SDL_POWERSTATE_UNKNOWN) {
-                LOG_WARN("DeviceManager", "Battery [%s]: State=%s (battery info not available)",
+                LOG_WARN(kTag, "Battery [%s]: State=%s (battery info not available)",
                         dev.name.c_str(), state_str);
-                LOG_WARN("DeviceManager", "Possible causes: hid_playstation not loaded, missing udev rules, or SDL can't read battery");
+                LOG_WARN(kTag, "Possible causes: hid_playstation not loaded, missing udev rules, or SDL can't read battery");
             } else if (dev.battery_state != SDL_POWERSTATE_NO_BATTERY) {
-                LOG_DEBUG("DeviceManager", "Battery [%s]: State=%s, Percent=%d%%",
+                LOG_DEBUG(kTag, "Battery [%s]: State=%s, Percent=%d%%",
                         dev.name.c_str(), state_str, percent);
             }
         }
@@ -237,7 +239,7 @@ void DeviceManager::UpdateBatteryInfo(DeviceState &dev) {
                     if (leftState != SDL_POWERSTATE_NO_BATTERY) {
                         dev.battery_state_L   = leftState;
                         dev.battery_percent_L = leftPercent;
-                        LOG_DEBUG("DeviceManager", "Battery L [%s]: Percent=%d%%", dev.name.c_str(), leftPercent);
+                        LOG_DEBUG(kTag, "Battery L [%s]: Percent=%d%%", dev.name.c_str(), leftPercent);
                         SDL_CloseJoystick(joy);
                         break;
                     }
@@ -275,7 +277,7 @@ void DeviceManager::UpdateBatteryInfo(DeviceState &dev) {
             }
 
             if (dev.battery_state != SDL_POWERSTATE_NO_BATTERY && dev.battery_state != SDL_POWERSTATE_UNKNOWN) {
-                LOG_DEBUG("DeviceManager", "Battery (Joystick) [%s]: State=%s, Percent=%d%%",
+                LOG_DEBUG(kTag, "Battery (Joystick) [%s]: State=%s, Percent=%d%%",
                         dev.name.c_str(), state_str, percent);
             }
         }
@@ -302,7 +304,7 @@ bool DeviceManager::SetDeviceHidden(DeviceState& dev, bool hidden) {
                          ? dev.joystick
                          : (dev.gamepad ? SDL_GetGamepadJoystick(dev.gamepad) : nullptr);
     if (!joy) {
-        LOG_WARN("DeviceManager", "SetDeviceHidden: no joystick handle for '%s'.",
+        LOG_WARN(kTag, "SetDeviceHidden: no joystick handle for '%s'.",
                 dev.name.c_str());
         return false;
     }
@@ -312,7 +314,7 @@ bool DeviceManager::SetDeviceHidden(DeviceState& dev, bool hidden) {
     return ok;
 #else
     (void)dev; (void)hidden;
-    LOG_WARN("DeviceManager", "SetDeviceHidden: exclusive input support not compiled in.");
+    LOG_WARN(kTag, "SetDeviceHidden: exclusive input support not compiled in.");
     return false;
 #endif
 }

--- a/src/Devices/DeviceManager.h
+++ b/src/Devices/DeviceManager.h
@@ -31,6 +31,7 @@ class DeviceManager {
     static std::string GetDeviceGUIDString(const DeviceState& dev);
 
     HapticDevice* GetHapticDevice(SDL_JoystickID instance_id) const;
+    void SetDeviceKeepalive(SDL_JoystickID instance_id, bool enable);
 
     void UpdateBatteryInfo(DeviceState& dev);
 

--- a/src/Devices/SensorReader.cpp
+++ b/src/Devices/SensorReader.cpp
@@ -2,6 +2,8 @@
 #include "App/Log.h"
 #include <algorithm>
 
+static constexpr const char* kTag = "SensorReader";
+
 // ── Private helpers ───────────────────────────────────────────────────────────
 //
 // All six Read*Gyro / Read*Accel public methods previously duplicated the same
@@ -89,7 +91,7 @@ void SensorReader::Enable(SDL_Gamepad* gamepad, const SensorCapabilities& caps) 
     for (const auto& entry : kMotionSensors) {
         if (caps.*entry.flag) {
             if (!SDL_SetGamepadSensorEnabled(gamepad, entry.type, true))
-                LOG_WARN("SensorReader", "Enable: failed to enable sensor type %d: %s",
+                LOG_WARN(kTag, "Enable: failed to enable sensor type %d: %s",
                          (int)entry.type, SDL_GetError());
         }
     }
@@ -106,9 +108,9 @@ SensorCapabilities SensorReader::EnableAll(SDL_Gamepad* gamepad) {
 GyroState  SensorReader::ReadGyro (SDL_Gamepad* g) { return ReadGyroSensor (g, SDL_SENSOR_GYRO);    }
 AccelState SensorReader::ReadAccel(SDL_Gamepad* g) { return ReadAccelSensor(g, SDL_SENSOR_ACCEL);   }
 GyroState  SensorReader::ReadGyroL(SDL_Gamepad* g) { return ReadGyroSensor (g, SDL_SENSOR_GYRO_L);  }
-AccelState SensorReader::ReadAccelL(SDL_Gamepad* g){ return ReadAccelSensor(g, SDL_SENSOR_ACCEL_L); }
+AccelState SensorReader::ReadAccelL(SDL_Gamepad* g) { return ReadAccelSensor(g, SDL_SENSOR_ACCEL_L); }
 GyroState  SensorReader::ReadGyroR(SDL_Gamepad* g) { return ReadGyroSensor (g, SDL_SENSOR_GYRO_R);  }
-AccelState SensorReader::ReadAccelR(SDL_Gamepad* g){ return ReadAccelSensor(g, SDL_SENSOR_ACCEL_R); }
+AccelState SensorReader::ReadAccelR(SDL_Gamepad* g) { return ReadAccelSensor(g, SDL_SENSOR_ACCEL_R); }
 
 // ── Touch ─────────────────────────────────────────────────────────────────────
 

--- a/src/Devices/SensorReader.cpp
+++ b/src/Devices/SensorReader.cpp
@@ -1,4 +1,5 @@
 #include "SensorReader.h"
+#include "App/Log.h"
 #include <algorithm>
 
 // ── Private helpers ───────────────────────────────────────────────────────────
@@ -88,9 +89,8 @@ void SensorReader::Enable(SDL_Gamepad* gamepad, const SensorCapabilities& caps) 
     for (const auto& entry : kMotionSensors) {
         if (caps.*entry.flag) {
             if (!SDL_SetGamepadSensorEnabled(gamepad, entry.type, true))
-                SDL_LogWarn(SDL_LOG_CATEGORY_INPUT,
-                            "SensorReader::Enable: failed to enable sensor type %d: %s",
-                            (int)entry.type, SDL_GetError());
+                LOG_WARN("SensorReader", "Enable: failed to enable sensor type %d: %s",
+                         (int)entry.type, SDL_GetError());
         }
     }
 }

--- a/src/Devices/SensorState.h
+++ b/src/Devices/SensorState.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <cstdint>
 #include <array>
 
 /**

--- a/src/Devices/VirtualDeviceManager.cpp
+++ b/src/Devices/VirtualDeviceManager.cpp
@@ -2,6 +2,8 @@
 #include "VirtualDeviceManager.h"
 #include <algorithm>
 
+static constexpr const char* kTag = "VirtualDeviceManager";
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Preset tables
 // ─────────────────────────────────────────────────────────────────────────────
@@ -132,14 +134,14 @@ SDL_JoystickID VirtualDeviceManager::AddDevice(VirtualDeviceType type,
 
     SDL_JoystickID id = SDL_AttachVirtualJoystick(&desc);
     if (id == 0) {
-        LOG_ERROR("VirtualDeviceManager", "SDL_AttachVirtualJoystick failed: %s",
+        LOG_ERROR(kTag, "SDL_AttachVirtualJoystick failed: %s",
                 SDL_GetError());
         return 0;
     }
 
     SDL_Joystick* joystick = SDL_OpenJoystick(id);
     if (!joystick) {
-        LOG_ERROR("VirtualDeviceManager", "SDL_OpenJoystick failed: %s", SDL_GetError());
+        LOG_ERROR(kTag, "SDL_OpenJoystick failed: %s", SDL_GetError());
         SDL_DetachVirtualJoystick(id);
         return 0;
     }
@@ -149,7 +151,7 @@ SDL_JoystickID VirtualDeviceManager::AddDevice(VirtualDeviceType type,
     // Push defaults immediately so SDL has a consistent initial state.
     PushState(id);
 
-    LOG_INFO("VirtualDeviceManager", "created '%s' (type=%d, id=%u)",
+    LOG_INFO(kTag, "created '%s' (type=%d, id=%u)",
             name.c_str(), static_cast<int>(type), static_cast<unsigned>(id));
     return id;
 }
@@ -170,7 +172,7 @@ void VirtualDeviceManager::RemoveDevice(SDL_JoystickID id) {
     SDL_DetachVirtualJoystick(id);
 
     m_Devices.erase(it);
-    LOG_INFO("VirtualDeviceManager", "removed virtual device id=%u",
+    LOG_INFO(kTag, "removed virtual device id=%u",
             static_cast<unsigned>(id));
 }
 

--- a/src/Haptics/DualSenseController.cpp
+++ b/src/Haptics/DualSenseController.cpp
@@ -92,13 +92,13 @@ DualSense::ConnectionType DualSenseController::DetectConnectionType() const {
         
         // USB devices report as charging or charged
         if (state == SDL_POWERSTATE_CHARGING || state == SDL_POWERSTATE_CHARGED) {
-            LOG_INFO("DualSense", "USB detected via power state (charging/charged)");
+            LOG_DEBUG("DualSense", "USB detected via power state (charging/charged)");
             return DualSense::ConnectionType::USB;
         }
         
         // Battery-powered means Bluetooth
         if (state == SDL_POWERSTATE_ON_BATTERY) {
-            LOG_INFO("DualSense", "Bluetooth detected via power state (on battery)");
+            LOG_DEBUG("DualSense", "Bluetooth detected via power state (on battery)");
             return DualSense::ConnectionType::Bluetooth;
         }
     }
@@ -110,25 +110,25 @@ DualSense::ConnectionType DualSenseController::DetectConnectionType() const {
         std::transform(pathStr.begin(), pathStr.end(), pathStr.begin(),
                       [](unsigned char c) { return std::tolower(c); });
         
-        LOG_INFO("DualSense", "Checking path: %s", path);
+        LOG_DEBUG("DualSense", "Checking path: %s", path);
         
         // Explicit USB indicators
         if (pathStr.find("usb") != std::string::npos) {
-            LOG_INFO("DualSense", "USB detected via path (contains 'usb')");
+            LOG_DEBUG("DualSense", "USB detected via path (contains 'usb')");
             return DualSense::ConnectionType::USB;
         }
         
         // Explicit Bluetooth indicators
         if (pathStr.find("bluetooth") != std::string::npos ||
             pathStr.find("-bt-") != std::string::npos) {
-            LOG_INFO("DualSense", "Bluetooth detected via path (contains 'bluetooth'/'bt')");
+            LOG_DEBUG("DualSense", "Bluetooth detected via path (contains 'bluetooth'/'bt')");
             return DualSense::ConnectionType::Bluetooth;
         }
         
         // On Linux: hidraw without Bluetooth indicators = USB
         #ifdef __linux__
         if (pathStr.find("hidraw") != std::string::npos) {
-            LOG_INFO("DualSense", "USB detected via Linux hidraw");
+            LOG_DEBUG("DualSense", "USB detected via Linux hidraw");
             return DualSense::ConnectionType::USB;
         }
         #endif
@@ -139,7 +139,7 @@ DualSense::ConnectionType DualSenseController::DetectConnectionType() const {
     
     // Default to Bluetooth (more common for wireless play)
     // Note: Previous code defaulted to USB, but Bluetooth is more common
-    LOG_INFO("DualSense", "Defaulting to Bluetooth (could not determine definitively)");
+    LOG_DEBUG("DualSense", "Defaulting to Bluetooth (could not determine definitively)");
     return DualSense::ConnectionType::Bluetooth;
 }
 
@@ -162,7 +162,7 @@ int DualSenseController::SetTriggerEffect(const std::string& trigger,
     const bool updateRight = (trigger == "right" || trigger == "both");
     
     if (!updateLeft && !updateRight) {
-        LOG_INFO("DualSense", "SetTriggerEffect - Invalid trigger: %s", trigger.c_str());
+        LOG_WARN("DualSense", "SetTriggerEffect - Invalid trigger: %s", trigger.c_str());
         return -1;
     }
     
@@ -176,7 +176,7 @@ int DualSenseController::SetTriggerEffect(const std::string& trigger,
     }
     
     if (!success) {
-        LOG_INFO("DualSense", "SetTriggerEffect - Failed to apply effect");
+        LOG_WARN("DualSense", "SetTriggerEffect - Failed to apply effect");
         return -1;
     }
     
@@ -243,7 +243,7 @@ bool DualSenseController::ApplyTriggerEffect(uint8_t* triggerData,
                                                         amplitudeA, amplitudeB, frequency, period);
     }
     else {
-        LOG_INFO("DualSense", "Unknown effect type '%s'", effectType.c_str());
+        LOG_WARN("DualSense", "Unknown effect type '%s'", effectType.c_str());
         return ExtendInput::DataTools::DualSense::DualSenseTriggerEffectGenerator::Off(triggerData, 0);
     }
 }
@@ -293,7 +293,7 @@ void DualSenseController::ApplyOutputState() {
         }
         
         if (!success) {
-            LOG_INFO("DualSense", "Failed to send output state");
+            LOG_WARN("DualSense", "Failed to send output state");
         }
     });
 }
@@ -357,7 +357,7 @@ bool DualSenseController::SendUSBOutput() {
            m_outputState.rightTriggerEffect[0], m_outputState.leftTriggerEffect[0]);
     
     if (!SDL_SendJoystickEffect(m_joystick, data.data(), data.size())) {
-        LOG_INFO("DualSense", "DualSense USB: Send failed - %s", SDL_GetError());
+        LOG_WARN("DualSense", "DualSense USB: Send failed - %s", SDL_GetError());
         return false;
     }
     
@@ -427,7 +427,7 @@ bool DualSenseController::SendBluetoothOutput() {
     
     // SDL handles CRC32 for Bluetooth automatically
     if (!SDL_SendJoystickEffect(m_joystick, data.data(), data.size())) {
-        LOG_INFO("DualSense", "DualSense BT: Send failed - %s", SDL_GetError());
+        LOG_WARN("DualSense", "DualSense BT: Send failed - %s", SDL_GetError());
         return false;
     }
     

--- a/src/Haptics/DualSenseController.cpp
+++ b/src/Haptics/DualSenseController.cpp
@@ -15,6 +15,8 @@
 #include <cstring>
 #include <cctype>
 
+static constexpr const char* kTag = "DualSense";
+
 // ==================== OutputState Implementation ====================
 
 DualSense::OutputState::OutputState() 
@@ -56,7 +58,7 @@ InputBridge::Result<bool, InputBridge::HapticError> DualSenseController::Init() 
         m_connectionType = DetectConnectionType();
         m_connectionTypeDetected = true;
         
-        LOG_INFO("DualSense", "DualSense initialized: Connection=%s", 
+        LOG_INFO(kTag, "DualSense initialized: Connection=%s", 
                m_connectionType == DualSense::ConnectionType::USB ? "USB" : "Bluetooth");
     }
     
@@ -92,13 +94,13 @@ DualSense::ConnectionType DualSenseController::DetectConnectionType() const {
         
         // USB devices report as charging or charged
         if (state == SDL_POWERSTATE_CHARGING || state == SDL_POWERSTATE_CHARGED) {
-            LOG_DEBUG("DualSense", "USB detected via power state (charging/charged)");
+            LOG_DEBUG(kTag, "USB detected via power state (charging/charged)");
             return DualSense::ConnectionType::USB;
         }
         
         // Battery-powered means Bluetooth
         if (state == SDL_POWERSTATE_ON_BATTERY) {
-            LOG_DEBUG("DualSense", "Bluetooth detected via power state (on battery)");
+            LOG_DEBUG(kTag, "Bluetooth detected via power state (on battery)");
             return DualSense::ConnectionType::Bluetooth;
         }
     }
@@ -110,25 +112,25 @@ DualSense::ConnectionType DualSenseController::DetectConnectionType() const {
         std::transform(pathStr.begin(), pathStr.end(), pathStr.begin(),
                       [](unsigned char c) { return std::tolower(c); });
         
-        LOG_DEBUG("DualSense", "Checking path: %s", path);
+        LOG_DEBUG(kTag, "Checking path: %s", path);
         
         // Explicit USB indicators
         if (pathStr.find("usb") != std::string::npos) {
-            LOG_DEBUG("DualSense", "USB detected via path (contains 'usb')");
+            LOG_DEBUG(kTag, "USB detected via path (contains 'usb')");
             return DualSense::ConnectionType::USB;
         }
         
         // Explicit Bluetooth indicators
         if (pathStr.find("bluetooth") != std::string::npos ||
             pathStr.find("-bt-") != std::string::npos) {
-            LOG_DEBUG("DualSense", "Bluetooth detected via path (contains 'bluetooth'/'bt')");
+            LOG_DEBUG(kTag, "Bluetooth detected via path (contains 'bluetooth'/'bt')");
             return DualSense::ConnectionType::Bluetooth;
         }
         
         // On Linux: hidraw without Bluetooth indicators = USB
         #ifdef __linux__
         if (pathStr.find("hidraw") != std::string::npos) {
-            LOG_DEBUG("DualSense", "USB detected via Linux hidraw");
+            LOG_DEBUG(kTag, "USB detected via Linux hidraw");
             return DualSense::ConnectionType::USB;
         }
         #endif
@@ -139,7 +141,7 @@ DualSense::ConnectionType DualSenseController::DetectConnectionType() const {
     
     // Default to Bluetooth (more common for wireless play)
     // Note: Previous code defaulted to USB, but Bluetooth is more common
-    LOG_DEBUG("DualSense", "Defaulting to Bluetooth (could not determine definitively)");
+    LOG_DEBUG(kTag, "Defaulting to Bluetooth (could not determine definitively)");
     return DualSense::ConnectionType::Bluetooth;
 }
 
@@ -162,7 +164,7 @@ int DualSenseController::SetTriggerEffect(const std::string& trigger,
     const bool updateRight = (trigger == "right" || trigger == "both");
     
     if (!updateLeft && !updateRight) {
-        LOG_WARN("DualSense", "SetTriggerEffect - Invalid trigger: %s", trigger.c_str());
+        LOG_WARN(kTag, "SetTriggerEffect - Invalid trigger: %s", trigger.c_str());
         return -1;
     }
     
@@ -176,7 +178,7 @@ int DualSenseController::SetTriggerEffect(const std::string& trigger,
     }
     
     if (!success) {
-        LOG_WARN("DualSense", "SetTriggerEffect - Failed to apply effect");
+        LOG_WARN(kTag, "SetTriggerEffect - Failed to apply effect");
         return -1;
     }
     
@@ -243,7 +245,7 @@ bool DualSenseController::ApplyTriggerEffect(uint8_t* triggerData,
                                                         amplitudeA, amplitudeB, frequency, period);
     }
     else {
-        LOG_WARN("DualSense", "Unknown effect type '%s'", effectType.c_str());
+        LOG_WARN(kTag, "Unknown effect type '%s'", effectType.c_str());
         return ExtendInput::DataTools::DualSense::DualSenseTriggerEffectGenerator::Off(triggerData, 0);
     }
 }
@@ -293,7 +295,7 @@ void DualSenseController::ApplyOutputState() {
         }
         
         if (!success) {
-            LOG_WARN("DualSense", "Failed to send output state");
+            LOG_WARN(kTag, "Failed to send output state");
         }
     });
 }
@@ -350,18 +352,18 @@ bool DualSenseController::SendUSBOutput() {
     // LED brightness (offset 43)
     data[43] = m_outputState.ledBrightness;
     
-    LOG_DEBUG("DualSense", "USB: Sending report, size=%zu", data.size());
-    LOG_DEBUG("DualSense", "  Flags: [1]=0x%02X [2]=0x%02X", data[1], data[2]);
-    LOG_DEBUG("DualSense", "  Rumble: L=%d R=%d", data[4], data[3]);
-    LOG_DEBUG("DualSense", "  Triggers: R[0]=0x%02X L[0]=0x%02X", 
+    LOG_DEBUG(kTag, "USB: Sending report, size=%zu", data.size());
+    LOG_DEBUG(kTag, "  Flags: [1]=0x%02X [2]=0x%02X", data[1], data[2]);
+    LOG_DEBUG(kTag, "  Rumble: L=%d R=%d", data[4], data[3]);
+    LOG_DEBUG(kTag, "  Triggers: R[0]=0x%02X L[0]=0x%02X", 
            m_outputState.rightTriggerEffect[0], m_outputState.leftTriggerEffect[0]);
     
     if (!SDL_SendJoystickEffect(m_joystick, data.data(), data.size())) {
-        LOG_WARN("DualSense", "DualSense USB: Send failed - %s", SDL_GetError());
+        LOG_WARN(kTag, "DualSense USB: Send failed - %s", SDL_GetError());
         return false;
     }
     
-    LOG_DEBUG("DualSense", "USB: Report sent successfully");
+    LOG_DEBUG(kTag, "USB: Report sent successfully");
     return true;
 }
 
@@ -419,18 +421,18 @@ bool DualSenseController::SendBluetoothOutput() {
     // Player LEDs (offset 44)
     data[44] = m_outputState.playerLEDs;
     
-    LOG_DEBUG("DualSense", "BT: Sending report, size=%zu, seq=%d", data.size(), m_bluetoothSequence);
-    LOG_DEBUG("DualSense", "  Flags: [1]=0x%02X [2]=0x%02X [3]=0x%02X", data[1], data[2], data[3]);
-    LOG_DEBUG("DualSense", "  Rumble: L=%d R=%d", data[5], data[4]);
-    LOG_DEBUG("DualSense", "  Triggers: R[0]=0x%02X L[0]=0x%02X", 
+    LOG_DEBUG(kTag, "BT: Sending report, size=%zu, seq=%d", data.size(), m_bluetoothSequence);
+    LOG_DEBUG(kTag, "  Flags: [1]=0x%02X [2]=0x%02X [3]=0x%02X", data[1], data[2], data[3]);
+    LOG_DEBUG(kTag, "  Rumble: L=%d R=%d", data[5], data[4]);
+    LOG_DEBUG(kTag, "  Triggers: R[0]=0x%02X L[0]=0x%02X", 
            m_outputState.rightTriggerEffect[0], m_outputState.leftTriggerEffect[0]);
     
     // SDL handles CRC32 for Bluetooth automatically
     if (!SDL_SendJoystickEffect(m_joystick, data.data(), data.size())) {
-        LOG_WARN("DualSense", "DualSense BT: Send failed - %s", SDL_GetError());
+        LOG_WARN(kTag, "DualSense BT: Send failed - %s", SDL_GetError());
         return false;
     }
     
-    LOG_DEBUG("DualSense", "BT: Report sent successfully");
+    LOG_DEBUG(kTag, "BT: Report sent successfully");
     return true;
 }

--- a/src/Haptics/FlightStickHaptics.cpp
+++ b/src/Haptics/FlightStickHaptics.cpp
@@ -2,6 +2,8 @@
 #include "FlightStickHaptics.h"
 #include <algorithm>
 
+static constexpr const char* kTag = "FlightStickHaptics";
+
 // ---------------------------------------------------------------------------
 // PlayConstant
 // ---------------------------------------------------------------------------
@@ -9,7 +11,7 @@
 int FlightStickHaptics::PlayConstant(int slot, float strength, uint32_t duration_ms) {
     RunAsync([this, slot, strength, duration_ms]() {
         if (!m_haptic) {
-            LOG_WARN("FlightStickHaptics", "PlayConstant - Haptic device not ready");
+            LOG_WARN(kTag, "PlayConstant - Haptic device not ready");
             return;
         }
 
@@ -35,7 +37,7 @@ int FlightStickHaptics::PlayConstant(int slot, float strength, uint32_t duration
             m_constantEffects[slot] = newId;
             if (created) {
                 if (!SDL_RunHapticEffect(m_haptic.Get(), newId, 1)) {
-                    LOG_ERROR("FlightStickHaptics", "PlayConstant - Run failed: %s", SDL_GetError());
+                    LOG_ERROR(kTag, "PlayConstant - Run failed: %s", SDL_GetError());
                 }
             }
             {
@@ -75,7 +77,7 @@ int FlightStickHaptics::PlayPeriodic(int slot, HapticPeriodicType wave_type, flo
                                      uint32_t duration_ms) {
     RunAsync([this, slot, wave_type, strength, period, magnitude, offset, phase, duration_ms]() {
         if (!m_haptic) {
-            LOG_WARN("FlightStickHaptics", "PlayPeriodic - Haptic device not ready");
+            LOG_WARN(kTag, "PlayPeriodic - Haptic device not ready");
             return;
         }
 
@@ -128,7 +130,7 @@ int FlightStickHaptics::PlayPeriodic(int slot, HapticPeriodicType wave_type, flo
             m_periodicEffects[slot] = newId;
             if (created) {
                 if (!SDL_RunHapticEffect(m_haptic.Get(), newId, 1)) {
-                    LOG_ERROR("FlightStickHaptics", "PlayPeriodic - Run failed: %s", SDL_GetError());
+                    LOG_ERROR(kTag, "PlayPeriodic - Run failed: %s", SDL_GetError());
                 }
             }
             {
@@ -190,14 +192,14 @@ int FlightStickHaptics::PlayCondition(int slot, HapticConditionType type,
     RunAsync([this, slot, type, right_sat, left_sat,
               right_coeff, left_coeff, deadband, center, duration_ms]() {
         if (!m_haptic) {
-            LOG_WARN("FlightStickHaptics", "PlayCondition - Haptic device not ready");
+            LOG_WARN(kTag, "PlayCondition - Haptic device not ready");
             return;
         }
 
         {
             int max_effects = SDL_GetMaxHapticEffects(m_haptic.Get());
             if (slot < 0 || slot >= max_effects) {
-                LOG_WARN("FlightStickHaptics", "PlayCondition - Invalid slot %d (max: %d)",
+                LOG_WARN(kTag, "PlayCondition - Invalid slot %d (max: %d)",
                         slot, max_effects);
                 return;
             }
@@ -234,7 +236,7 @@ int FlightStickHaptics::PlayCondition(int slot, HapticConditionType type,
             m_conditionEffects[slot] = newId;
             if (created) {
                 if (!SDL_RunHapticEffect(m_haptic.Get(), newId, 1)) {
-                    LOG_ERROR("FlightStickHaptics", "PlayCondition - Run failed for type %s: %s",
+                    LOG_ERROR(kTag, "PlayCondition - Run failed for type %s: %s",
                             ConditionTypeName(type), SDL_GetError());
                     std::lock_guard<std::mutex> lock(m_activeEffectsMutex);
                     m_activeConditions.erase(slot);

--- a/src/Haptics/GamepadHaptics.cpp
+++ b/src/Haptics/GamepadHaptics.cpp
@@ -4,6 +4,8 @@
 #include "Core/Result.h"
 #include <algorithm>
 
+static constexpr const char* kTag = "GamepadHaptics";
+
 // ==================== Destructor ====================
 
 GamepadHaptics::~GamepadHaptics() {
@@ -27,25 +29,25 @@ InputBridge::Result<bool, InputBridge::HapticError> GamepadHaptics::Init() {
     if (IsDualSense()) {
         m_dualSense = std::make_unique<DualSenseController>(m_joystick);
         m_dualSense->Init();
-        LOG_INFO("GamepadHaptics", "Initialized as DualSense");
+        LOG_INFO(kTag, "Initialized as DualSense");
     }
     else if (IsXboxController()) {
         m_xbox = std::make_unique<XboxController>(m_joystick);
         m_xbox->Init();
-        LOG_INFO("GamepadHaptics", "Initialized as Xbox");
+        LOG_INFO(kTag, "Initialized as Xbox");
     }
     else if (IsSteamControllerV1()) {
         // V1 haptic pulses are sent via SDL_SendGamepadEffect in SendSteamControllerHaptic(),
         // which routes through SDL's already-open HIDAPI handle.  No separate HID open needed.
-        LOG_INFO("GamepadHaptics", "Initialized as Steam Controller V1 (trackpad HID haptics)");
+        LOG_INFO(kTag, "Initialized as Steam Controller V1 (trackpad HID haptics)");
     }
     else if (IsSteamControllerV2()) {
         // V2 supports SDL_RumbleGamepad natively since SDL 3.4.10.
         // No special initialization required — the standard rumble path is used.
-        LOG_INFO("GamepadHaptics", "Initialized as Steam Controller V2 (SDL_RumbleGamepad)");
+        LOG_INFO(kTag, "Initialized as Steam Controller V2 (SDL_RumbleGamepad)");
     }
     else {
-        LOG_INFO("GamepadHaptics", "Initialized as generic gamepad");
+        LOG_INFO(kTag, "Initialized as generic gamepad");
     }
 
     return result;
@@ -161,7 +163,7 @@ int GamepadHaptics::PlayRumble(int slot, float largeMagnitude, float smallMagnit
         // name-based fallback and routed here by mistake.
         if (!IsSteamControllerV2() && IsSteamControllerV1()) {
             const float magnitude = (largeMagnitude + smallMagnitude) * 0.5f;
-            LOG_DEBUG("GamepadHaptics", "PlayRumble - Steam Controller V1: HID trackpad haptic (magnitude=%.2f, duration=%ums)",
+            LOG_DEBUG(kTag, "PlayRumble - Steam Controller V1: HID trackpad haptic (magnitude=%.2f, duration=%ums)",
                     magnitude, durationMs);
 
             SendSteamControllerHaptic(0, magnitude, durationMs); // left  trackpad
@@ -185,7 +187,7 @@ int GamepadHaptics::PlayRumble(int slot, float largeMagnitude, float smallMagnit
             const Uint16 highFreq = static_cast<Uint16>(smallMagnitude * 0xFFFF);
 
             if (!SDL_RumbleGamepad(m_gamepad, lowFreq, highFreq, durationMs)) {
-                LOG_WARN("GamepadHaptics", "PlayRumble - SDL_RumbleGamepad failed: %s", SDL_GetError());
+                LOG_WARN(kTag, "PlayRumble - SDL_RumbleGamepad failed: %s", SDL_GetError());
                 std::lock_guard<std::mutex> lock(m_activeEffectsMutex);
                 m_activeRumbles.erase(slot);
             } else {
@@ -196,11 +198,11 @@ int GamepadHaptics::PlayRumble(int slot, float largeMagnitude, float smallMagnit
                 info.small_magnitude = smallMagnitude;
                 info.duration_ms     = durationMs;
                 info.last_updated    = SDL_GetTicks();
-                LOG_DEBUG("GamepadHaptics", "PlayRumble - Success slot=%d (low=%u, high=%u, duration=%ums)",
+                LOG_DEBUG(kTag, "PlayRumble - Success slot=%d (low=%u, high=%u, duration=%ums)",
                         slot, lowFreq, highFreq, durationMs);
             }
         } else {
-            LOG_WARN("GamepadHaptics", "PlayRumble - No gamepad handle available");
+            LOG_WARN(kTag, "PlayRumble - No gamepad handle available");
         }
     });
 
@@ -273,7 +275,7 @@ void GamepadHaptics::SendSteamControllerHaptic(uint8_t pad, float magnitude, uin
     // report[10–11] = dBgain (Sint16) — 0 = default gain
     // report[12]    = priority flags — 0 = HAPTIC_PULSE_NORMAL
 
-    LOG_DEBUG("GamepadHaptics", "SendSteamControllerHaptic - pad=%u magnitude=%.2f durationUs=%u periodUs=%u pulseCount=%u",
+    LOG_DEBUG(kTag, "SendSteamControllerHaptic - pad=%u magnitude=%.2f durationUs=%u periodUs=%u pulseCount=%u",
             pad, magnitude, durationUs, periodUs, pulseCount);
 
     // Prefer the cached gamepad handle (SDL_SendGamepadEffect); fall back to
@@ -281,11 +283,11 @@ void GamepadHaptics::SendSteamControllerHaptic(uint8_t pad, float magnitude, uin
     // Both reach the same HIDAPI steam SendJoystickEffect handler.
     if (m_gamepad) {
         if (!SDL_SendGamepadEffect(m_gamepad, report, sizeof(report))) {
-            LOG_WARN("GamepadHaptics", "SendSteamControllerHaptic - SDL_SendGamepadEffect failed: %s", SDL_GetError());
+            LOG_WARN(kTag, "SendSteamControllerHaptic - SDL_SendGamepadEffect failed: %s", SDL_GetError());
         }
     } else {
         if (!SDL_SendJoystickEffect(m_joystick, report, sizeof(report))) {
-            LOG_WARN("GamepadHaptics", "SendSteamControllerHaptic - SDL_SendJoystickEffect fallback failed: %s", SDL_GetError());
+            LOG_WARN(kTag, "SendSteamControllerHaptic - SDL_SendJoystickEffect fallback failed: %s", SDL_GetError());
         }
     }
 }
@@ -302,7 +304,7 @@ int GamepadHaptics::PlayDualSenseTrigger(const std::string& trigger,
                                          const std::string& effect_type,
                                          const std::map<std::string, int>& params) {
     if (!m_dualSense) {
-        LOG_WARN("GamepadHaptics", "SendDualSenseTrigger - Not a DualSense controller");
+        LOG_WARN(kTag, "SendDualSenseTrigger - Not a DualSense controller");
         return -1;
     }
 
@@ -330,7 +332,7 @@ int GamepadHaptics::SendXboxImpulseTrigger(uint8_t leftIntensity,
                                            uint8_t rightIntensity,
                                            uint32_t durationMs) {
     if (!m_xbox) {
-        LOG_WARN("GamepadHaptics", "SendXboxImpulseTrigger - Not an Xbox controller");
+        LOG_WARN(kTag, "SendXboxImpulseTrigger - Not an Xbox controller");
         return -1;
     }
 

--- a/src/Haptics/GamepadHaptics.cpp
+++ b/src/Haptics/GamepadHaptics.cpp
@@ -161,7 +161,7 @@ int GamepadHaptics::PlayRumble(int slot, float largeMagnitude, float smallMagnit
         // name-based fallback and routed here by mistake.
         if (!IsSteamControllerV2() && IsSteamControllerV1()) {
             const float magnitude = (largeMagnitude + smallMagnitude) * 0.5f;
-            LOG_INFO("GamepadHaptics", "PlayRumble - Steam Controller V1: HID trackpad haptic (magnitude=%.2f, duration=%ums)",
+            LOG_DEBUG("GamepadHaptics", "PlayRumble - Steam Controller V1: HID trackpad haptic (magnitude=%.2f, duration=%ums)",
                     magnitude, durationMs);
 
             SendSteamControllerHaptic(0, magnitude, durationMs); // left  trackpad
@@ -185,7 +185,7 @@ int GamepadHaptics::PlayRumble(int slot, float largeMagnitude, float smallMagnit
             const Uint16 highFreq = static_cast<Uint16>(smallMagnitude * 0xFFFF);
 
             if (!SDL_RumbleGamepad(m_gamepad, lowFreq, highFreq, durationMs)) {
-                LOG_INFO("GamepadHaptics", "PlayRumble - SDL_RumbleGamepad failed: %s", SDL_GetError());
+                LOG_WARN("GamepadHaptics", "PlayRumble - SDL_RumbleGamepad failed: %s", SDL_GetError());
                 std::lock_guard<std::mutex> lock(m_activeEffectsMutex);
                 m_activeRumbles.erase(slot);
             } else {
@@ -196,11 +196,11 @@ int GamepadHaptics::PlayRumble(int slot, float largeMagnitude, float smallMagnit
                 info.small_magnitude = smallMagnitude;
                 info.duration_ms     = durationMs;
                 info.last_updated    = SDL_GetTicks();
-                LOG_INFO("GamepadHaptics", "PlayRumble - Success slot=%d (low=%u, high=%u, duration=%ums)",
+                LOG_DEBUG("GamepadHaptics", "PlayRumble - Success slot=%d (low=%u, high=%u, duration=%ums)",
                         slot, lowFreq, highFreq, durationMs);
             }
         } else {
-            LOG_INFO("GamepadHaptics", "PlayRumble - No gamepad handle available");
+            LOG_WARN("GamepadHaptics", "PlayRumble - No gamepad handle available");
         }
     });
 
@@ -273,7 +273,7 @@ void GamepadHaptics::SendSteamControllerHaptic(uint8_t pad, float magnitude, uin
     // report[10–11] = dBgain (Sint16) — 0 = default gain
     // report[12]    = priority flags — 0 = HAPTIC_PULSE_NORMAL
 
-    LOG_INFO("GamepadHaptics", "SendSteamControllerHaptic - pad=%u magnitude=%.2f durationUs=%u periodUs=%u pulseCount=%u",
+    LOG_DEBUG("GamepadHaptics", "SendSteamControllerHaptic - pad=%u magnitude=%.2f durationUs=%u periodUs=%u pulseCount=%u",
             pad, magnitude, durationUs, periodUs, pulseCount);
 
     // Prefer the cached gamepad handle (SDL_SendGamepadEffect); fall back to
@@ -281,11 +281,11 @@ void GamepadHaptics::SendSteamControllerHaptic(uint8_t pad, float magnitude, uin
     // Both reach the same HIDAPI steam SendJoystickEffect handler.
     if (m_gamepad) {
         if (!SDL_SendGamepadEffect(m_gamepad, report, sizeof(report))) {
-            LOG_INFO("GamepadHaptics", "SendSteamControllerHaptic - SDL_SendGamepadEffect failed: %s", SDL_GetError());
+            LOG_WARN("GamepadHaptics", "SendSteamControllerHaptic - SDL_SendGamepadEffect failed: %s", SDL_GetError());
         }
     } else {
         if (!SDL_SendJoystickEffect(m_joystick, report, sizeof(report))) {
-            LOG_INFO("GamepadHaptics", "SendSteamControllerHaptic - SDL_SendJoystickEffect fallback failed: %s", SDL_GetError());
+            LOG_WARN("GamepadHaptics", "SendSteamControllerHaptic - SDL_SendJoystickEffect fallback failed: %s", SDL_GetError());
         }
     }
 }
@@ -302,7 +302,7 @@ int GamepadHaptics::PlayDualSenseTrigger(const std::string& trigger,
                                          const std::string& effect_type,
                                          const std::map<std::string, int>& params) {
     if (!m_dualSense) {
-        LOG_INFO("GamepadHaptics", "SendDualSenseTrigger - Not a DualSense controller");
+        LOG_WARN("GamepadHaptics", "SendDualSenseTrigger - Not a DualSense controller");
         return -1;
     }
 
@@ -330,7 +330,7 @@ int GamepadHaptics::SendXboxImpulseTrigger(uint8_t leftIntensity,
                                            uint8_t rightIntensity,
                                            uint32_t durationMs) {
     if (!m_xbox) {
-        LOG_INFO("GamepadHaptics", "SendXboxImpulseTrigger - Not an Xbox controller");
+        LOG_WARN("GamepadHaptics", "SendXboxImpulseTrigger - Not an Xbox controller");
         return -1;
     }
 

--- a/src/Haptics/HapticDevice.cpp
+++ b/src/Haptics/HapticDevice.cpp
@@ -89,6 +89,8 @@ void HapticDevice::RunAsync(std::function<void()> task) {
 }
 
 void HapticDevice::ThreadLoop() {
+    uint64_t lastKeepalive = SDL_GetTicks();
+
     while (true) {
         std::function<void()> task;
         {
@@ -112,6 +114,16 @@ void HapticDevice::ThreadLoop() {
 
         // Check for finished effects (handles hardware status and software timeout fallback)
         PruneFinishedEffects();
+
+        // Re-upload INFINITY effects on devices that truncate the 32-bit length
+        // field to 16 bits (e.g. Thrustmaster T150, which stops after ~65 s).
+        if (m_keepaliveEnabled) {
+            uint64_t now = SDL_GetTicks();
+            if (now - lastKeepalive >= kKeepaliveIntervalMs) {
+                lastKeepalive = now;
+                RefreshInfiniteEffects();
+            }
+        }
     }
 }
 
@@ -162,6 +174,83 @@ void HapticDevice::PruneFinishedEffects() {
     pruneMap(m_activePeriodicEffects,  m_periodicEffects);
     pruneMap(m_activeRumbles,          m_rumbleEffects);
     pruneMap(m_activeConditions,       m_conditionEffects);
+}
+
+// Re-upload every active effect that was created with SDL_HAPTIC_INFINITY so
+// that devices which silently truncate the 32-bit length to 16 bits
+// (Thrustmaster T150 and similar) never reach the ~65 s firmware cutoff.
+// On well-behaved hardware SDL_UpdateHapticEffect merely overwrites the
+// already-running effect with identical parameters, which is a no-op from
+// the user's perspective.
+void HapticDevice::RefreshInfiniteEffects() {
+    if (!m_haptic) return;
+
+    std::lock_guard<std::mutex> lock(m_activeEffectsMutex);
+
+    // Constants
+    for (auto const& [slot, info] : m_activeConstants) {
+        if (info.duration_ms != SDL_HAPTIC_INFINITY) continue;
+        auto idIt = m_constantEffects.find(slot);
+        if (idIt == m_constantEffects.end() || idIt->second == -1) continue;
+
+        SDL_HapticEffect e;
+        SDL_memset(&e, 0, sizeof(e));
+        e.type = SDL_HAPTIC_CONSTANT;
+        e.constant.direction.type    = SDL_HAPTIC_CARTESIAN;
+        e.constant.direction.dir[0]  = -1;
+        e.constant.level             = static_cast<Sint16>(info.strength * 32767.0f);
+        e.constant.length            = SDL_HAPTIC_INFINITY;
+
+        if (!SDL_UpdateHapticEffect(m_haptic.Get(), idIt->second, &e))
+            LOG_WARN("HapticDevice", "RefreshInfiniteEffects - constant slot %d update failed: %s", slot, SDL_GetError());
+        SDL_RunHapticEffect(m_haptic.Get(), idIt->second, 1);
+    }
+
+    // Periodics
+    for (auto const& [slot, info] : m_activePeriodicEffects) {
+        if (info.duration_ms != SDL_HAPTIC_INFINITY) continue;
+        auto idIt = m_periodicEffects.find(slot);
+        if (idIt == m_periodicEffects.end() || idIt->second == -1) continue;
+
+        SDL_HapticEffect e;
+        SDL_memset(&e, 0, sizeof(e));
+        e.type = ToSDLPeriodicType(info.wave_type);
+        e.periodic.direction.type    = SDL_HAPTIC_CARTESIAN;
+        e.periodic.direction.dir[0]  = 1;
+        e.periodic.period            = static_cast<Uint16>(info.period);
+        e.periodic.magnitude         = static_cast<Sint16>(info.magnitude * 32767.0f);
+        e.periodic.offset            = static_cast<Sint16>(info.offset    * 32767.0f);
+        e.periodic.phase             = static_cast<Uint16>(info.phase);
+        e.periodic.length            = SDL_HAPTIC_INFINITY;
+
+        if (!SDL_UpdateHapticEffect(m_haptic.Get(), idIt->second, &e))
+            LOG_WARN("HapticDevice", "RefreshInfiniteEffects - periodic slot %d update failed: %s", slot, SDL_GetError());
+        SDL_RunHapticEffect(m_haptic.Get(), idIt->second, 1);
+    }
+
+    // Conditions
+    for (auto const& [slot, info] : m_activeConditions) {
+        if (info.duration_ms != SDL_HAPTIC_INFINITY) continue;
+        auto idIt = m_conditionEffects.find(slot);
+        if (idIt == m_conditionEffects.end() || idIt->second == -1) continue;
+
+        SDL_HapticEffect e;
+        SDL_memset(&e, 0, sizeof(e));
+        e.type = ToSDLConditionType(info.type);
+        e.condition.direction.type   = SDL_HAPTIC_CARTESIAN;
+        e.condition.direction.dir[0] = 1;
+        e.condition.right_sat[0]     = static_cast<Uint16>(info.right_sat   * 65535.0f);
+        e.condition.left_sat[0]      = static_cast<Uint16>(info.left_sat    * 65535.0f);
+        e.condition.right_coeff[0]   = static_cast<Sint16>(info.right_coeff * 32767.0f);
+        e.condition.left_coeff[0]    = static_cast<Sint16>(info.left_coeff  * 32767.0f);
+        e.condition.deadband[0]      = static_cast<Uint16>(info.deadband    * 65535.0f);
+        e.condition.center[0]        = static_cast<Sint16>(info.center      * 32767.0f);
+        e.condition.length           = SDL_HAPTIC_INFINITY;
+
+        if (!SDL_UpdateHapticEffect(m_haptic.Get(), idIt->second, &e))
+            LOG_WARN("HapticDevice", "RefreshInfiniteEffects - condition slot %d update failed: %s", slot, SDL_GetError());
+        SDL_RunHapticEffect(m_haptic.Get(), idIt->second, 1);
+    }
 }
 
 SDL_HapticEffectID HapticDevice::UploadEffect(const SDL_HapticEffect& effect, SDL_HapticEffectID existingId, bool* outCreated) {

--- a/src/Haptics/HapticDevice.cpp
+++ b/src/Haptics/HapticDevice.cpp
@@ -437,7 +437,7 @@ void HapticDevice::SetCondition(HapticConditionType type, float saturation, floa
         if (existing == -1) {
             LOG_WARN("HapticDevice", "SetCondition - existingID -1");
         } else {
-            LOG_INFO("HapticDevice", "SetCondition - existingID %d", existing);
+            LOG_DEBUG("HapticDevice", "SetCondition - existingID %d", existing);
         }
 
         bool created = false;

--- a/src/Haptics/HapticDevice.cpp
+++ b/src/Haptics/HapticDevice.cpp
@@ -3,6 +3,8 @@
 #include "SDL3/SDL_haptic.h"
 #include <algorithm>
 
+static constexpr const char* kTag = "HapticDevice";
+
 HapticDevice::HapticDevice(SDL_Joystick* joystick) : m_joystick(joystick) {}
 
 HapticDevice::~HapticDevice() {
@@ -11,23 +13,23 @@ HapticDevice::~HapticDevice() {
 
 InputBridge::Result<bool, InputBridge::HapticError> HapticDevice::Init() {
     if (!m_joystick) {
-        LOG_ERROR("HapticDevice", "Init - Failed: Device not found (joystick is null)");
+        LOG_ERROR(kTag, "Init - Failed: Device not found (joystick is null)");
         return InputBridge::Result<bool, InputBridge::HapticError>::Err(InputBridge::HapticError::DeviceNotFound);
     }
 
     auto joystickID = SDL_GetJoystickID(m_joystick);
     bool isHaptic = SDL_IsJoystickHaptic(m_joystick);
-    LOG_INFO("HapticDevice", "Init - Joystick ID %u, IsHaptic: %d", joystickID, isHaptic);
+    LOG_INFO(kTag, "Init - Joystick ID %u, IsHaptic: %d", joystickID, isHaptic);
 
     if (isHaptic) {
         m_haptic.Reset(SDL_OpenHapticFromJoystick(m_joystick));
         if (!m_haptic) {
-            LOG_WARN("HapticDevice", "Warning: SDL_OpenHapticFromJoystick failed: %s", SDL_GetError());
-            LOG_INFO("HapticDevice", "Will continue - gamepad rumble fallback may still work, but advanced haptics will NOT work.");
+            LOG_WARN(kTag, "Warning: SDL_OpenHapticFromJoystick failed: %s", SDL_GetError());
+            LOG_INFO(kTag, "Will continue - gamepad rumble fallback may still work, but advanced haptics will NOT work.");
         } else {
             if (SDL_HapticRumbleSupported(m_haptic.Get())) {
                 if (!SDL_InitHapticRumble(m_haptic.Get())) {
-                    LOG_WARN("HapticDevice", "Warning: SDL_InitHapticRumble failed: %s", SDL_GetError());
+                    LOG_WARN(kTag, "Warning: SDL_InitHapticRumble failed: %s", SDL_GetError());
                 }
             }
             SDL_SetHapticGain(m_haptic.Get(), 100);
@@ -41,11 +43,11 @@ InputBridge::Result<bool, InputBridge::HapticError> HapticDevice::Init() {
     }
 
     if (m_haptic || SDL_IsGamepad(joystickID)) {
-        LOG_INFO("HapticDevice", "Init - Success");
+        LOG_INFO(kTag, "Init - Success");
         return InputBridge::Result<bool, InputBridge::HapticError>::Ok(true);
     }
 
-    LOG_ERROR("HapticDevice", "Init - Failed: Unsupported device type");
+    LOG_ERROR(kTag, "Init - Failed: Unsupported device type");
     return InputBridge::Result<bool, InputBridge::HapticError>::Err(InputBridge::HapticError::UnsupportedEffect);
 }
 
@@ -202,7 +204,7 @@ void HapticDevice::RefreshInfiniteEffects() {
         e.constant.length            = SDL_HAPTIC_INFINITY;
 
         if (!SDL_UpdateHapticEffect(m_haptic.Get(), idIt->second, &e))
-            LOG_WARN("HapticDevice", "RefreshInfiniteEffects - constant slot %d update failed: %s", slot, SDL_GetError());
+            LOG_WARN(kTag, "RefreshInfiniteEffects - constant slot %d update failed: %s", slot, SDL_GetError());
         SDL_RunHapticEffect(m_haptic.Get(), idIt->second, 1);
     }
 
@@ -224,7 +226,7 @@ void HapticDevice::RefreshInfiniteEffects() {
         e.periodic.length            = SDL_HAPTIC_INFINITY;
 
         if (!SDL_UpdateHapticEffect(m_haptic.Get(), idIt->second, &e))
-            LOG_WARN("HapticDevice", "RefreshInfiniteEffects - periodic slot %d update failed: %s", slot, SDL_GetError());
+            LOG_WARN(kTag, "RefreshInfiniteEffects - periodic slot %d update failed: %s", slot, SDL_GetError());
         SDL_RunHapticEffect(m_haptic.Get(), idIt->second, 1);
     }
 
@@ -248,7 +250,7 @@ void HapticDevice::RefreshInfiniteEffects() {
         e.condition.length           = SDL_HAPTIC_INFINITY;
 
         if (!SDL_UpdateHapticEffect(m_haptic.Get(), idIt->second, &e))
-            LOG_WARN("HapticDevice", "RefreshInfiniteEffects - condition slot %d update failed: %s", slot, SDL_GetError());
+            LOG_WARN(kTag, "RefreshInfiniteEffects - condition slot %d update failed: %s", slot, SDL_GetError());
         SDL_RunHapticEffect(m_haptic.Get(), idIt->second, 1);
     }
 }
@@ -262,14 +264,14 @@ SDL_HapticEffectID HapticDevice::UploadEffect(const SDL_HapticEffect& effect, SD
             if (outCreated) *outCreated = false;
             return existingId;
         } else {
-            LOG_ERROR("HapticDevice", "UploadEffect - Update failed for ID %d: %s. Recreating.", existingId, SDL_GetError());
+            LOG_ERROR(kTag, "UploadEffect - Update failed for ID %d: %s. Recreating.", existingId, SDL_GetError());
         }
         SDL_DestroyHapticEffect(m_haptic.Get(), existingId);
     }
 
     SDL_HapticEffectID newId = SDL_CreateHapticEffect(m_haptic.Get(), &effect);
     if (newId == -1) {
-        LOG_ERROR("HapticDevice", "UploadEffect - Create failed: %s", SDL_GetError());
+        LOG_ERROR(kTag, "UploadEffect - Create failed: %s", SDL_GetError());
     }
     if (outCreated) *outCreated = (newId != -1);
     return newId;
@@ -323,7 +325,7 @@ std::map<std::string, ActiveDualSenseTriggerInfo> HapticDevice::GetActiveDualSen
 void HapticDevice::SetConstantForce(float level, float direction) {
     RunAsync([this, level, direction]() {
         if (!m_haptic) {
-            LOG_WARN("HapticDevice", "SetConstantForce - Haptic device not ready");
+            LOG_WARN(kTag, "SetConstantForce - Haptic device not ready");
             return;
         }
 
@@ -345,7 +347,7 @@ void HapticDevice::SetConstantForce(float level, float direction) {
             m_constantEffects[kInternalSlot] = newId;
             if (created) {
                 if (!SDL_RunHapticEffect(m_haptic.Get(), newId, 1)) {
-                    LOG_ERROR("HapticDevice", "SetConstantForce - Run failed: %s", SDL_GetError());
+                    LOG_ERROR(kTag, "SetConstantForce - Run failed: %s", SDL_GetError());
                 }
             }
         }
@@ -398,7 +400,7 @@ void HapticDevice::SetPeriodic(HapticPeriodicType type, float magnitude, int per
             m_periodicEffects[kInternalSlot] = newId;
             if (created) {
                 if (!SDL_RunHapticEffect(m_haptic.Get(), newId, 1)) {
-                    LOG_ERROR("HapticDevice", "SetPeriodic - Run failed: %s", SDL_GetError());
+                    LOG_ERROR(kTag, "SetPeriodic - Run failed: %s", SDL_GetError());
                 }
             }
         }
@@ -435,9 +437,9 @@ void HapticDevice::SetCondition(HapticConditionType type, float saturation, floa
         if (it != m_conditionEffects.end()) existing = it->second;
 
         if (existing == -1) {
-            LOG_WARN("HapticDevice", "SetCondition - existingID -1");
+            LOG_WARN(kTag, "SetCondition - existingID -1");
         } else {
-            LOG_DEBUG("HapticDevice", "SetCondition - existingID %d", existing);
+            LOG_DEBUG(kTag, "SetCondition - existingID %d", existing);
         }
 
         bool created = false;
@@ -446,7 +448,7 @@ void HapticDevice::SetCondition(HapticConditionType type, float saturation, floa
             m_conditionEffects[internalKey] = newId;
             if (created) {
                 if (!SDL_RunHapticEffect(m_haptic.Get(), newId, 1)) {
-                    LOG_ERROR("HapticDevice", "SetCondition - Run failed: %s", SDL_GetError());
+                    LOG_ERROR(kTag, "SetCondition - Run failed: %s", SDL_GetError());
                 }
             }
         }
@@ -474,7 +476,7 @@ void HapticDevice::SetRumble(float low_freq, float high_freq, Uint32 duration) {
             m_rumbleEffects[kInternalSlot] = newId;
             if (created) {
                 if (!SDL_RunHapticEffect(m_haptic.Get(), newId, 1)) {
-                    LOG_ERROR("HapticDevice", "SetRumble - Run failed: %s", SDL_GetError());
+                    LOG_ERROR(kTag, "SetRumble - Run failed: %s", SDL_GetError());
                 }
             }
         }

--- a/src/Haptics/HapticDevice.h
+++ b/src/Haptics/HapticDevice.h
@@ -212,6 +212,7 @@ public:
     // Call this after Init() for devices known to truncate the 32-bit length
     // field to 16 bits (e.g. Thrustmaster T150).
     void EnableKeepalive(bool enable = true) { m_keepaliveEnabled = enable; }
+    bool IsKeepaliveEnabled() const { return m_keepaliveEnabled; }
 
     /**
      * @brief Return the set of haptic effect families this device supports.

--- a/src/Haptics/HapticDevice.h
+++ b/src/Haptics/HapticDevice.h
@@ -208,6 +208,11 @@ public:
     void Close();
     virtual bool IsReady() const;
 
+    // Enable periodic re-upload of SDL_HAPTIC_INFINITY effects.
+    // Call this after Init() for devices known to truncate the 32-bit length
+    // field to 16 bits (e.g. Thrustmaster T150).
+    void EnableKeepalive(bool enable = true) { m_keepaliveEnabled = enable; }
+
     /**
      * @brief Return the set of haptic effect families this device supports.
      *
@@ -300,6 +305,19 @@ protected:
     SDL_HapticEffectID UploadEffect(const SDL_HapticEffect& effect, SDL_HapticEffectID existingId, bool* outCreated = nullptr);
     void RunAsync(std::function<void()> task);
 
+    // Some devices (e.g. Thrustmaster T150) only honour the lower 16 bits of
+    // the SDL effect length field, so SDL_HAPTIC_INFINITY (0xFFFFFFFF) is
+    // silently truncated to 0xFFFF = 65 535 ms ≈ 65 s before the effect stops.
+    // Enabling keepalives causes the thread to periodically re-upload and
+    // re-run every active INFINITY effect before that window expires, which
+    // keeps it playing indefinitely on affected hardware while remaining a
+    // no-op on devices that handle INFINITY correctly.
+    bool m_keepaliveEnabled = false;
+
+    // Interval at which INFINITY effects are refreshed (ms).
+    // Must be safely below the 65 535 ms firmware cutoff.
+    static constexpr uint32_t kKeepaliveIntervalMs = 30000; // 30 s
+
 private:
     std::thread m_thread;
     std::mutex m_mutex;
@@ -308,4 +326,5 @@ private:
     bool m_running = false;
     void ThreadLoop();
     void PruneFinishedEffects();
+    void RefreshInfiniteEffects();
 };

--- a/src/Haptics/SteeringWheelHaptics.cpp
+++ b/src/Haptics/SteeringWheelHaptics.cpp
@@ -2,6 +2,8 @@
 #include "SteeringWheelHaptics.h"
 #include <algorithm>
 
+static constexpr const char* kTag = "SteeringWheelHaptics";
+
 int SteeringWheelHaptics::SetGain(int gain) {
     RunAsync([this, gain]() {
         if (!m_haptic) return;
@@ -13,7 +15,7 @@ int SteeringWheelHaptics::SetGain(int gain) {
 int SteeringWheelHaptics::PlayConstant(int slot, float strength, uint32_t duration_ms) {
     RunAsync([this, slot, strength, duration_ms]() {
         if (!m_haptic) {
-            LOG_WARN("SteeringWheelHaptics", "PlayConstant - Haptic device not ready");
+            LOG_WARN(kTag, "PlayConstant - Haptic device not ready");
             return;
         }
 
@@ -37,7 +39,7 @@ int SteeringWheelHaptics::PlayConstant(int slot, float strength, uint32_t durati
             m_constantEffects[slot] = newId;
             if (created) {
                 if (!SDL_RunHapticEffect(m_haptic.Get(), newId, 1)) {
-                    LOG_ERROR("SteeringWheelHaptics", "PlayConstant - Run failed: %s", SDL_GetError());
+                    LOG_ERROR(kTag, "PlayConstant - Run failed: %s", SDL_GetError());
                 }
             }
             {
@@ -71,7 +73,7 @@ int SteeringWheelHaptics::StopConstant(int slot) {
 int SteeringWheelHaptics::PlayPeriodic(int slot, HapticPeriodicType wave_type, float strength, uint32_t period, float magnitude, float offset, uint32_t phase, uint32_t duration_ms) {
     RunAsync([this, slot, wave_type, strength, period, magnitude, offset, phase, duration_ms]() {
         if (!m_haptic) {
-            LOG_WARN("SteeringWheelHaptics", "PlayPeriodic - Haptic device not ready");
+            LOG_WARN(kTag, "PlayPeriodic - Haptic device not ready");
             return;
         }
 
@@ -96,7 +98,7 @@ int SteeringWheelHaptics::PlayPeriodic(int slot, HapticPeriodicType wave_type, f
             m_periodicEffects[slot] = newId;
             if (created) {
                 if (!SDL_RunHapticEffect(m_haptic.Get(), newId, 1)) {
-                    LOG_ERROR("SteeringWheelHaptics", "PlayPeriodic - Run failed: %s", SDL_GetError());
+                    LOG_ERROR(kTag, "PlayPeriodic - Run failed: %s", SDL_GetError());
                 }
             }
             {
@@ -145,14 +147,14 @@ int SteeringWheelHaptics::PlayRumble(int slot, float large_magnitude, float smal
 int SteeringWheelHaptics::PlayCondition(int slot, HapticConditionType type, float right_sat, float left_sat, float right_coeff, float left_coeff, float deadband, float center, uint32_t duration_ms) {
     RunAsync([this, slot, type, right_sat, left_sat, right_coeff, left_coeff, deadband, center, duration_ms]() {
         if (!m_haptic) {
-            LOG_WARN("SteeringWheelHaptics", "PlayCondition - Haptic device not ready");
+            LOG_WARN(kTag, "PlayCondition - Haptic device not ready");
             return;
         }
 
         {
             int max_effects = SDL_GetMaxHapticEffects(m_haptic.Get());
             if (slot < 0 || slot >= max_effects) {
-                LOG_WARN("SteeringWheelHaptics", "PlayCondition - Invalid slot %d (max: %d)", slot, max_effects);
+                LOG_WARN(kTag, "PlayCondition - Invalid slot %d (max: %d)", slot, max_effects);
                 return;
             }
         }
@@ -182,7 +184,7 @@ int SteeringWheelHaptics::PlayCondition(int slot, HapticConditionType type, floa
             m_conditionEffects[slot] = newId;
             if (created) {
                 if (!SDL_RunHapticEffect(m_haptic.Get(), newId, 1)) {
-                    LOG_ERROR("SteeringWheelHaptics", "PlayCondition - Run failed for type %s: %s",
+                    LOG_ERROR(kTag, "PlayCondition - Run failed for type %s: %s",
                             ConditionTypeName(type), SDL_GetError());
                     std::lock_guard<std::mutex> lock(m_activeEffectsMutex);
                     m_activeConditions.erase(slot);

--- a/src/Haptics/XboxController.cpp
+++ b/src/Haptics/XboxController.cpp
@@ -12,6 +12,8 @@
 #include <SDL3/SDL_gamepad.h>
 #include <array>
 
+static constexpr const char* kTag = "XboxController";
+
 // ==================== Initialization ====================
 
 bool XboxController::IsReady() const {
@@ -70,7 +72,7 @@ int XboxController::SetImpulseTriggers(uint8_t leftIntensity,
                                        uint8_t rightIntensity,
                                        uint16_t durationMs) {
     if (!IsXboxController()) {
-        LOG_WARN("XboxController", "SetImpulseTriggers: Not an Xbox controller");
+        LOG_WARN(kTag, "SetImpulseTriggers: Not an Xbox controller");
         return -1;
     }
     
@@ -81,7 +83,7 @@ int XboxController::SetImpulseTriggers(uint8_t leftIntensity,
         state.durationMs = durationMs;
         
         if (!SendImpulseTriggerCommand(state)) {
-            LOG_ERROR("XboxController", "SetImpulseTriggers: Failed to send command");
+            LOG_ERROR(kTag, "SetImpulseTriggers: Failed to send command");
         }
     });
     
@@ -122,14 +124,14 @@ bool XboxController::SendImpulseTriggerCommand(const Xbox::ImpulseTriggerState& 
     data[6] = static_cast<uint8_t>(state.durationMs & 0xFF);
     data[7] = static_cast<uint8_t>((state.durationMs >> 8) & 0xFF);
     
-    LOG_DEBUG("XboxController", "Impulse: Report=0x%02X, L=%d, R=%d, Duration=%dms",
+    LOG_DEBUG(kTag, "Impulse: Report=0x%02X, L=%d, R=%d, Duration=%dms",
            data[0], state.leftTriggerMotor, state.rightTriggerMotor, state.durationMs);
     
     if (!SDL_SendJoystickEffect(m_joystick, data.data(), data.size())) {
-        LOG_ERROR("XboxController", "Impulse: Send failed - %s", SDL_GetError());
+        LOG_ERROR(kTag, "Impulse: Send failed - %s", SDL_GetError());
         return false;
     }
     
-    LOG_DEBUG("XboxController", "Impulse: Report sent successfully");
+    LOG_DEBUG(kTag, "Impulse: Report sent successfully");
     return true;
 }

--- a/src/Mappers/ButtonBinder.cpp
+++ b/src/Mappers/ButtonBinder.cpp
@@ -4,7 +4,7 @@
 
 static constexpr const char* kTag = "ButtonBinder";
 
-void ButtonBinder::StartBinding(const std::vector<struct DeviceState>& connectedDevices) {
+void ButtonBinder::StartBinding(const std::vector<DeviceState>& connectedDevices) {
     m_baselineButtonStates.clear();
     for (const auto& dev : connectedDevices) {
         if (!dev.joystick) continue;
@@ -23,7 +23,7 @@ void ButtonBinder::StartBinding(const std::vector<struct DeviceState>& connected
     LOG_INFO(kTag, "Started binding process for all connected joysticks.");
 }
 
-std::optional<BoundButtonInfo> ButtonBinder::Update(const std::vector<struct DeviceState>& connectedDevices) {
+std::optional<BoundButtonInfo> ButtonBinder::Update(const std::vector<DeviceState>& connectedDevices) {
     if (!m_isBinding) {
         return std::nullopt;
     }

--- a/src/Mappers/ButtonBinder.cpp
+++ b/src/Mappers/ButtonBinder.cpp
@@ -2,6 +2,8 @@
 #include "ButtonBinder.h"
 #include "Devices/DeviceManager.h" // For DeviceState
 
+static constexpr const char* kTag = "ButtonBinder";
+
 void ButtonBinder::StartBinding(const std::vector<struct DeviceState>& connectedDevices) {
     m_baselineButtonStates.clear();
     for (const auto& dev : connectedDevices) {
@@ -14,11 +16,11 @@ void ButtonBinder::StartBinding(const std::vector<struct DeviceState>& connected
                 states[i] = SDL_GetJoystickButton(dev.joystick, i);
             }
             m_baselineButtonStates[id] = states;
-            LOG_INFO("ButtonBinder", "Captured baseline for joystick '%s' (ID: %u).", SDL_GetJoystickName(dev.joystick), id);
+            LOG_INFO(kTag, "Captured baseline for joystick '%s' (ID: %u).", SDL_GetJoystickName(dev.joystick), id);
         }
     }
     m_isBinding = true;
-    LOG_INFO("ButtonBinder", "Started binding process for all connected joysticks.");
+    LOG_INFO(kTag, "Started binding process for all connected joysticks.");
 }
 
 std::optional<BoundButtonInfo> ButtonBinder::Update(const std::vector<struct DeviceState>& connectedDevices) {
@@ -41,7 +43,7 @@ std::optional<BoundButtonInfo> ButtonBinder::Update(const std::vector<struct Dev
         int numButtons = SDL_GetNumJoystickButtons(dev.joystick);
 
         if (joystickBaseline.size() != numButtons) {
-            LOG_WARN("ButtonBinder", "Joystick '%s' (ID: %u) button count changed or baseline mismatch. Re-snapshotting.", SDL_GetJoystickName(dev.joystick), id);
+            LOG_WARN(kTag, "Joystick '%s' (ID: %u) button count changed or baseline mismatch. Re-snapshotting.", SDL_GetJoystickName(dev.joystick), id);
             // Re-snapshot this specific joystick's baseline
             joystickBaseline.assign(numButtons, false);
             for (int i = 0; i < numButtons; ++i) joystickBaseline[i] = SDL_GetJoystickButton(dev.joystick, i);
@@ -54,7 +56,7 @@ std::optional<BoundButtonInfo> ButtonBinder::Update(const std::vector<struct Dev
 
             if (currentState != wasActiveAtStart) {
                 m_isBinding = false;
-                LOG_INFO("ButtonBinder", "Button %d change detected on joystick '%s' (ID: %u).", i, SDL_GetJoystickName(dev.joystick), id);
+                LOG_INFO(kTag, "Button %d change detected on joystick '%s' (ID: %u).", i, SDL_GetJoystickName(dev.joystick), id);
                 return BoundButtonInfo{id, i};
             }
         }
@@ -63,7 +65,7 @@ std::optional<BoundButtonInfo> ButtonBinder::Update(const std::vector<struct Dev
 }
 
 void ButtonBinder::Cancel() {
-    if (m_isBinding) LOG_INFO("ButtonBinder", "Binding process cancelled.");
+    if (m_isBinding) LOG_INFO(kTag, "Binding process cancelled.");
     m_isBinding = false;
     m_baselineButtonStates.clear();
 }

--- a/src/Mappers/ButtonBinder.h
+++ b/src/Mappers/ButtonBinder.h
@@ -14,8 +14,8 @@ struct BoundButtonInfo {
 
 class ButtonBinder {
 public:
-    void StartBinding(const std::vector<struct DeviceState>& connectedDevices);
-    std::optional<BoundButtonInfo> Update(const std::vector<struct DeviceState>& connectedDevices);
+    void StartBinding(const std::vector<DeviceState>& connectedDevices);
+    std::optional<BoundButtonInfo> Update(const std::vector<DeviceState>& connectedDevices);
     void Cancel();
     bool IsBindingActive() const;
 

--- a/src/Mappers/InputExclusiveMode.cpp
+++ b/src/Mappers/InputExclusiveMode.cpp
@@ -2,6 +2,8 @@
 #include "InputExclusiveMode.h"
 #include "InputExclusiveModeImpl.h"
 
+static constexpr const char* kTag = "ExclusiveMode";
+
 #ifdef ENABLE_EXCLUSIVE_INPUT
 #  ifdef _WIN32
 #    include "WindowsExclusiveMode.h"
@@ -17,7 +19,7 @@
 class DummyExclusiveMode : public InputExclusiveModeImpl {
 public:
     bool HideDevice(SDL_Joystick*) override {
-        LOG_INFO("ExclusiveMode", "Device hide: not implemented on this platform or feature disabled.");
+        LOG_INFO(kTag, "Device hide: not implemented on this platform or feature disabled.");
         return false;
     }
     bool UnhideDevice(SDL_Joystick*) override { return true; }

--- a/src/Mappers/InputMapper.cpp
+++ b/src/Mappers/InputMapper.cpp
@@ -917,10 +917,10 @@ void InputMapper::DrawMappingContent() {
         float sp = style.ItemSpacing.x;
         float bindW = ImGui::CalcTextSize("Bind").x + style.FramePadding.x * 2;
 
-        float dw = 0.f, rw = 0.f;
+        float dw = 80.f, rw = 0.f;
         bool hasSrc = (src.axisIndex != -1) || (src.sensorChannel != SC::None);
         if (hasSrc) {
-            dw = 80.f;
+            dw = 180.f;
             rw = 80.f;
         }
 

--- a/src/Mappers/InputMapper.cpp
+++ b/src/Mappers/InputMapper.cpp
@@ -27,6 +27,8 @@
 #include <unordered_set>
 #include <string_view>
 
+static constexpr const char* kTag = "InputMapper";
+
 using json = nlohmann::json;
 
 NLOHMANN_JSON_SERIALIZE_ENUM(InputMapper::ButtonToDigitalMapping::Mode, {
@@ -245,7 +247,7 @@ void InputMapper::UpdateListening() {
             bool updated = false;
             const DeviceState* boundDeviceState = getDeviceState(boundButton->joystickID);
             if (!boundDeviceState) {
-                LOG_WARN("InputMapper", "Bound joystick (ID: %u) not found for button binding.", boundButton->joystickID);
+                LOG_WARN(kTag, "Bound joystick (ID: %u) not found for button binding.", boundButton->joystickID);
                 CancelListening();
                 return;
             }
@@ -2007,7 +2009,7 @@ void InputMapper::LoadProfiles() {
                             std::filesystem::copy_file(e.path(), dst,
                                 std::filesystem::copy_options::skip_existing, ec);
                             if (ec)
-                                LOG_ERROR("InputMapper", "Failed to seed preset profile %s: %s",
+                                LOG_ERROR(kTag, "Failed to seed preset profile %s: %s",
                                           e.path().filename().string().c_str(), ec.message().c_str());
                         }
                     }
@@ -2092,9 +2094,9 @@ void InputMapper::LoadProfiles() {
                 p.wsInputEnabled  = data.value("ws_input_enabled",  true);
 
                 m_Profiles.push_back(p);
-            } catch (const std::exception& ex) { LOG_ERROR("InputMapper", "Failed to parse profile %s: %s",e.path().string().c_str(),ex.what()); }
+            } catch (const std::exception& ex) { LOG_ERROR(kTag, "Failed to parse profile %s: %s",e.path().string().c_str(),ex.what()); }
         }
-    } catch (const std::exception& ex) { LOG_ERROR("InputMapper", "Failed to load profiles: %s",ex.what()); }
+    } catch (const std::exception& ex) { LOG_ERROR(kTag, "Failed to load profiles: %s",ex.what()); }
 }
 
 void InputMapper::SaveProfile(const MappingProfile &profile) const {
@@ -2151,7 +2153,7 @@ void InputMapper::SaveProfile(const MappingProfile &profile) const {
         data["ws_input_enabled"]  = profile.wsInputEnabled;
 
         std::ofstream o(path); if (o) o<<data.dump(4);
-    } catch (const std::exception& ex) { LOG_ERROR("InputMapper", "Failed to save profile: %s",ex.what()); }
+    } catch (const std::exception& ex) { LOG_ERROR(kTag, "Failed to save profile: %s",ex.what()); }
 }
 
 std::vector<HapticTarget>* InputMapper::GetCurrentHapticTargets() {

--- a/src/Mappers/InputMapper.cpp
+++ b/src/Mappers/InputMapper.cpp
@@ -2092,9 +2092,9 @@ void InputMapper::LoadProfiles() {
                 p.wsInputEnabled  = data.value("ws_input_enabled",  true);
 
                 m_Profiles.push_back(p);
-            } catch (const std::exception& ex) { LOG_INFO("InputMapper", "Failed to parse profile %s: %s",e.path().string().c_str(),ex.what()); }
+            } catch (const std::exception& ex) { LOG_ERROR("InputMapper", "Failed to parse profile %s: %s",e.path().string().c_str(),ex.what()); }
         }
-    } catch (const std::exception& ex) { LOG_INFO("InputMapper", "Failed to load profiles: %s",ex.what()); }
+    } catch (const std::exception& ex) { LOG_ERROR("InputMapper", "Failed to load profiles: %s",ex.what()); }
 }
 
 void InputMapper::SaveProfile(const MappingProfile &profile) const {
@@ -2151,7 +2151,7 @@ void InputMapper::SaveProfile(const MappingProfile &profile) const {
         data["ws_input_enabled"]  = profile.wsInputEnabled;
 
         std::ofstream o(path); if (o) o<<data.dump(4);
-    } catch (const std::exception& ex) { LOG_INFO("InputMapper", "Failed to save profile: %s",ex.what()); }
+    } catch (const std::exception& ex) { LOG_ERROR("InputMapper", "Failed to save profile: %s",ex.what()); }
 }
 
 std::vector<HapticTarget>* InputMapper::GetCurrentHapticTargets() {

--- a/src/Mappers/LinuxExclusiveMode.cpp
+++ b/src/Mappers/LinuxExclusiveMode.cpp
@@ -16,6 +16,8 @@
 #include <cstdio>
 #include <algorithm>
 
+static constexpr const char* kTag = "ExclusiveMode";
+
 #ifndef EVIOCGRAB
 #define EVIOCGRAB _IOW('E', 0x90, int)
 #endif
@@ -43,10 +45,10 @@ std::vector<std::string> LinuxExclusiveMode::FindAllInputDevicePaths(SDL_Joystic
 
     const char* sdlPath = SDL_GetJoystickPath(joystick);
     if (!sdlPath) {
-        LOG_ERROR("ExclusiveMode", "LinuxExclusiveMode: cannot get joystick path.");
+        LOG_ERROR(kTag, "LinuxExclusiveMode: cannot get joystick path.");
         return result;
     }
-    LOG_INFO("ExclusiveMode", "LinuxExclusiveMode: SDL reported path = %s", sdlPath);
+    LOG_INFO(kTag, "LinuxExclusiveMode: SDL reported path = %s", sdlPath);
 
     // Collect both event* and js* leaves from a sysfs input directory.
     auto collectInputNodes = [&](const std::filesystem::path& dir) {
@@ -58,14 +60,14 @@ std::vector<std::string> LinuxExclusiveMode::FindAllInputDevicePaths(SDL_Joystic
                 && std::isdigit(static_cast<unsigned char>(fname[5])))
             {
                 result.push_back("/dev/input/" + fname);
-                LOG_INFO("ExclusiveMode", "LinuxExclusiveMode:  + evdev  %s", result.back().c_str());
+                LOG_INFO(kTag, "LinuxExclusiveMode:  + evdev  %s", result.back().c_str());
             }
             // jsN  (/dev/input/jsN)
             else if (fname.rfind("js", 0) == 0 && fname.size() > 2
                      && std::isdigit(static_cast<unsigned char>(fname[2])))
             {
                 result.push_back("/dev/input/" + fname);
-                LOG_INFO("ExclusiveMode", "LinuxExclusiveMode:  + joydev %s", result.back().c_str());
+                LOG_INFO(kTag, "LinuxExclusiveMode:  + joydev %s", result.back().c_str());
             }
         }
     };
@@ -80,13 +82,13 @@ std::vector<std::string> LinuxExclusiveMode::FindAllInputDevicePaths(SDL_Joystic
                 && std::isdigit(static_cast<unsigned char>(fname[5])))
             {
                 result.push_back("/dev/input/" + fname);
-                LOG_INFO("ExclusiveMode", "LinuxExclusiveMode:  + evdev  %s", result.back().c_str());
+                LOG_INFO(kTag, "LinuxExclusiveMode:  + evdev  %s", result.back().c_str());
             }
             else if (fname.rfind("js", 0) == 0 && fname.size() > 2
                      && std::isdigit(static_cast<unsigned char>(fname[2])))
             {
                 result.push_back("/dev/input/" + fname);
-                LOG_INFO("ExclusiveMode", "LinuxExclusiveMode:  + joydev %s", result.back().c_str());
+                LOG_INFO(kTag, "LinuxExclusiveMode:  + joydev %s", result.back().c_str());
             }
         }
     };
@@ -113,14 +115,14 @@ std::vector<std::string> LinuxExclusiveMode::FindAllInputDevicePaths(SDL_Joystic
             }
             collectInputNodes(devPath);
         } catch (const std::exception& ex) {
-            LOG_ERROR("ExclusiveMode", "LinuxExclusiveMode: hidraw sysfs walk error: %s", ex.what());
+            LOG_ERROR(kTag, "LinuxExclusiveMode: hidraw sysfs walk error: %s", ex.what());
         }
     }
     // ── Case 2: legacy joydev path (/dev/input/jsN) ───────────────────────
     else if (strncmp(sdlPath, "/dev/input/js", 13) == 0) {
         // Add the js node itself first.
         result.push_back(sdlPath);
-        LOG_INFO("ExclusiveMode", "LinuxExclusiveMode:  + joydev %s", sdlPath);
+        LOG_INFO(kTag, "LinuxExclusiveMode:  + joydev %s", sdlPath);
 
         // Walk sysfs to find sibling eventN nodes.
         int num = std::atoi(sdlPath + 13);
@@ -130,14 +132,14 @@ std::vector<std::string> LinuxExclusiveMode::FindAllInputDevicePaths(SDL_Joystic
         try {
             collectInputNodes(sysPath);
         } catch (...) {
-            LOG_ERROR("ExclusiveMode", "LinuxExclusiveMode: js%d sysfs walk failed.", num);
+            LOG_ERROR(kTag, "LinuxExclusiveMode: js%d sysfs walk failed.", num);
         }
     }
     // ── Case 3: evdev path (/dev/input/eventN) ────────────────────────────
     else if (strncmp(sdlPath, "/dev/input/event", 16) == 0) {
         // Add the event node itself.
         result.push_back(sdlPath);
-        LOG_INFO("ExclusiveMode", "LinuxExclusiveMode:  + evdev  %s", sdlPath);
+        LOG_INFO(kTag, "LinuxExclusiveMode:  + evdev  %s", sdlPath);
 
         // Walk sysfs backward to find sibling js* nodes.
         // /sys/class/input/eventN -> device -> input -> inputN -> js*, event*
@@ -151,10 +153,10 @@ std::vector<std::string> LinuxExclusiveMode::FindAllInputDevicePaths(SDL_Joystic
                 std::filesystem::path(sysEventPath).parent_path()
                 / std::filesystem::read_symlink(sysEventPath));
 
-            LOG_INFO("ExclusiveMode", "LinuxExclusiveMode: resolved inputN = %s", inputN.c_str());
+            LOG_INFO(kTag, "LinuxExclusiveMode: resolved inputN = %s", inputN.c_str());
             collectFromInputN(inputN);
         } catch (const std::exception& ex) {
-            LOG_ERROR("ExclusiveMode", "LinuxExclusiveMode: eventN sysfs walk error: %s", ex.what());
+            LOG_ERROR(kTag, "LinuxExclusiveMode: eventN sysfs walk error: %s", ex.what());
         }
     }
 
@@ -173,7 +175,7 @@ bool LinuxExclusiveMode::HideDevice(SDL_Joystick* joystick) {
 
     auto paths = FindAllInputDevicePaths(joystick);
     if (paths.empty()) {
-        LOG_INFO("ExclusiveMode", "LinuxExclusiveMode: no input nodes found for '%s'.",
+        LOG_INFO(kTag, "LinuxExclusiveMode: no input nodes found for '%s'.",
                 SDL_GetJoystickName(joystick));
         return false;
     }
@@ -187,7 +189,7 @@ bool LinuxExclusiveMode::HideDevice(SDL_Joystick* joystick) {
             // to us (not other processes) once we also hold the evdev grab.
             fd = open(devPath.c_str(), O_RDONLY | O_NONBLOCK);
             if (fd < 0) {
-                LOG_ERROR("ExclusiveMode", "LinuxExclusiveMode: open(%s) failed: %s",
+                LOG_ERROR(kTag, "LinuxExclusiveMode: open(%s) failed: %s",
                         devPath.c_str(), strerror(errno));
                 continue;
             }
@@ -201,23 +203,23 @@ bool LinuxExclusiveMode::HideDevice(SDL_Joystick* joystick) {
             if (errno != ENOTTY && errno != EINVAL) {
                 // Real error (e.g. EBUSY — another process already has an
                 // exclusive grab).
-                LOG_ERROR("ExclusiveMode", "LinuxExclusiveMode: EVIOCGRAB on %s failed: %s",
+                LOG_ERROR(kTag, "LinuxExclusiveMode: EVIOCGRAB on %s failed: %s",
                         devPath.c_str(), strerror(errno));
             } else {
-                LOG_INFO("ExclusiveMode", "LinuxExclusiveMode: EVIOCGRAB not supported on %s "
+                LOG_INFO(kTag, "LinuxExclusiveMode: EVIOCGRAB not supported on %s "
                         "(joydev node — fd held open).", devPath.c_str());
             }
             // Keep the fd open regardless so we at least hold a reference.
         }
 
         grabbed.push_back({fd, devPath});
-        LOG_INFO("ExclusiveMode", "LinuxExclusiveMode: holding %s", devPath.c_str());
+        LOG_INFO(kTag, "LinuxExclusiveMode: holding %s", devPath.c_str());
     }
 
     if (grabbed.empty()) return false;
 
     m_GrabbedDevices[id] = std::move(grabbed);
-    LOG_INFO("ExclusiveMode", "LinuxExclusiveMode: '%s' is now hidden (%zu node(s) grabbed).",
+    LOG_INFO(kTag, "LinuxExclusiveMode: '%s' is now hidden (%zu node(s) grabbed).",
             SDL_GetJoystickName(joystick), m_GrabbedDevices[id].size());
     return true;
 }
@@ -227,7 +229,7 @@ bool LinuxExclusiveMode::HideDevice(SDL_Joystick* joystick) {
 bool LinuxExclusiveMode::UnhideDevice(SDL_Joystick* joystick) {
     SDL_JoystickID id = SDL_GetJoystickID(joystick);
     ReleaseInstance(id);
-    LOG_INFO("ExclusiveMode", "LinuxExclusiveMode: '%s' unhidden.", SDL_GetJoystickName(joystick));
+    LOG_INFO(kTag, "LinuxExclusiveMode: '%s' unhidden.", SDL_GetJoystickName(joystick));
     return true;
 }
 
@@ -238,7 +240,7 @@ void LinuxExclusiveMode::ReleaseInstance(SDL_JoystickID id) {
     for (auto& entry : it->second) {
         ioctl(entry.fd, EVIOCGRAB, 0); // no-op on js* fds but harmless
         close(entry.fd);
-        LOG_INFO("ExclusiveMode", "LinuxExclusiveMode: released %s", entry.path.c_str());
+        LOG_INFO(kTag, "LinuxExclusiveMode: released %s", entry.path.c_str());
     }
     m_GrabbedDevices.erase(it);
 }

--- a/src/Mappers/MacOSExclusiveMode.cpp
+++ b/src/Mappers/MacOSExclusiveMode.cpp
@@ -5,6 +5,8 @@
 
 #include <SDL3/SDL.h>
 
+static constexpr const char* kTag = "ExclusiveMode";
+
 // kIOMainPortDefault was renamed from kIOMasterPortDefault in newer SDKs.
 #ifndef kIOMainPortDefault
 #define kIOMainPortDefault kIOMasterPortDefault
@@ -59,21 +61,21 @@ bool MacOSExclusiveMode::HideDevice(SDL_Joystick* joystick) {
 
     IOHIDDeviceRef dev = FindHIDDevice(vid, pid);
     if (!dev) {
-        LOG_INFO("ExclusiveMode", "MacOSExclusiveMode: could not find IOHIDDevice for '%s' "
+        LOG_INFO(kTag, "MacOSExclusiveMode: could not find IOHIDDevice for '%s' "
                 "(VID=%04X PID=%04X).", SDL_GetJoystickName(joystick), vid, pid);
         return false;
     }
 
     IOReturn ret = IOHIDDeviceOpen(dev, kIOHIDOptionsTypeSeizeDevice);
     if (ret != kIOReturnSuccess) {
-        LOG_ERROR("ExclusiveMode", "MacOSExclusiveMode: IOHIDDeviceOpen(seize) failed for '%s': 0x%x.",
+        LOG_ERROR(kTag, "MacOSExclusiveMode: IOHIDDeviceOpen(seize) failed for '%s': 0x%x.",
                 SDL_GetJoystickName(joystick), ret);
         CFRelease(dev);
         return false;
     }
 
     m_SeizedDevices[id] = dev;
-    LOG_INFO("ExclusiveMode", "MacOSExclusiveMode: '%s' is now hidden.", SDL_GetJoystickName(joystick));
+    LOG_INFO(kTag, "MacOSExclusiveMode: '%s' is now hidden.", SDL_GetJoystickName(joystick));
     return true;
 }
 
@@ -87,7 +89,7 @@ bool MacOSExclusiveMode::UnhideDevice(SDL_Joystick* joystick) {
     IOHIDDeviceClose(it->second, kIOHIDOptionsTypeSeizeDevice);
     CFRelease(it->second);
     m_SeizedDevices.erase(it);
-    LOG_INFO("ExclusiveMode", "MacOSExclusiveMode: '%s' is now visible.", SDL_GetJoystickName(joystick));
+    LOG_INFO(kTag, "MacOSExclusiveMode: '%s' is now visible.", SDL_GetJoystickName(joystick));
     return true;
 }
 

--- a/src/Mappers/OutputMapper.cpp
+++ b/src/Mappers/OutputMapper.cpp
@@ -10,6 +10,8 @@
 #include <nlohmann/json.hpp>
 #include <SDL3/SDL_filesystem.h>
 
+static constexpr const char* kTag = "OutputMapper";
+
 using json = nlohmann::json;
 
 std::unique_ptr<OutputMapper> OutputMapper::s_Instance;
@@ -359,7 +361,7 @@ void OutputMapper::UpdateHapticDevice(HapticTarget& target) {
                 if (SDL_HapticRumbleSupported(target.haptic_device)) {
                     if (!SDL_InitHapticRumble(target.haptic_device)) {
                         target.status_message = std::string("Rumble Init Failed: ") + SDL_GetError();
-                        LOG_WARN("OutputMapper", "SDL_InitHapticRumble failed: %s", SDL_GetError());
+                        LOG_WARN(kTag, "SDL_InitHapticRumble failed: %s", SDL_GetError());
                     }
                 }
                 SDL_SetHapticGain(target.haptic_device, 100);

--- a/src/Mappers/OutputMapper.cpp
+++ b/src/Mappers/OutputMapper.cpp
@@ -359,7 +359,7 @@ void OutputMapper::UpdateHapticDevice(HapticTarget& target) {
                 if (SDL_HapticRumbleSupported(target.haptic_device)) {
                     if (!SDL_InitHapticRumble(target.haptic_device)) {
                         target.status_message = std::string("Rumble Init Failed: ") + SDL_GetError();
-                        LOG_ERROR("OutputMapper", "Warning: SDL_InitHapticRumble failed: %s", SDL_GetError());
+                        LOG_WARN("OutputMapper", "SDL_InitHapticRumble failed: %s", SDL_GetError());
                     }
                 }
                 SDL_SetHapticGain(target.haptic_device, 100);

--- a/src/Mappers/WindowsExclusiveMode.cpp
+++ b/src/Mappers/WindowsExclusiveMode.cpp
@@ -12,6 +12,8 @@
 #include <setupapi.h>
 #include <shlobj.h>
 
+static constexpr const char* kTag = "ExclusiveMode";
+
 #pragma comment(lib, "setupapi.lib")
 #pragma comment(lib, "cfgmgr32.lib")
 
@@ -101,12 +103,12 @@ bool WindowsExclusiveMode::EnsureWhitelisted(const std::wstring &own, const std:
     }
 
     if (changed && !SetAllowList(wl)) {
-        LOG_ERROR("ExclusiveMode", "HidHide: failed to add InputBridge to the allow-list.");
+        LOG_ERROR(kTag, "HidHide: failed to add InputBridge to the allow-list.");
         return false;
     }
 
     selfWhitelistedFlag = true;
-    LOG_INFO("ExclusiveMode", "HidHide: InputBridge added to allow-list.");
+    LOG_INFO(kTag, "HidHide: InputBridge added to allow-list.");
     return true;
 }
 
@@ -122,7 +124,7 @@ bool WindowsExclusiveMode::HideDevice(SDL_Joystick *joystick) {
 
     auto paths = GetInstancePaths(joystick);
     if (paths.empty()) {
-        LOG_INFO("ExclusiveMode", "HidHide: could not determine instance path for '%s'.", SDL_GetJoystickName(joystick));
+        LOG_INFO(kTag, "HidHide: could not determine instance path for '%s'.", SDL_GetJoystickName(joystick));
         return false;
     }
 
@@ -132,7 +134,7 @@ bool WindowsExclusiveMode::HideDevice(SDL_Joystick *joystick) {
         if (bl.find(p) == bl.end()) {
             bl.insert(p);
             changed = true;
-            LOG_INFO("ExclusiveMode", "HidHide: hiding device path '%ls'.", p.c_str());
+            LOG_INFO(kTag, "HidHide: hiding device path '%ls'.", p.c_str());
         }
     }
 
@@ -140,7 +142,7 @@ bool WindowsExclusiveMode::HideDevice(SDL_Joystick *joystick) {
         return true; // already hidden
 
     if (!SetBlockList(bl)) {
-        LOG_ERROR("ExclusiveMode", "HidHide: failed to write block-list.");
+        LOG_ERROR(kTag, "HidHide: failed to write block-list.");
         return false;
     }
 
@@ -153,7 +155,7 @@ bool WindowsExclusiveMode::HideDevice(SDL_Joystick *joystick) {
         CloseHandle(h);
     }
 
-    LOG_INFO("ExclusiveMode", "HidHide: '%s' is now hidden.", SDL_GetJoystickName(joystick));
+    LOG_INFO(kTag, "HidHide: '%s' is now hidden.", SDL_GetJoystickName(joystick));
     return true;
 }
 
@@ -174,7 +176,7 @@ bool WindowsExclusiveMode::UnhideDevice(SDL_Joystick *joystick) {
         if (it != bl.end()) {
             bl.erase(it);
             changed = true;
-            LOG_INFO("ExclusiveMode", "HidHide: unhiding device path '%ls'.", p.c_str());
+            LOG_INFO(kTag, "HidHide: unhiding device path '%ls'.", p.c_str());
         }
     }
 
@@ -182,11 +184,11 @@ bool WindowsExclusiveMode::UnhideDevice(SDL_Joystick *joystick) {
         return true;
 
     if (!SetBlockList(bl)) {
-        LOG_ERROR("ExclusiveMode", "HidHide: failed to write block-list on unhide.");
+        LOG_ERROR(kTag, "HidHide: failed to write block-list on unhide.");
         return false;
     }
 
-    LOG_INFO("ExclusiveMode", "HidHide: '%s' is now visible to all applications.", SDL_GetJoystickName(joystick));
+    LOG_INFO(kTag, "HidHide: '%s' is now visible to all applications.", SDL_GetJoystickName(joystick));
     return true;
 }
 
@@ -196,7 +198,7 @@ HANDLE WindowsExclusiveMode::OpenControlDevice() const {
     HANDLE h = CreateFileW(kHidHideDevice, GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
     if (h == INVALID_HANDLE_VALUE) {
         // Driver not installed — this is expected on systems without HidHide.
-        LOG_WARN("ExclusiveMode", "HidHide: control device not found (driver not installed?).");
+        LOG_WARN(kTag, "HidHide: control device not found (driver not installed?).");
     }
     return h;
 }
@@ -328,7 +330,7 @@ std::vector<std::wstring> WindowsExclusiveMode::GetInstancePaths(SDL_Joystick *j
 
         if (ipLow.find(prefix) == 0) {
             result.push_back(ip);
-            LOG_INFO("ExclusiveMode", "HidHide: matched instance path '%ls'.", ip.c_str());
+            LOG_INFO(kTag, "HidHide: matched instance path '%ls'.", ip.c_str());
         }
     }
 

--- a/src/Network/HapticDispatcher.cpp
+++ b/src/Network/HapticDispatcher.cpp
@@ -4,6 +4,7 @@
 void HapticDispatcher::DispatchRumble(lo_arg** argv, int argc, OutputMapper* mapper)
 {
     if (!mapper || argc < 5) return;
+    for (int i = 0; i < 5; ++i) { if (!argv[i]) return; }
     const int   id       = argv[0]->i;
     const int   slot     = argv[1]->i;
     const float low      = argv[2]->f;
@@ -15,6 +16,7 @@ void HapticDispatcher::DispatchRumble(lo_arg** argv, int argc, OutputMapper* map
 void HapticDispatcher::DispatchConstant(lo_arg** argv, int argc, OutputMapper* mapper)
 {
     if (!mapper || argc < 4) return;
+    for (int i = 0; i < 4; ++i) { if (!argv[i]) return; }
     const int   id       = argv[0]->i;
     const int   slot     = argv[1]->i;
     const float strength = argv[2]->f;
@@ -55,6 +57,13 @@ void HapticDispatcher::DispatchPeriodic(lo_arg** argv, int argc, OutputMapper* m
 void HapticDispatcher::DispatchCondition(lo_arg** argv, int argc, OutputMapper* mapper)
 {
     if (!mapper || argc < 10) return;
+
+    // Guard every slot: a sparse or malformed OSC message can leave argv[i]
+    // null even when argc is large enough, causing a segfault on dereference.
+    for (int i = 0; i < 10; ++i) {
+        if (!argv[i]) return;
+    }
+
     const int   id       = argv[0]->i;
     const int   slot     = argv[1]->i;
     const HapticConditionType ctype = ConditionTypeFromIndex(argv[2]->i);
@@ -71,6 +80,7 @@ void HapticDispatcher::DispatchCondition(lo_arg** argv, int argc, OutputMapper* 
 void HapticDispatcher::DispatchGain(lo_arg** argv, int argc, OutputMapper* mapper)
 {
     if (!mapper || argc < 2) return;
+    for (int i = 0; i < 2; ++i) { if (!argv[i]) return; }
     const int id   = argv[0]->i;
     const int gain = argv[1]->i;
     mapper->QueueSetGain(id, gain);

--- a/src/Network/OSCServer.cpp
+++ b/src/Network/OSCServer.cpp
@@ -19,6 +19,8 @@
 #include <thread>
 #include <string_view>
 
+static constexpr const char* kTag = "OSCServer";
+
 namespace {
     // Preference Keys
     const char* const kOSCSection = "OSC";
@@ -211,7 +213,7 @@ bool OSCServer::Start(const std::string& send_host, int send_port, int recv_port
     // Setup sending address
     m_send_address = lo_address_new(send_host.c_str(), std::to_string(send_port).c_str());
     if (!m_send_address) {
-        LOG_ERROR("OSCServer", "Could not create send address %s:%d", send_host.c_str(), send_port);
+        LOG_ERROR(kTag, "Could not create send address %s:%d", send_host.c_str(), send_port);
         return false;
     }
 
@@ -219,7 +221,7 @@ bool OSCServer::Start(const std::string& send_host, int send_port, int recv_port
     std::string recv_port_str = std::to_string(recv_port);
     m_server_thread = lo_server_thread_new_with_proto(recv_port_str.c_str(), LO_UDP, nullptr);
     if (!m_server_thread) {
-        LOG_ERROR("OSCServer", "Could not create server on port %d", recv_port);
+        LOG_ERROR(kTag, "Could not create server on port %d", recv_port);
         lo_address_free(m_send_address);
         m_send_address = nullptr;
         return false;
@@ -249,7 +251,7 @@ bool OSCServer::Start(const std::string& send_host, int send_port, int recv_port
     if (!m_OutputMapper && m_savedOutputMapper)
         m_OutputMapper = m_savedOutputMapper;
 
-    LOG_INFO("OSCServer", "Started — sending to %s:%d, listening on port %d",
+    LOG_INFO(kTag, "Started — sending to %s:%d, listening on port %d",
              send_host.c_str(), send_port, recv_port);
 
     m_logs.push_back({"OSC server started. Sending to " + send_host + ":" + std::to_string(send_port) + ", Listening on port " + std::to_string(recv_port), false});
@@ -322,7 +324,7 @@ void OSCServer::Stop() {
                 lo_address_free(address_to_free);
             }
             std::lock_guard<std::mutex> lock(m_mutex);
-            LOG_INFO("OSCServer", "Stopped");
+            LOG_INFO(kTag, "Stopped");
             m_logs.push_back({"OSC server stopped.", false});
             if (m_logs.size() > 100) m_logs.pop_front();
         });

--- a/src/Preferences/Preferences.cpp
+++ b/src/Preferences/Preferences.cpp
@@ -262,6 +262,15 @@ void PreferencesManager::SetDeviceMapping(const std::string &guid, const std::st
     Save();
 }
 
+bool PreferencesManager::GetDeviceKeepalive(const std::string &guid) const {
+    return GetBool(std::string(kDeviceSectionPrefix) + guid, kKeepaliveKey, false);
+}
+
+void PreferencesManager::SetDeviceKeepalive(const std::string &guid, bool enabled) {
+    SetBool(std::string(kDeviceSectionPrefix) + guid, kKeepaliveKey, enabled);
+    Save();
+}
+
 bool PreferencesManager::IsPreferenceApplied(SDL_JoystickID instance_id) const { return m_AppliedPreferences.find(instance_id) != m_AppliedPreferences.end(); }
 
 void PreferencesManager::MarkPreferenceApplied(SDL_JoystickID instance_id) { m_AppliedPreferences.insert(instance_id); }

--- a/src/Preferences/Preferences.h
+++ b/src/Preferences/Preferences.h
@@ -51,6 +51,9 @@ class PreferencesManager {
     std::string GetDeviceMapping(const std::string &guid) const;
     void SetDeviceMapping(const std::string &guid, const std::string &mapping);
 
+    bool GetDeviceKeepalive(const std::string &guid) const;
+    void SetDeviceKeepalive(const std::string &guid, bool enabled);
+
     bool IsPreferenceApplied(SDL_JoystickID instance_id) const;
     void MarkPreferenceApplied(SDL_JoystickID instance_id);
     void ClearAppliedPreference(SDL_JoystickID instance_id);
@@ -67,5 +70,6 @@ class PreferencesManager {
     static constexpr const char* kVisualizerKey = "Visualizer";
     static constexpr const char* kMappingKey = "Mapping";
     static constexpr const char* kMappingPrefix = "Mapping.";
+    static constexpr const char* kKeepaliveKey = "HapticKeepalive";
     static constexpr size_t kMappingPrefixLen = 8; // strlen("Mapping.")
 };

--- a/src/Protocols/OSCBaseProtocol.cpp
+++ b/src/Protocols/OSCBaseProtocol.cpp
@@ -146,6 +146,19 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
             }
         });
     }
+    // RPM LED meter — /inputbridge/wheel/led_rpm f  (value 0.0 – 1.0)
+    // Sets the RPM LED bar on all connected RPM-capable steering wheels.
+    else if (path_sv == "/inputbridge/wheel/led_rpm" && std::strcmp(types, "f") == 0 && argc == 1) {
+        handled = true;
+        float rpm_percent = argv[0]->f;
+        if (rpm_percent < 0.0f) rpm_percent = 0.0f;
+        if (rpm_percent > 1.0f) rpm_percent = 1.0f;
+
+        auto& deviceManager = DeviceManager::GetInstance();
+        for (const auto& wheel : deviceManager.GetWheelRPMDevices()) {
+            wheel->setRPM(rpm_percent);
+        }
+    }
 
     // ── Subchannel paths: /inputbridge/haptics/<effect>/<slot> ───────────────
     // The slot is encoded as the trailing decimal path component instead of

--- a/src/Protocols/OSCBaseProtocol.cpp
+++ b/src/Protocols/OSCBaseProtocol.cpp
@@ -1,4 +1,5 @@
 #include "Protocols/OSCBaseProtocol.h"
+#include "Protocols/OscValidation.h"
 #include "Network/OSCServer.h"
 #include "Devices/DeviceManager.h"
 #include "Protocols/ProtocolManager.h"
@@ -24,6 +25,11 @@ namespace {
 }
 
 bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo_arg** argv, int argc) {
+    using namespace OscValidation;
+
+    if (!CheckPointers(path, types, argv, argc))
+        return false;
+
     std::string_view path_sv(path);
 
     std::string activeId = ProtocolManager::GetInstance().GetActiveInputProtocolId();
@@ -40,82 +46,128 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
         }
     }
 
-    // Helper to check if we matched a field or if we should fallback to legacy path
     auto match = [&](const char* legacyPath, const char* fid) {
         return (fieldId == fid) || (fieldId.empty() && path_sv == legacyPath);
     };
 
     bool handled = false;
 
+    // /inputbridge/haptics/rumble  iiffi  (deviceId, slot, low_freq, high_freq, duration_ms)
     if (match("/inputbridge/haptics/rumble", "haptic_rumble") && std::strcmp(types, "iiffi") == 0 && argc == 5) {
         handled = true;
-        int slot = argv[1]->i;
-        float low_freq = argv[2]->f;
-        float high_freq = argv[3]->f;
-        int duration_ms = argv[4]->i;
+        int   slot        = argv[1]->i;
+        float low_freq    = argv[2]->f;
+        float high_freq   = argv[3]->f;
+        int   duration_ms = argv[4]->i;
+
+        if (!ValidateSlot(slot, path_sv)) return handled;
+        low_freq  = ClampNorm(low_freq,  "low_freq",  path_sv);
+        high_freq = ClampNorm(high_freq, "high_freq", path_sv);
+
         DispatchHapticCommand<GamepadHaptics>([&](GamepadHaptics* gamepad) {
-            gamepad->PlayRumble(slot, low_freq, high_freq, (duration_ms < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration_ms);
+            gamepad->PlayRumble(slot, low_freq, high_freq,
+                (duration_ms < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration_ms);
         });
     }
+    // /inputbridge/haptics/force  iifi  (deviceId, slot, strength, duration_ms)
     else if (match("/inputbridge/haptics/force", "haptic_constant") && std::strcmp(types, "iifi") == 0 && argc == 4) {
         handled = true;
-        int slot = argv[1]->i;
-        float strength = argv[2]->f;
-        int duration_int = argv[3]->i;
+        int   slot         = argv[1]->i;
+        float strength     = argv[2]->f;
+        int   duration_int = argv[3]->i;
+
+        if (!ValidateSlot(slot, path_sv)) return handled;
+        strength = ClampStrength(strength, "strength", path_sv);
+
         DispatchHapticCommand<SteeringWheelHaptics>([&](SteeringWheelHaptics* wheel) {
-            wheel->PlayConstant(slot, strength, (duration_int < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration_int);
+            wheel->PlayConstant(slot, strength,
+                (duration_int < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration_int);
         });
     }
+    // /inputbridge/haptics/periodic  iiififfii  (deviceId, slot, wave_type, strength, period, magnitude, offset, phase, duration_ms)
     else if (match("/inputbridge/haptics/periodic", "haptic_periodic") && std::strcmp(types, "iiififfii") == 0 && argc == 9) {
         handled = true;
-        int slot = argv[1]->i;
-        HapticPeriodicType wave_type = PeriodicTypeFromIndex(argv[2]->i);
-        float strength = argv[3]->f;
-        int period = argv[4]->i;
-        float magnitude = argv[5]->f;
-        float offset = argv[6]->f;
-        int phase = argv[7]->i;
-        int duration_int = argv[8]->i;
+        int   slot         = argv[1]->i;
+        int   wave_idx     = argv[2]->i;
+        float strength     = argv[3]->f;
+        int   period       = argv[4]->i;
+        float magnitude    = argv[5]->f;
+        float offset       = argv[6]->f;
+        int   phase        = argv[7]->i;
+        int   duration_int = argv[8]->i;
+
+        if (!ValidateSlot(slot, path_sv))         return handled;
+        if (!ValidateWaveType(wave_idx, path_sv)) return handled;
+        strength  = ClampNorm(strength,  "strength",  path_sv);
+        magnitude = ClampNorm(magnitude, "magnitude", path_sv);
+        offset    = ClampSigned(offset,  "offset",    path_sv);
+
+        HapticPeriodicType wave_type = PeriodicTypeFromIndex(wave_idx);
         DispatchHapticCommand<SteeringWheelHaptics>([&](SteeringWheelHaptics* wheel) {
-            wheel->PlayPeriodic(slot, wave_type, strength, period, magnitude, offset, phase, (duration_int < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration_int);
+            wheel->PlayPeriodic(slot, wave_type, strength, period, magnitude, offset, phase,
+                (duration_int < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration_int);
         });
     }
-    // Legacy: no wave_type argument — defaults to Sine.
+    // Legacy periodic — no wave_type, defaults to Sine.
     else if (match("/inputbridge/haptics/periodic", "haptic_periodic") && std::strcmp(types, "iififfii") == 0 && argc == 8) {
         handled = true;
-        int slot = argv[1]->i;
-        float strength = argv[2]->f;
-        int period = argv[3]->i;
-        float magnitude = argv[4]->f;
-        float offset = argv[5]->f;
-        int phase = argv[6]->i;
-        int duration_int = argv[7]->i;
+        int   slot         = argv[1]->i;
+        float strength     = argv[2]->f;
+        int   period       = argv[3]->i;
+        float magnitude    = argv[4]->f;
+        float offset       = argv[5]->f;
+        int   phase        = argv[6]->i;
+        int   duration_int = argv[7]->i;
+
+        if (!ValidateSlot(slot, path_sv)) return handled;
+        strength  = ClampNorm(strength,  "strength",  path_sv);
+        magnitude = ClampNorm(magnitude, "magnitude", path_sv);
+        offset    = ClampSigned(offset,  "offset",    path_sv);
+
         DispatchHapticCommand<SteeringWheelHaptics>([&](SteeringWheelHaptics* wheel) {
-            wheel->PlayPeriodic(slot, HapticPeriodicType::Sine, strength, period, magnitude, offset, phase, (duration_int < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration_int);
+            wheel->PlayPeriodic(slot, HapticPeriodicType::Sine, strength, period, magnitude, offset, phase,
+                (duration_int < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration_int);
         });
     }
+    // /inputbridge/haptics/condition  iiiffffffi  (deviceId, slot, condition_type, right_sat, left_sat, right_coeff, left_coeff, deadband, center, duration_ms)
     else if (match("/inputbridge/haptics/condition", "haptic_condition") && std::strcmp(types, "iiiffffffi") == 0 && argc == 10) {
         handled = true;
-        int slot = argv[1]->i;
-        HapticConditionType condition_type = ConditionTypeFromIndex(argv[2]->i);
-        float right_sat = argv[3]->f;
-        float left_sat = argv[4]->f;
-        float right_coeff = argv[5]->f;
-        float left_coeff = argv[6]->f;
-        float deadband = argv[7]->f;
-        float center = argv[8]->f;
-        int duration_int = argv[9]->i;
+        int   slot           = argv[1]->i;
+        int   cond_idx       = argv[2]->i;
+        float right_sat      = argv[3]->f;
+        float left_sat       = argv[4]->f;
+        float right_coeff    = argv[5]->f;
+        float left_coeff     = argv[6]->f;
+        float deadband       = argv[7]->f;
+        float center         = argv[8]->f;
+        int   duration_int   = argv[9]->i;
+
+        if (!ValidateSlot(slot, path_sv))              return handled;
+        if (!ValidateConditionType(cond_idx, path_sv)) return handled;
+        right_sat   = ClampNorm(right_sat,     "right_sat",   path_sv);
+        left_sat    = ClampNorm(left_sat,       "left_sat",    path_sv);
+        right_coeff = ClampSigned(right_coeff, "right_coeff", path_sv);
+        left_coeff  = ClampSigned(left_coeff,  "left_coeff",  path_sv);
+        deadband    = ClampNorm(deadband,      "deadband",    path_sv);
+        center      = ClampSigned(center,      "center",      path_sv);
+
+        HapticConditionType condition_type = ConditionTypeFromIndex(cond_idx);
         DispatchHapticCommand<SteeringWheelHaptics>([&](SteeringWheelHaptics* wheel) {
-            wheel->PlayCondition(slot, condition_type, right_sat, left_sat, right_coeff, left_coeff, deadband, center, (duration_int < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration_int);
+            wheel->PlayCondition(slot, condition_type, right_sat, left_sat,
+                right_coeff, left_coeff, deadband, center,
+                (duration_int < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration_int);
         });
     }
+    // /inputbridge/haptics/gain  ii  (deviceId, gain)
     else if (match("/inputbridge/haptics/gain", "haptic_gain") && std::strcmp(types, "ii") == 0 && argc == 2) {
         handled = true;
-        int gain = argv[1]->i;
+        int gain = ClampGain(argv[1]->i, path_sv);
         DispatchHapticCommand<SteeringWheelHaptics>([&](SteeringWheelHaptics* wheel) {
             wheel->SetGain(gain);
         });
     }
+    // DualSense Trigger Effects
+    // /inputbridge/haptics/dualsense/trigger/{left|right}/{feedback|weapon|vibration|off}
     else if (path_sv.find("/inputbridge/haptics/dualsense/trigger/") != std::string_view::npos) {
         handled = true;
         DispatchHapticCommand<GamepadHaptics>([&](GamepadHaptics* gamepad) {
@@ -125,18 +177,18 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
 
             if (path_sv.ends_with("/feedback") && std::strcmp(types, "iii") == 0 && argc == 3) {
                 effect = "feedback";
-                params["position"] = argv[1]->i;
-                params["strength"] = argv[2]->i;
+                params["position"] = ClampDSPosition(argv[1]->i, path_sv);
+                params["strength"] = ClampDSStrength(argv[2]->i, path_sv);
             } else if (path_sv.ends_with("/weapon") && std::strcmp(types, "iiii") == 0 && argc == 4) {
                 effect = "weapon";
-                params["start_position"] = argv[1]->i;
-                params["end_position"] = argv[2]->i;
-                params["strength"] = argv[3]->i;
+                params["start_position"] = ClampDSStartPos(argv[1]->i, path_sv);
+                params["end_position"]   = ClampDSEndPos(argv[2]->i,   path_sv);
+                params["strength"]       = ClampDSStrength(argv[3]->i, path_sv);
             } else if (path_sv.ends_with("/vibration") && std::strcmp(types, "iiii") == 0 && argc == 4) {
                 effect = "vibration";
-                params["position"] = argv[1]->i;
-                params["amplitude"] = argv[2]->i;
-                params["frequency"] = argv[3]->i;
+                params["position"]  = ClampDSPosition(argv[1]->i,  path_sv);
+                params["amplitude"] = ClampDSAmplitude(argv[2]->i, path_sv);
+                params["frequency"] = ClampDSFrequency(argv[3]->i, path_sv);
             } else if (path_sv.ends_with("/off")) {
                 effect = "off";
             }
@@ -146,13 +198,10 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
             }
         });
     }
-    // RPM LED meter — /inputbridge/wheel/led_rpm f  (value 0.0 – 1.0)
-    // Sets the RPM LED bar on all connected RPM-capable steering wheels.
+    // /inputbridge/wheel/led_rpm  f  (rpm_percent 0.0–1.0)
     else if (path_sv == "/inputbridge/wheel/led_rpm" && std::strcmp(types, "f") == 0 && argc == 1) {
         handled = true;
-        float rpm_percent = argv[0]->f;
-        if (rpm_percent < 0.0f) rpm_percent = 0.0f;
-        if (rpm_percent > 1.0f) rpm_percent = 1.0f;
+        float rpm_percent = ClampNorm(argv[0]->f, "rpm_percent", path_sv);
 
         auto& deviceManager = DeviceManager::GetInstance();
         for (const auto& wheel : deviceManager.GetWheelRPMDevices()) {
@@ -184,6 +233,8 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
     for (char c : tail) slot = slot * 10 + (c - '0');
     const std::string_view base = path_sv.substr(0, last_slash);
 
+    if (!ValidateSlot(slot, path_sv)) return handled;
+
     // Re-run field-id lookup against the base path (without the /N suffix).
     std::string baseFieldId;
     if (def) {
@@ -202,9 +253,9 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
     if (matchBase("/inputbridge/haptics/rumble", "haptic_rumble")
         && std::strcmp(types, "iffi") == 0 && argc == 4) {
         handled = true;
-        const float low      = argv[1]->f;
-        const float high     = argv[2]->f;
-        const int   duration = argv[3]->i;
+        float low      = ClampNorm(argv[1]->f, "low_freq",  path_sv);
+        float high     = ClampNorm(argv[2]->f, "high_freq", path_sv);
+        const int duration = argv[3]->i;
         DispatchHapticCommand<GamepadHaptics>([&](GamepadHaptics* gamepad) {
             gamepad->PlayRumble(slot, low, high, (duration < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration);
         });
@@ -213,8 +264,8 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
     else if (matchBase("/inputbridge/haptics/force", "haptic_constant")
         && std::strcmp(types, "ifi") == 0 && argc == 3) {
         handled = true;
-        const float strength = argv[1]->f;
-        const int   duration = argv[2]->i;
+        float strength     = ClampStrength(argv[1]->f, "strength", path_sv);
+        const int duration = argv[2]->i;
         DispatchHapticCommand<SteeringWheelHaptics>([&](SteeringWheelHaptics* wheel) {
             wheel->PlayConstant(slot, strength, (duration < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration);
         });
@@ -223,13 +274,15 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
     else if (matchBase("/inputbridge/haptics/periodic", "haptic_periodic")
         && std::strcmp(types, "iififfii") == 0 && argc == 8) {
         handled = true;
-        const HapticPeriodicType wave_type = PeriodicTypeFromIndex(argv[1]->i);
-        const float strength  = argv[2]->f;
-        const int   period    = argv[3]->i;
-        const float magnitude = argv[4]->f;
-        const float offset    = argv[5]->f;
-        const int   phase     = argv[6]->i;
-        const int   duration  = argv[7]->i;
+        int wave_idx = argv[1]->i;
+        if (!ValidateWaveType(wave_idx, path_sv)) return handled;
+        float strength      = ClampNorm(argv[2]->f,    "strength",  path_sv);
+        const int period    = argv[3]->i;
+        float magnitude     = ClampNorm(argv[4]->f,    "magnitude", path_sv);
+        float offset        = ClampSigned(argv[5]->f,  "offset",    path_sv);
+        const int phase     = argv[6]->i;
+        const int duration  = argv[7]->i;
+        HapticPeriodicType wave_type = PeriodicTypeFromIndex(wave_idx);
         DispatchHapticCommand<SteeringWheelHaptics>([&](SteeringWheelHaptics* wheel) {
             wheel->PlayPeriodic(slot, wave_type, strength, period, magnitude, offset, phase,
                 (duration < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration);
@@ -239,12 +292,12 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
     else if (matchBase("/inputbridge/haptics/periodic", "haptic_periodic")
         && std::strcmp(types, "ififfii") == 0 && argc == 7) {
         handled = true;
-        const float strength  = argv[1]->f;
-        const int   period    = argv[2]->i;
-        const float magnitude = argv[3]->f;
-        const float offset    = argv[4]->f;
-        const int   phase     = argv[5]->i;
-        const int   duration  = argv[6]->i;
+        float strength      = ClampNorm(argv[1]->f,    "strength",  path_sv);
+        const int period    = argv[2]->i;
+        float magnitude     = ClampNorm(argv[3]->f,    "magnitude", path_sv);
+        float offset        = ClampSigned(argv[4]->f,  "offset",    path_sv);
+        const int phase     = argv[5]->i;
+        const int duration  = argv[6]->i;
         DispatchHapticCommand<SteeringWheelHaptics>([&](SteeringWheelHaptics* wheel) {
             wheel->PlayPeriodic(slot, HapticPeriodicType::Sine, strength, period, magnitude, offset, phase,
                 (duration < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration);
@@ -254,14 +307,16 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
     else if (matchBase("/inputbridge/haptics/condition", "haptic_condition")
         && std::strcmp(types, "iiffffffi") == 0 && argc == 9) {
         handled = true;
-        const HapticConditionType ctype  = ConditionTypeFromIndex(argv[1]->i);
-        const float right_sat  = argv[2]->f;
-        const float left_sat   = argv[3]->f;
-        const float right_coeff = argv[4]->f;
-        const float left_coeff  = argv[5]->f;
-        const float deadband   = argv[6]->f;
-        const float center     = argv[7]->f;
-        const int   duration   = argv[8]->i;
+        int cond_idx = argv[1]->i;
+        if (!ValidateConditionType(cond_idx, path_sv)) return handled;
+        float right_sat     = ClampNorm(argv[2]->f,    "right_sat",   path_sv);
+        float left_sat      = ClampNorm(argv[3]->f,    "left_sat",    path_sv);
+        float right_coeff   = ClampSigned(argv[4]->f,  "right_coeff", path_sv);
+        float left_coeff    = ClampSigned(argv[5]->f,  "left_coeff",  path_sv);
+        float deadband      = ClampNorm(argv[6]->f,    "deadband",    path_sv);
+        float center        = ClampSigned(argv[7]->f,  "center",      path_sv);
+        const int duration  = argv[8]->i;
+        HapticConditionType ctype = ConditionTypeFromIndex(cond_idx);
         DispatchHapticCommand<SteeringWheelHaptics>([&](SteeringWheelHaptics* wheel) {
             wheel->PlayCondition(slot, ctype, right_sat, left_sat, right_coeff, left_coeff, deadband, center,
                 (duration < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration);

--- a/src/Protocols/OSCBaseProtocol.cpp
+++ b/src/Protocols/OSCBaseProtocol.cpp
@@ -1,4 +1,3 @@
-#include "App/Log.h"
 #include "Protocols/OSCBaseProtocol.h"
 #include "Protocols/OscValidation.h"
 #include "Network/OSCServer.h"

--- a/src/Protocols/OSCBaseProtocol.cpp
+++ b/src/Protocols/OSCBaseProtocol.cpp
@@ -1,3 +1,4 @@
+#include "App/Log.h"
 #include "Protocols/OSCBaseProtocol.h"
 #include "Protocols/OscValidation.h"
 #include "Network/OSCServer.h"

--- a/src/Protocols/OSCProtocol.cpp
+++ b/src/Protocols/OSCProtocol.cpp
@@ -1,4 +1,3 @@
-#include "App/Log.h"
 #include "Protocols/OSCProtocol.h"
 #include "Protocols/OscValidation.h"
 #include "Network/OSCServer.h"

--- a/src/Protocols/OSCProtocol.cpp
+++ b/src/Protocols/OSCProtocol.cpp
@@ -1,3 +1,4 @@
+#include "App/Log.h"
 #include "Protocols/OSCProtocol.h"
 #include "Protocols/OscValidation.h"
 #include "Network/OSCServer.h"

--- a/src/Protocols/OSCProtocol.cpp
+++ b/src/Protocols/OSCProtocol.cpp
@@ -127,96 +127,35 @@ bool OSCProtocol::handle_osc_message(const char* path, const char* types, lo_arg
         });
     }
     // DualSense Trigger Effects
-    // Example: /inputbridge/haptics/dualsense/trigger/left/feedback i i i (deviceId, position, strength)
-    else if (path_sv == "/inputbridge/haptics/dualsense/trigger/left/feedback" && std::strcmp(types, "iii") == 0 && argc == 3) {
-        handled = true;
-        int position = argv[1]->i;
-        int strength = argv[2]->i;
-        DispatchHapticCommand<GamepadHaptics>([&](GamepadHaptics* gamepad) {
-            std::map<std::string, int> params;
-            params["position"] = position;
-            params["strength"] = strength;
-            gamepad->SendDualSenseTrigger("left", "feedback", params);
-        });
-    }
-    else if (path_sv == "/inputbridge/haptics/dualsense/trigger/right/feedback" && std::strcmp(types, "iii") == 0 && argc == 3) {
-        handled = true;
-        int position = argv[1]->i;
-        int strength = argv[2]->i;
-        DispatchHapticCommand<GamepadHaptics>([&](GamepadHaptics* gamepad) {
-            std::map<std::string, int> params;
-            params["position"] = position;
-            params["strength"] = strength;
-            gamepad->SendDualSenseTrigger("right", "feedback", params);
-        });
-    }
-    // Example: /inputbridge/haptics/dualsense/trigger/left/weapon i i i i (deviceId, start_position, end_position, strength)
-    else if (path_sv == "/inputbridge/haptics/dualsense/trigger/left/weapon" && std::strcmp(types, "iiii") == 0 && argc == 4) {
-        handled = true;
-        int start_pos = argv[1]->i;
-        int end_pos = argv[2]->i;
-        int strength = argv[3]->i;
-        DispatchHapticCommand<GamepadHaptics>([&](GamepadHaptics* gamepad) {
-            std::map<std::string, int> params;
-            params["start_position"] = start_pos;
-            params["end_position"] = end_pos;
-            params["strength"] = strength;
-            gamepad->SendDualSenseTrigger("left", "weapon", params);
-        });
-    }
-    else if (path_sv == "/inputbridge/haptics/dualsense/trigger/right/weapon" && std::strcmp(types, "iiii") == 0 && argc == 4) {
-        handled = true;
-        int start_pos = argv[1]->i;
-        int end_pos = argv[2]->i;
-        int strength = argv[3]->i;
-        DispatchHapticCommand<GamepadHaptics>([&](GamepadHaptics* gamepad) {
-            std::map<std::string, int> params;
-            params["start_position"] = start_pos;
-            params["end_position"] = end_pos;
-            params["strength"] = strength;
-            gamepad->SendDualSenseTrigger("right", "weapon", params);
-        });
-    }
-    // Example: /inputbridge/haptics/dualsense/trigger/left/vibration i i i i (deviceId, position, amplitude, frequency)
-    else if (path_sv == "/inputbridge/haptics/dualsense/trigger/left/vibration" && std::strcmp(types, "iiii") == 0 && argc == 4) {
-        handled = true;
-        int position = argv[1]->i;
-        int amplitude = argv[2]->i;
-        int frequency = argv[3]->i;
-        DispatchHapticCommand<GamepadHaptics>([&](GamepadHaptics* gamepad) {
-            std::map<std::string, int> params;
-            params["position"] = position;
-            params["amplitude"] = amplitude;
-            params["frequency"] = frequency;
-            gamepad->SendDualSenseTrigger("left", "vibration", params);
-        });
-    }
-    else if (path_sv == "/inputbridge/haptics/dualsense/trigger/right/vibration" && std::strcmp(types, "iiii") == 0 && argc == 4) {
-        handled = true;
-        int position = argv[1]->i;
-        int amplitude = argv[2]->i;
-        int frequency = argv[3]->i;
-        DispatchHapticCommand<GamepadHaptics>([&](GamepadHaptics* gamepad) {
-            std::map<std::string, int> params;
-            params["position"] = position;
-            params["amplitude"] = amplitude;
-            params["frequency"] = frequency;
-            gamepad->SendDualSenseTrigger("right", "vibration", params);
-        });
-    }
-    // Example: /inputbridge/haptics/dualsense/trigger/left/off i (deviceId)
-    else if (path_sv == "/inputbridge/haptics/dualsense/trigger/left/off" && std::strcmp(types, "i") == 0 && argc == 1) {
+    // /inputbridge/haptics/dualsense/trigger/{left|right}/{feedback|weapon|vibration|off}
+    else if (path_sv.find("/inputbridge/haptics/dualsense/trigger/") != std::string_view::npos) {
         handled = true;
         DispatchHapticCommand<GamepadHaptics>([&](GamepadHaptics* gamepad) {
+            std::string trigger = (path_sv.find("/left/") != std::string_view::npos) ? "left" : "right";
+            std::string effect = "off";
             std::map<std::string, int> params;
-            gamepad->SendDualSenseTrigger("left", "off", params);
-        });
-    }
-    else if (path_sv == "/inputbridge/haptics/dualsense/trigger/right/off" && std::strcmp(types, "i") == 0 && argc == 1) {
-        handled = true;
-        DispatchHapticCommand<GamepadHaptics>([&](GamepadHaptics* gamepad) {
-            std::map<std::string, int> params;
-            gamepad->SendDualSenseTrigger("right", "off", params);
+
+            if (path_sv.ends_with("/feedback") && std::strcmp(types, "iii") == 0 && argc == 3) {
+                effect = "feedback";
+                params["position"] = argv[1]->i;
+                params["strength"] = argv[2]->i;
+            } else if (path_sv.ends_with("/weapon") && std::strcmp(types, "iiii") == 0 && argc == 4) {
+                effect = "weapon";
+                params["start_position"] = argv[1]->i;
+                params["end_position"]   = argv[2]->i;
+                params["strength"]       = argv[3]->i;
+            } else if (path_sv.ends_with("/vibration") && std::strcmp(types, "iiii") == 0 && argc == 4) {
+                effect = "vibration";
+                params["position"]  = argv[1]->i;
+                params["amplitude"] = argv[2]->i;
+                params["frequency"] = argv[3]->i;
+            } else if (path_sv.ends_with("/off")) {
+                effect = "off";
+            }
+
+            if (effect != "off" || path_sv.ends_with("/off")) {
+                gamepad->SendDualSenseTrigger(trigger.c_str(), effect.c_str(), params);
+            }
         });
     }
     // RPM LED meter — /inputbridge/wheel/led_rpm f  (value 0.0 – 1.0)

--- a/src/Protocols/OSCProtocol.cpp
+++ b/src/Protocols/OSCProtocol.cpp
@@ -1,8 +1,9 @@
 #include "Protocols/OSCProtocol.h"
+#include "Protocols/OscValidation.h"
+#include "Network/OSCServer.h"
 #include "Devices/DeviceManager.h"
 #include "Haptics/GamepadHaptics.h"
 #include "Haptics/SteeringWheelHaptics.h"
-#include "Haptics/HapticDevice.h"
 #include <string_view>
 #include <cstring>
 #include <map>
@@ -45,83 +46,124 @@ std::string OSCProtocol::format_wheel(const std::map<std::string, float>& values
 bool OSCProtocol::parse(const std::string& message) { return false; }
 
 bool OSCProtocol::handle_osc_message(const char* path, const char* types, lo_arg** argv, int argc) {
-    std::string_view path_sv(path);
+    using namespace OscValidation;
 
+    if (!CheckPointers(path, types, argv, argc))
+        return false;
+
+    std::string_view path_sv(path);
     bool handled = false;
 
-    // Incoming haptics messages
-    // Example: /inputbridge/haptics/rumble i i f f i (deviceId, slot, low_freq, high_freq, duration_ms)
+    // /inputbridge/haptics/rumble  iiffi  (deviceId, slot, low_freq, high_freq, duration_ms)
     if (path_sv == "/inputbridge/haptics/rumble" && std::strcmp(types, "iiffi") == 0 && argc == 5) {
         handled = true;
-        int slot = argv[1]->i;
-        float low_freq = argv[2]->f;
-        float high_freq = argv[3]->f;
-        int duration_ms = argv[4]->i;
+        int   slot        = argv[1]->i;
+        float low_freq    = argv[2]->f;
+        float high_freq   = argv[3]->f;
+        int   duration_ms = argv[4]->i;
+
+        if (!ValidateSlot(slot, path_sv)) return handled;
+        low_freq  = ClampNorm(low_freq,  "low_freq",  path_sv);
+        high_freq = ClampNorm(high_freq, "high_freq", path_sv);
+
         DispatchHapticCommand<GamepadHaptics>([&](GamepadHaptics* gamepad) {
-            gamepad->PlayRumble(slot, low_freq, high_freq, (duration_ms < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration_ms);
+            gamepad->PlayRumble(slot, low_freq, high_freq,
+                (duration_ms < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration_ms);
         });
     }
-    // Example: /inputbridge/haptics/force i i f i (deviceId, slot, strength, duration_ms)
+    // /inputbridge/haptics/force  iifi  (deviceId, slot, strength, duration_ms)
     else if (path_sv == "/inputbridge/haptics/force" && std::strcmp(types, "iifi") == 0 && argc == 4) {
         handled = true;
-        int slot = argv[1]->i;
-        float strength = argv[2]->f;
-        int duration_int = argv[3]->i;
+        int   slot         = argv[1]->i;
+        float strength     = argv[2]->f;
+        int   duration_int = argv[3]->i;
+
+        if (!ValidateSlot(slot, path_sv)) return handled;
+        strength = ClampStrength(strength, "strength", path_sv);
+
         DispatchHapticCommand<SteeringWheelHaptics>([&](SteeringWheelHaptics* wheel) {
-            wheel->PlayConstant(slot, strength, (duration_int < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration_int);
+            wheel->PlayConstant(slot, strength,
+                (duration_int < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration_int);
         });
     }
-    // Example: /inputbridge/haptics/periodic i i i f i f f i i (deviceId, slot, wave_type, strength, period, magnitude, offset, phase, duration_ms)
-    // wave_type: 0=Sine, 1=Triangle, 2=SawtoothUp, 3=SawtoothDown
+    // /inputbridge/haptics/periodic  iiififfii  (deviceId, slot, wave_type, strength, period, magnitude, offset, phase, duration_ms)
     else if (path_sv == "/inputbridge/haptics/periodic" && std::strcmp(types, "iiififfii") == 0 && argc == 9) {
         handled = true;
-        int slot = argv[1]->i;
-        HapticPeriodicType wave_type = PeriodicTypeFromIndex(argv[2]->i);
-        float strength = argv[3]->f;
-        int period = argv[4]->i;
-        float magnitude = argv[5]->f;
-        float offset = argv[6]->f;
-        int phase = argv[7]->i;
-        int duration_int = argv[8]->i;
+        int   slot         = argv[1]->i;
+        int   wave_idx     = argv[2]->i;
+        float strength     = argv[3]->f;
+        int   period       = argv[4]->i;
+        float magnitude    = argv[5]->f;
+        float offset       = argv[6]->f;
+        int   phase        = argv[7]->i;
+        int   duration_int = argv[8]->i;
+
+        if (!ValidateSlot(slot, path_sv))         return handled;
+        if (!ValidateWaveType(wave_idx, path_sv)) return handled;
+        strength  = ClampNorm(strength,   "strength",  path_sv);
+        magnitude = ClampNorm(magnitude,  "magnitude", path_sv);
+        offset    = ClampSigned(offset,   "offset",    path_sv);
+
+        HapticPeriodicType wave_type = PeriodicTypeFromIndex(wave_idx);
         DispatchHapticCommand<SteeringWheelHaptics>([&](SteeringWheelHaptics* wheel) {
-            wheel->PlayPeriodic(slot, wave_type, strength, period, magnitude, offset, phase, (duration_int < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration_int);
+            wheel->PlayPeriodic(slot, wave_type, strength, period, magnitude, offset, phase,
+                (duration_int < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration_int);
         });
     }
-    // Legacy: no wave_type argument — defaults to Sine.
+    // Legacy periodic — no wave_type, defaults to Sine.
     else if (path_sv == "/inputbridge/haptics/periodic" && std::strcmp(types, "iififfii") == 0 && argc == 8) {
         handled = true;
-        int slot = argv[1]->i;
-        float strength = argv[2]->f;
-        int period = argv[3]->i;
-        float magnitude = argv[4]->f;
-        float offset = argv[5]->f;
-        int phase = argv[6]->i;
-        int duration_int = argv[7]->i;
+        int   slot         = argv[1]->i;
+        float strength     = argv[2]->f;
+        int   period       = argv[3]->i;
+        float magnitude    = argv[4]->f;
+        float offset       = argv[5]->f;
+        int   phase        = argv[6]->i;
+        int   duration_int = argv[7]->i;
+
+        if (!ValidateSlot(slot, path_sv)) return handled;
+        strength  = ClampNorm(strength,  "strength",  path_sv);
+        magnitude = ClampNorm(magnitude, "magnitude", path_sv);
+        offset    = ClampSigned(offset,  "offset",    path_sv);
+
         DispatchHapticCommand<SteeringWheelHaptics>([&](SteeringWheelHaptics* wheel) {
-            wheel->PlayPeriodic(slot, HapticPeriodicType::Sine, strength, period, magnitude, offset, phase, (duration_int < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration_int);
+            wheel->PlayPeriodic(slot, HapticPeriodicType::Sine, strength, period, magnitude, offset, phase,
+                (duration_int < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration_int);
         });
     }
-    // Example: /inputbridge/haptics/condition i i i f f f f f f i (deviceId, slot, condition_type, right_sat, left_sat, right_coeff, left_coeff, deadband, center, duration_ms)
-    // condition_type: 0=Spring, 1=Damper, 2=Inertia, 3=Friction
+    // /inputbridge/haptics/condition  iiiffffffi  (deviceId, slot, condition_type, right_sat, left_sat, right_coeff, left_coeff, deadband, center, duration_ms)
     else if (path_sv == "/inputbridge/haptics/condition" && std::strcmp(types, "iiiffffffi") == 0 && argc == 10) {
         handled = true;
-        int slot = argv[1]->i;
-        HapticConditionType condition_type = ConditionTypeFromIndex(argv[2]->i);
-        float right_sat = argv[3]->f;
-        float left_sat = argv[4]->f;
-        float right_coeff = argv[5]->f;
-        float left_coeff = argv[6]->f;
-        float deadband = argv[7]->f;
-        float center = argv[8]->f;
-        int duration_int = argv[9]->i;
+        int   slot           = argv[1]->i;
+        int   cond_idx       = argv[2]->i;
+        float right_sat      = argv[3]->f;
+        float left_sat       = argv[4]->f;
+        float right_coeff    = argv[5]->f;
+        float left_coeff     = argv[6]->f;
+        float deadband       = argv[7]->f;
+        float center         = argv[8]->f;
+        int   duration_int   = argv[9]->i;
+
+        if (!ValidateSlot(slot, path_sv))              return handled;
+        if (!ValidateConditionType(cond_idx, path_sv)) return handled;
+        right_sat   = ClampNorm(right_sat,     "right_sat",   path_sv);
+        left_sat    = ClampNorm(left_sat,      "left_sat",    path_sv);
+        right_coeff = ClampSigned(right_coeff, "right_coeff", path_sv);
+        left_coeff  = ClampSigned(left_coeff,  "left_coeff",  path_sv);
+        deadband    = ClampNorm(deadband,      "deadband",    path_sv);
+        center      = ClampSigned(center,      "center",      path_sv);
+
+        HapticConditionType condition_type = ConditionTypeFromIndex(cond_idx);
         DispatchHapticCommand<SteeringWheelHaptics>([&](SteeringWheelHaptics* wheel) {
-            wheel->PlayCondition(slot, condition_type, right_sat, left_sat, right_coeff, left_coeff, deadband, center, (duration_int < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration_int);
+            wheel->PlayCondition(slot, condition_type, right_sat, left_sat,
+                right_coeff, left_coeff, deadband, center,
+                (duration_int < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration_int);
         });
     }
-    // Example: /inputbridge/haptics/gain i i (deviceId, gain)
+    // /inputbridge/haptics/gain  ii  (deviceId, gain)
     else if (path_sv == "/inputbridge/haptics/gain" && std::strcmp(types, "ii") == 0 && argc == 2) {
         handled = true;
-        int gain = argv[1]->i;
+        int gain = ClampGain(argv[1]->i, path_sv);
         DispatchHapticCommand<SteeringWheelHaptics>([&](SteeringWheelHaptics* wheel) {
             wheel->SetGain(gain);
         });
@@ -137,18 +179,18 @@ bool OSCProtocol::handle_osc_message(const char* path, const char* types, lo_arg
 
             if (path_sv.ends_with("/feedback") && std::strcmp(types, "iii") == 0 && argc == 3) {
                 effect = "feedback";
-                params["position"] = argv[1]->i;
-                params["strength"] = argv[2]->i;
+                params["position"] = ClampDSPosition(argv[1]->i, path_sv);
+                params["strength"] = ClampDSStrength(argv[2]->i, path_sv);
             } else if (path_sv.ends_with("/weapon") && std::strcmp(types, "iiii") == 0 && argc == 4) {
                 effect = "weapon";
-                params["start_position"] = argv[1]->i;
-                params["end_position"]   = argv[2]->i;
-                params["strength"]       = argv[3]->i;
+                params["start_position"] = ClampDSStartPos(argv[1]->i, path_sv);
+                params["end_position"]   = ClampDSEndPos(argv[2]->i,   path_sv);
+                params["strength"]       = ClampDSStrength(argv[3]->i, path_sv);
             } else if (path_sv.ends_with("/vibration") && std::strcmp(types, "iiii") == 0 && argc == 4) {
                 effect = "vibration";
-                params["position"]  = argv[1]->i;
-                params["amplitude"] = argv[2]->i;
-                params["frequency"] = argv[3]->i;
+                params["position"]  = ClampDSPosition(argv[1]->i,  path_sv);
+                params["amplitude"] = ClampDSAmplitude(argv[2]->i, path_sv);
+                params["frequency"] = ClampDSFrequency(argv[3]->i, path_sv);
             } else if (path_sv.ends_with("/off")) {
                 effect = "off";
             }
@@ -158,13 +200,10 @@ bool OSCProtocol::handle_osc_message(const char* path, const char* types, lo_arg
             }
         });
     }
-    // RPM LED meter — /inputbridge/wheel/led_rpm f  (value 0.0 – 1.0)
-    // Sets the RPM LED bar on all connected RPM-capable steering wheels.
+    // /inputbridge/wheel/led_rpm  f  (rpm_percent 0.0–1.0)
     else if (path_sv == "/inputbridge/wheel/led_rpm" && std::strcmp(types, "f") == 0 && argc == 1) {
         handled = true;
-        float rpm_percent = argv[0]->f;
-        if (rpm_percent < 0.0f) rpm_percent = 0.0f;
-        if (rpm_percent > 1.0f) rpm_percent = 1.0f;
+        float rpm_percent = ClampNorm(argv[0]->f, "rpm_percent", path_sv);
 
         auto& deviceManager = DeviceManager::GetInstance();
         for (const auto& wheel : deviceManager.GetWheelRPMDevices()) {
@@ -193,12 +232,14 @@ bool OSCProtocol::handle_osc_message(const char* path, const char* types, lo_arg
     for (char c : tail) slot = slot * 10 + (c - '0');
     const std::string_view base = path_sv.substr(0, last_slash);
 
+    if (!ValidateSlot(slot, path_sv)) return handled;
+
     // /inputbridge/haptics/rumble/N  iffi  (id, low_freq, high_freq, duration_ms)
     if (base == "/inputbridge/haptics/rumble" && std::strcmp(types, "iffi") == 0 && argc == 4) {
         handled = true;
-        const float low      = argv[1]->f;
-        const float high     = argv[2]->f;
-        const int   duration = argv[3]->i;
+        float low      = ClampNorm(argv[1]->f, "low_freq",  path_sv);
+        float high     = ClampNorm(argv[2]->f, "high_freq", path_sv);
+        const int duration = argv[3]->i;
         DispatchHapticCommand<GamepadHaptics>([&](GamepadHaptics* gamepad) {
             gamepad->PlayRumble(slot, low, high, (duration < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration);
         });
@@ -206,8 +247,8 @@ bool OSCProtocol::handle_osc_message(const char* path, const char* types, lo_arg
     // /inputbridge/haptics/force/N  ifi  (id, strength, duration_ms)
     else if (base == "/inputbridge/haptics/force" && std::strcmp(types, "ifi") == 0 && argc == 3) {
         handled = true;
-        const float strength = argv[1]->f;
-        const int   duration = argv[2]->i;
+        float strength     = ClampStrength(argv[1]->f, "strength", path_sv);
+        const int duration = argv[2]->i;
         DispatchHapticCommand<SteeringWheelHaptics>([&](SteeringWheelHaptics* wheel) {
             wheel->PlayConstant(slot, strength, (duration < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration);
         });
@@ -215,13 +256,15 @@ bool OSCProtocol::handle_osc_message(const char* path, const char* types, lo_arg
     // /inputbridge/haptics/periodic/N  iififfii  (id, wave_type, strength, period, magnitude, offset, phase, duration_ms)
     else if (base == "/inputbridge/haptics/periodic" && std::strcmp(types, "iififfii") == 0 && argc == 8) {
         handled = true;
-        const HapticPeriodicType wave_type = PeriodicTypeFromIndex(argv[1]->i);
-        const float strength  = argv[2]->f;
-        const int   period    = argv[3]->i;
-        const float magnitude = argv[4]->f;
-        const float offset    = argv[5]->f;
-        const int   phase     = argv[6]->i;
-        const int   duration  = argv[7]->i;
+        int wave_idx = argv[1]->i;
+        if (!ValidateWaveType(wave_idx, path_sv)) return handled;
+        float strength      = ClampNorm(argv[2]->f,    "strength",  path_sv);
+        const int period    = argv[3]->i;
+        float magnitude     = ClampNorm(argv[4]->f,    "magnitude", path_sv);
+        float offset        = ClampSigned(argv[5]->f,  "offset",    path_sv);
+        const int phase     = argv[6]->i;
+        const int duration  = argv[7]->i;
+        HapticPeriodicType wave_type = PeriodicTypeFromIndex(wave_idx);
         DispatchHapticCommand<SteeringWheelHaptics>([&](SteeringWheelHaptics* wheel) {
             wheel->PlayPeriodic(slot, wave_type, strength, period, magnitude, offset, phase,
                 (duration < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration);
@@ -230,12 +273,12 @@ bool OSCProtocol::handle_osc_message(const char* path, const char* types, lo_arg
     // Legacy: /inputbridge/haptics/periodic/N  ififfii  — no wave_type, defaults to Sine
     else if (base == "/inputbridge/haptics/periodic" && std::strcmp(types, "ififfii") == 0 && argc == 7) {
         handled = true;
-        const float strength  = argv[1]->f;
-        const int   period    = argv[2]->i;
-        const float magnitude = argv[3]->f;
-        const float offset    = argv[4]->f;
-        const int   phase     = argv[5]->i;
-        const int   duration  = argv[6]->i;
+        float strength      = ClampNorm(argv[1]->f,    "strength",  path_sv);
+        const int period    = argv[2]->i;
+        float magnitude     = ClampNorm(argv[3]->f,    "magnitude", path_sv);
+        float offset        = ClampSigned(argv[4]->f,  "offset",    path_sv);
+        const int phase     = argv[5]->i;
+        const int duration  = argv[6]->i;
         DispatchHapticCommand<SteeringWheelHaptics>([&](SteeringWheelHaptics* wheel) {
             wheel->PlayPeriodic(slot, HapticPeriodicType::Sine, strength, period, magnitude, offset, phase,
                 (duration < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration);
@@ -244,14 +287,16 @@ bool OSCProtocol::handle_osc_message(const char* path, const char* types, lo_arg
     // /inputbridge/haptics/condition/N  iiffffffi  (id, condition_type, rsat, lsat, rcoeff, lcoeff, deadband, center, duration_ms)
     else if (base == "/inputbridge/haptics/condition" && std::strcmp(types, "iiffffffi") == 0 && argc == 9) {
         handled = true;
-        const HapticConditionType ctype   = ConditionTypeFromIndex(argv[1]->i);
-        const float right_sat  = argv[2]->f;
-        const float left_sat   = argv[3]->f;
-        const float right_coeff = argv[4]->f;
-        const float left_coeff  = argv[5]->f;
-        const float deadband   = argv[6]->f;
-        const float center     = argv[7]->f;
-        const int   duration   = argv[8]->i;
+        int cond_idx = argv[1]->i;
+        if (!ValidateConditionType(cond_idx, path_sv)) return handled;
+        float right_sat     = ClampNorm(argv[2]->f,    "right_sat",   path_sv);
+        float left_sat      = ClampNorm(argv[3]->f,    "left_sat",    path_sv);
+        float right_coeff   = ClampSigned(argv[4]->f,  "right_coeff", path_sv);
+        float left_coeff    = ClampSigned(argv[5]->f,  "left_coeff",  path_sv);
+        float deadband      = ClampNorm(argv[6]->f,    "deadband",    path_sv);
+        float center        = ClampSigned(argv[7]->f,  "center",      path_sv);
+        const int duration  = argv[8]->i;
+        HapticConditionType ctype = ConditionTypeFromIndex(cond_idx);
         DispatchHapticCommand<SteeringWheelHaptics>([&](SteeringWheelHaptics* wheel) {
             wheel->PlayCondition(slot, ctype, right_sat, left_sat, right_coeff, left_coeff, deadband, center,
                 (duration < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration);

--- a/src/Protocols/OscValidation.h
+++ b/src/Protocols/OscValidation.h
@@ -1,0 +1,115 @@
+#pragma once
+// OscValidation.h — lightweight helpers used by OSCProtocol and OSCBaseProtocol
+// to guard against malformed or out-of-range haptic messages before they reach
+// SDL's haptic driver (which can crash or assert on invalid values).
+//
+// Design goals:
+//   • Null-safety: reject messages with null path/types/argv pointers.
+//   • Type-tag + argc matching: already done at the call site via strcmp/argc
+//     checks, so we only need value-range guards here.
+//   • Clamping over rejection for float ranges: a slightly-out-of-range
+//     magnitude is better delivered clamped than silently dropped.
+//   • Hard rejection for int enums: an unknown condition/wave type index cannot
+//     be safely defaulted, so we reject and log.
+
+#include "lo/lo_osc_types.h"
+#include "App/Log.h"
+#include <string_view>
+#include <algorithm>
+
+namespace OscValidation {
+
+// ── Pointer safety ────────────────────────────────────────────────────────────
+
+inline bool CheckPointers(const char* path, const char* types, lo_arg** argv, int argc) {
+    if (!path) {
+        LOG_WARN("OSCValidation", "Received OSC message with null path — ignored");
+        return false;
+    }
+    if (!types) {
+        LOG_WARN("OSCValidation", "Received OSC message on '%s' with null type string — ignored", path);
+        return false;
+    }
+    if (argc > 0 && !argv) {
+        LOG_WARN("OSCValidation", "Received OSC message on '%s' with argc=%d but null argv — ignored", path, argc);
+        return false;
+    }
+    for (int i = 0; i < argc; ++i) {
+        if (!argv[i]) {
+            LOG_WARN("OSCValidation", "Received OSC message on '%s': argv[%d] is null — ignored", path, i);
+            return false;
+        }
+    }
+    return true;
+}
+
+// ── Slot ─────────────────────────────────────────────────────────────────────
+
+static constexpr int kMaxSlot = 255;
+
+inline bool ValidateSlot(int slot, std::string_view path) {
+    if (slot < 0 || slot > kMaxSlot) {
+        LOG_WARN("OSCValidation", "OSC '%.*s': slot %d is out of range [0, %d] — ignored",
+            (int)path.size(), path.data(), slot, kMaxSlot);
+        return false;
+    }
+    return true;
+}
+
+// ── Float clamping ────────────────────────────────────────────────────────────
+
+inline float Clamp(float v, float lo, float hi, const char* paramName, std::string_view path) {
+    if (v < lo || v > hi) {
+        float clamped = std::clamp(v, lo, hi);
+        LOG_WARN("OSCValidation", "OSC '%.*s': %s value %.4f out of range [%.1f, %.1f] — clamped to %.4f",
+            (int)path.size(), path.data(), paramName, v, lo, hi, clamped);
+        return clamped;
+    }
+    return v;
+}
+
+inline float ClampNorm(float v, const char* n, std::string_view p)     { return Clamp(v,  0.0f,  1.0f, n, p); }
+inline float ClampSigned(float v, const char* n, std::string_view p)   { return Clamp(v, -1.0f,  1.0f, n, p); }
+inline float ClampStrength(float v, const char* n, std::string_view p) { return Clamp(v, -1.0f,  1.0f, n, p); }
+
+// ── Int enum guards ───────────────────────────────────────────────────────────
+
+inline bool ValidateWaveType(int idx, std::string_view path) {
+    if (idx < 0 || idx > 4) {
+        LOG_WARN("OSCValidation", "OSC '%.*s': wave_type %d is out of range [0, 4] — ignored",
+            (int)path.size(), path.data(), idx);
+        return false;
+    }
+    return true;
+}
+
+inline bool ValidateConditionType(int idx, std::string_view path) {
+    if (idx < 0 || idx > 3) {
+        LOG_WARN("OSCValidation", "OSC '%.*s': condition_type %d is out of range [0, 3] — ignored",
+            (int)path.size(), path.data(), idx);
+        return false;
+    }
+    return true;
+}
+
+// ── DualSense-specific int clamps ─────────────────────────────────────────────
+
+inline int ClampInt(int v, int lo, int hi, const char* paramName, std::string_view path) {
+    if (v < lo || v > hi) {
+        int clamped = std::clamp(v, lo, hi);
+        LOG_WARN("OSCValidation", "OSC '%.*s': %s value %d out of range [%d, %d] — clamped to %d",
+            (int)path.size(), path.data(), paramName, v, lo, hi, clamped);
+        return clamped;
+    }
+    return v;
+}
+
+inline int ClampGain(int v, std::string_view p)        { return ClampInt(v,   0, 100, "gain",           p); }
+inline int ClampDSPosition(int v, std::string_view p)  { return ClampInt(v,   0,   9, "position",       p); }
+inline int ClampDSStrength(int v, std::string_view p)  { return ClampInt(v,   0,   8, "strength",       p); }
+inline int ClampDSAmplitude(int v, std::string_view p) { return ClampInt(v,   0,   8, "amplitude",      p); }
+inline int ClampDSFrequency(int v, std::string_view p) { return ClampInt(v,   0, 255, "frequency",      p); }
+inline int ClampDSStartPos(int v, std::string_view p)  { return ClampInt(v,   2,   7, "start_position", p); }
+inline int ClampDSEndPos(int v, std::string_view p)    { return ClampInt(v,   3,   8, "end_position",   p); }
+
+} // namespace OscValidation

--- a/src/Protocols/OscValidation.h
+++ b/src/Protocols/OscValidation.h
@@ -14,29 +14,32 @@
 
 #include "lo/lo_osc_types.h"
 #include "App/Log.h"
+#include <cstring>
 #include <string_view>
 #include <algorithm>
 
 namespace OscValidation {
 
+static constexpr const char* kTag = "OSCValidation";
+
 // ── Pointer safety ────────────────────────────────────────────────────────────
 
 inline bool CheckPointers(const char* path, const char* types, lo_arg** argv, int argc) {
     if (!path) {
-        LOG_WARN("OSCValidation", "Received OSC message with null path — ignored");
+        LOG_WARN(kTag, "Received OSC message with null path — ignored");
         return false;
     }
     if (!types) {
-        LOG_WARN("OSCValidation", "Received OSC message on '%s' with null type string — ignored", path);
+        LOG_WARN(kTag, "Received OSC message on '%s' with null type string — ignored", path);
         return false;
     }
     if (argc > 0 && !argv) {
-        LOG_WARN("OSCValidation", "Received OSC message on '%s' with argc=%d but null argv — ignored", path, argc);
+        LOG_WARN(kTag, "Received OSC message on '%s' with argc=%d but null argv — ignored", path, argc);
         return false;
     }
     for (int i = 0; i < argc; ++i) {
         if (!argv[i]) {
-            LOG_WARN("OSCValidation", "Received OSC message on '%s': argv[%d] is null — ignored", path, i);
+            LOG_WARN(kTag, "Received OSC message on '%s': argv[%d] is null — ignored", path, i);
             return false;
         }
     }
@@ -49,7 +52,7 @@ static constexpr int kMaxSlot = 255;
 
 inline bool ValidateSlot(int slot, std::string_view path) {
     if (slot < 0 || slot > kMaxSlot) {
-        LOG_WARN("OSCValidation", "OSC '%.*s': slot %d is out of range [0, %d] — ignored",
+        LOG_WARN(kTag, "OSC '%.*s': slot %d is out of range [0, %d] — ignored",
             (int)path.size(), path.data(), slot, kMaxSlot);
         return false;
     }
@@ -61,7 +64,7 @@ inline bool ValidateSlot(int slot, std::string_view path) {
 inline float Clamp(float v, float lo, float hi, const char* paramName, std::string_view path) {
     if (v < lo || v > hi) {
         float clamped = std::clamp(v, lo, hi);
-        LOG_WARN("OSCValidation", "OSC '%.*s': %s value %.4f out of range [%.1f, %.1f] — clamped to %.4f",
+        LOG_WARN(kTag, "OSC '%.*s': %s value %.4f out of range [%.1f, %.1f] — clamped to %.4f",
             (int)path.size(), path.data(), paramName, v, lo, hi, clamped);
         return clamped;
     }
@@ -76,7 +79,7 @@ inline float ClampStrength(float v, const char* n, std::string_view p) { return 
 
 inline bool ValidateWaveType(int idx, std::string_view path) {
     if (idx < 0 || idx > 4) {
-        LOG_WARN("OSCValidation", "OSC '%.*s': wave_type %d is out of range [0, 4] — ignored",
+        LOG_WARN(kTag, "OSC '%.*s': wave_type %d is out of range [0, 4] — ignored",
             (int)path.size(), path.data(), idx);
         return false;
     }
@@ -85,7 +88,7 @@ inline bool ValidateWaveType(int idx, std::string_view path) {
 
 inline bool ValidateConditionType(int idx, std::string_view path) {
     if (idx < 0 || idx > 3) {
-        LOG_WARN("OSCValidation", "OSC '%.*s': condition_type %d is out of range [0, 3] — ignored",
+        LOG_WARN(kTag, "OSC '%.*s': condition_type %d is out of range [0, 3] — ignored",
             (int)path.size(), path.data(), idx);
         return false;
     }
@@ -97,7 +100,7 @@ inline bool ValidateConditionType(int idx, std::string_view path) {
 inline int ClampInt(int v, int lo, int hi, const char* paramName, std::string_view path) {
     if (v < lo || v > hi) {
         int clamped = std::clamp(v, lo, hi);
-        LOG_WARN("OSCValidation", "OSC '%.*s': %s value %d out of range [%d, %d] — clamped to %d",
+        LOG_WARN(kTag, "OSC '%.*s': %s value %d out of range [%d, %d] — clamped to %d",
             (int)path.size(), path.data(), paramName, v, lo, hi, clamped);
         return clamped;
     }

--- a/src/Protocols/OscValidation.h
+++ b/src/Protocols/OscValidation.h
@@ -14,7 +14,6 @@
 
 #include "lo/lo_osc_types.h"
 #include "App/Log.h"
-#include <cstring>
 #include <string_view>
 #include <algorithm>
 

--- a/src/Protocols/ProtocolEditorWindow.cpp
+++ b/src/Protocols/ProtocolEditorWindow.cpp
@@ -21,6 +21,8 @@
 #include <cctype>
 #include <cstdio>
 
+static constexpr const char* kTag = "ProtocolEditor";
+
 namespace fs = std::filesystem;
 using json = nlohmann::json;
 
@@ -99,7 +101,7 @@ void ProtocolEditorWindow::LoadSettings() {
         }
     } catch (const std::exception& e) {
         // Silently ignore settings load errors
-        LOG_ERROR("ProtocolEditor", "Failed to load protocol editor settings: %s", e.what());
+        LOG_ERROR(kTag, "Failed to load protocol editor settings: %s", e.what());
     }
 }
 
@@ -112,7 +114,7 @@ void ProtocolEditorWindow::SaveSettings() {
         std::ofstream outputFile(SETTINGS_FILE);
         outputFile << settingsJson.dump(4);
     } catch (const std::exception& e) {
-        LOG_ERROR("ProtocolEditor", "Failed to save protocol editor settings: %s", e.what());
+        LOG_ERROR(kTag, "Failed to save protocol editor settings: %s", e.what());
     }
 }
 
@@ -807,7 +809,7 @@ void ProtocolEditorWindow::HandleDroppedFile(const std::string& filePath) {
     }
 
     if (ValidateAndImportProtocol(filePath)) {
-        LOG_INFO("ProtocolEditor", "Successfully imported protocol via drag-and-drop: %s", filePath.c_str());
+        LOG_INFO(kTag, "Successfully imported protocol via drag-and-drop: %s", filePath.c_str());
     }
 }
 
@@ -2069,11 +2071,11 @@ void ProtocolEditorWindow::CreateBackupBeforeOperation(const std::string& operat
     std::string catalogPath = ProtocolRegistry::GetProtocolsDir() + "/input_fields.json";
     std::string backupPath  = s_backupManager.CreateBackup(catalogPath);
     if (!backupPath.empty())
-        LOG_INFO("ProtocolEditor", "Created backup before %s: %s", operationName.c_str(), backupPath.c_str());
+        LOG_INFO(kTag, "Created backup before %s: %s", operationName.c_str(), backupPath.c_str());
 
     std::string defsBackup = s_backupManager.CreateDirectoryBackup(ProtocolRegistry::GetDefsDir());
     if (!defsBackup.empty())
-        LOG_INFO("ProtocolEditor", "Created definitions backup: %s", defsBackup.c_str());
+        LOG_INFO(kTag, "Created definitions backup: %s", defsBackup.c_str());
 }
 
 bool ProtocolEditorWindow::ValidateAndImportProtocol(const std::string& filePath) {
@@ -2512,9 +2514,9 @@ void ProtocolEditorWindow::DrawSaveTemplateModal() {
 
                     std::ofstream out(templatePath);
                     out << j.dump(4);
-                    LOG_INFO("ProtocolEditor", "Saved template: %s", templatePath.c_str());
+                    LOG_INFO(kTag, "Saved template: %s", templatePath.c_str());
                 } catch (const std::exception& e) {
-                    LOG_ERROR("ProtocolEditor", "Failed to save template: %s", e.what());
+                    LOG_ERROR(kTag, "Failed to save template: %s", e.what());
                 }
             }
             ImGui::CloseCurrentPopup();
@@ -2625,7 +2627,7 @@ void ProtocolEditorWindow::DrawLoadTemplateModal() {
                     registry.SaveDefinition(def);
                 }
             } catch (const std::exception& e) {
-                LOG_ERROR("ProtocolEditor", "Failed to load template: %s", e.what());
+                LOG_ERROR(kTag, "Failed to load template: %s", e.what());
             }
             ImGui::CloseCurrentPopup();
         }

--- a/src/Protocols/ProtocolRegistry.cpp
+++ b/src/Protocols/ProtocolRegistry.cpp
@@ -11,6 +11,8 @@
 #include <random>
 #include <SDL3/SDL_filesystem.h>
 
+static constexpr const char* kTag = "ProtocolRegistry";
+
 namespace fs = std::filesystem;
 using json = nlohmann::json;
 
@@ -418,7 +420,7 @@ void ProtocolRegistry::SaveDefinition(const ProtocolDefinition& def) {
     if (ofs) {
         ofs << j.dump(4);
     } else {
-    LOG_ERROR("ProtocolRegistry", "Failed to write %s", path.c_str());
+    LOG_ERROR(kTag, "Failed to write %s", path.c_str());
     }
 }
 
@@ -483,7 +485,7 @@ static void BootstrapFromInstallDir(const std::string& prefProtocolsDir) {
                 fs::copy_file(entry.path(), dstFile,
                               fs::copy_options::skip_existing, ec);
                 if (ec)
-                    LOG_ERROR("ProtocolRegistry", "Bootstrap copy failed for %s: %s",
+                    LOG_ERROR(kTag, "Bootstrap copy failed for %s: %s",
                               entry.path().string().c_str(), ec.message().c_str());
             }
         }
@@ -567,7 +569,7 @@ void ProtocolRegistry::LoadFieldCatalog() {
             }
         }
     } catch (const std::exception& e) {
-    LOG_ERROR("ProtocolRegistry", "Failed to parse input_fields.json: %s", e.what());
+    LOG_ERROR(kTag, "Failed to parse input_fields.json: %s", e.what());
     }
 }
 
@@ -733,7 +735,7 @@ void ProtocolRegistry::LoadDefinitionFiles() {
 
             m_definitions.push_back(def);
         } catch (const std::exception& e) {
-            LOG_ERROR("ProtocolRegistry", "Failed to parse %s: %s",
+            LOG_ERROR(kTag, "Failed to parse %s: %s",
                       entry.path().string().c_str(), e.what());
         }
     }
@@ -818,7 +820,7 @@ void ProtocolRegistry::LoadBuiltinCatalog() {
             }
         }
     } catch (const std::exception& e) {
-    LOG_ERROR("ProtocolRegistry", "Failed to parse builtin_fields.json: %s", e.what());
+    LOG_ERROR(kTag, "Failed to parse builtin_fields.json: %s", e.what());
     }
 }
 

--- a/src/UI/DebugLogPanel.cpp
+++ b/src/UI/DebugLogPanel.cpp
@@ -145,29 +145,14 @@ void DrawDebugLogContent() {
         for (int row = clipper.DisplayStart; row < clipper.DisplayEnd; ++row) {
             const auto& e = entries[s_visible[row]];
 
-            // Selectable gives ImGui a stable, unique item ID (required by
-            // BeginPopupContextItem) and also lets users click to highlight a
-            // line.  We draw it with zero vertical padding so it looks like
-            // plain text, then overlay the coloured text manually.
             ImGui::PushID(s_visible[row]);
 
-            const ImVec2 textSize = ImGui::CalcTextSize(e.text.c_str(), nullptr, false);
-            const float  lineH    = textSize.y + ImGui::GetStyle().ItemSpacing.y * 0.5f;
+            // Record the top-left of this row in screen space before rendering text.
+            const ImVec2 rowScreenMin = ImGui::GetCursorScreenPos();
+            const float  rowWidth     = ImGui::GetContentRegionAvail().x;
 
-            // Save the left edge before the Selectable consumes the full width.
-            const float textStartX = ImGui::GetCursorPosX();
-            const float textStartY = ImGui::GetCursorPosY();
-
-            ImGui::PushStyleColor(ImGuiCol_Header,        ImVec4(1,1,1,0.08f));
-            ImGui::PushStyleColor(ImGuiCol_HeaderHovered, ImVec4(1,1,1,0.12f));
-            ImGui::PushStyleColor(ImGuiCol_HeaderActive,  ImVec4(1,1,1,0.20f));
-            ImGui::Selectable("##row", false,
-                              ImGuiSelectableFlags_None,
-                              ImVec2(ImGui::GetContentRegionAvail().x, lineH));
-            ImGui::PopStyleColor(3);
-
-            // Overlay the log text at the saved left edge in the correct colour.
-            ImGui::SetCursorPos(ImVec2(textStartX, textStartY));
+            // 1. Render the coloured text first — this advances the cursor naturally
+            //    so no rewinding is needed and row height is always correct.
             ImGui::PushStyleColor(ImGuiCol_Text, LevelColour(e.level));
             if (s_wordWrap)
                 ImGui::TextWrapped("%s", e.text.c_str());
@@ -175,7 +160,29 @@ void DrawDebugLogContent() {
                 ImGui::TextUnformatted(e.text.c_str());
             ImGui::PopStyleColor();
 
-            // Right-click context menu — ID comes from the Selectable above.
+            // 2. Now we know the row's screen-space bounds. Draw a hover/click
+            //    highlight behind the text using the draw list, and register an
+            //    InvisibleButton over the same rect for hover detection and the
+            //    right-click context menu.
+            const ImVec2 rowScreenMax = ImVec2(rowScreenMin.x + rowWidth,
+                                               ImGui::GetCursorScreenPos().y);
+            const float  rowH         = rowScreenMax.y - rowScreenMin.y;
+
+            ImGui::SetCursorScreenPos(rowScreenMin);
+            ImGui::InvisibleButton("##hit", ImVec2(rowWidth, rowH));
+
+            if (ImGui::IsItemHovered()) {
+                ImGui::GetWindowDrawList()->AddRectFilled(
+                    rowScreenMin, rowScreenMax,
+                    IM_COL32(255, 255, 255, 20));
+            }
+            if (ImGui::IsItemActive()) {
+                ImGui::GetWindowDrawList()->AddRectFilled(
+                    rowScreenMin, rowScreenMax,
+                    IM_COL32(255, 255, 255, 40));
+            }
+
+            // Right-click context menu.
             if (ImGui::BeginPopupContextItem("##ctx")) {
                 if (ImGui::MenuItem("Copy line"))
                     SDL_SetClipboardText(e.text.c_str());

--- a/src/UI/DevicePanel.cpp
+++ b/src/UI/DevicePanel.cpp
@@ -55,7 +55,7 @@ static void DrawDeviceSettingsTab(const DeviceState&  dev,
         ImGui::SetTooltip(
             "Re-uploads active infinite-duration effects every 30 s.\n"
             "Required for devices that truncate SDL_HAPTIC_INFINITY to ~65 s\n"
-            "Untested on any other device than Thrustmaster T150!"
+            "(e.g. Thrustmaster T150). Safe to enable on any device."
         );
     }
 }

--- a/src/UI/DevicePanel.cpp
+++ b/src/UI/DevicePanel.cpp
@@ -23,6 +23,44 @@
 static constexpr const char* kTag = "DevicePanel";
 
 // ---------------------------------------------------------------------------
+// DrawDeviceSettingsTab
+// ---------------------------------------------------------------------------
+// Draws the contents of the per-device "Settings" tab. Currently this just
+// hosts the "Infinite-effect keepalive" toggle, which used to live on each
+// Haptic Test tab individually.
+
+static void DrawDeviceSettingsTab(const DeviceState&  dev,
+                                   DeviceManager&      deviceManager,
+                                   PreferencesManager& prefs,
+                                   const std::string&  guid)
+{
+    HapticDevice* haptic = deviceManager.GetHapticDevice(dev.instance_id);
+
+    if (!haptic) {
+        ImGui::TextDisabled("No device-specific settings available.");
+        return;
+    }
+
+    // Restore saved preference once when the device first appears.
+    if (!prefs.IsPreferenceApplied(dev.instance_id)) {
+        haptic->EnableKeepalive(prefs.GetDeviceKeepalive(guid));
+    }
+
+    bool keepalive = haptic->IsKeepaliveEnabled();
+    if (ImGui::Checkbox("Infinite-effect keepalive", &keepalive)) {
+        deviceManager.SetDeviceKeepalive(dev.instance_id, keepalive);
+        prefs.SetDeviceKeepalive(guid, keepalive);
+    }
+    if (ImGui::IsItemHovered()) {
+        ImGui::SetTooltip(
+            "Re-uploads active infinite-duration effects every 30 s.\n"
+            "Required for devices that truncate SDL_HAPTIC_INFINITY to ~65 s\n"
+            "Untested on any other device than Thrustmaster T150!"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
 // DrawDeviceVisualizer
 // ---------------------------------------------------------------------------
 
@@ -108,6 +146,11 @@ void DrawDeviceVisualizer(const DeviceState&  dev,
                     TabItem("Sensors", sensor_viz);
             }
 
+            if (ImGui::BeginTabItem("Settings")) {
+                DrawDeviceSettingsTab(dev, deviceManager, prefs, guid);
+                ImGui::EndTabItem();
+            }
+
             SimulateTab();
             ImGui::EndTabBar();
         }
@@ -144,6 +187,11 @@ void DrawDeviceVisualizer(const DeviceState&  dev,
                         ImGui::EndTabItem();
                     }
                 }
+            }
+
+            if (ImGui::BeginTabItem("Settings")) {
+                DrawDeviceSettingsTab(dev, deviceManager, prefs, guid);
+                ImGui::EndTabItem();
             }
 
             SimulateTab();

--- a/src/UI/DevicePanel.cpp
+++ b/src/UI/DevicePanel.cpp
@@ -191,7 +191,7 @@ static void DrawDeviceHideControls(DeviceState& dev, DeviceManager& deviceManage
 
     if (ImGui::Checkbox("Hide from other applications", &hidden)) {
         if (!deviceManager.SetDeviceHidden(dev, hidden)) {
-            LOG_INFO("DevicePanel", "SetDeviceHidden failed for '%s'.", dev.name.c_str());
+            LOG_WARN("DevicePanel", "SetDeviceHidden failed for '%s'.", dev.name.c_str());
         }
     }
 

--- a/src/UI/DevicePanel.cpp
+++ b/src/UI/DevicePanel.cpp
@@ -88,7 +88,7 @@ void DrawDeviceVisualizer(const DeviceState&  dev,
         if (ImGui::BeginTabBar("DeviceMode")) {
             TabItem("Raw Inputs", generic_viz);
             if (ImGui::BeginTabItem("Haptic Test")) {
-                gamepad_haptics_viz.Draw(dev, deviceManager);
+                gamepad_haptics_viz.Draw(dev, deviceManager, prefs, guid);
                 ImGui::EndTabItem();
             }
 
@@ -120,7 +120,7 @@ void DrawDeviceVisualizer(const DeviceState&  dev,
             if (type == SDL_JOYSTICK_TYPE_FLIGHT_STICK
                 || type == SDL_JOYSTICK_TYPE_THROTTLE) {
                 if (ImGui::BeginTabItem("Haptic Test")) {
-                    flight_stick_haptics_viz.Draw(dev, deviceManager);
+                    flight_stick_haptics_viz.Draw(dev, deviceManager, prefs, guid);
                     ImGui::EndTabItem();
                 }
             }
@@ -130,7 +130,7 @@ void DrawDeviceVisualizer(const DeviceState&  dev,
             }
             if (type == SDL_JOYSTICK_TYPE_WHEEL) {
                 if (ImGui::BeginTabItem("Haptic Test")) {
-                    wheel_haptics_viz.Draw(dev, deviceManager);
+                    wheel_haptics_viz.Draw(dev, deviceManager, prefs, guid);
                     ImGui::EndTabItem();
                 }
             }

--- a/src/UI/DevicePanel.cpp
+++ b/src/UI/DevicePanel.cpp
@@ -20,6 +20,8 @@
 
 #include <string>
 
+static constexpr const char* kTag = "DevicePanel";
+
 // ---------------------------------------------------------------------------
 // DrawDeviceVisualizer
 // ---------------------------------------------------------------------------
@@ -191,7 +193,7 @@ static void DrawDeviceHideControls(DeviceState& dev, DeviceManager& deviceManage
 
     if (ImGui::Checkbox("Hide from other applications", &hidden)) {
         if (!deviceManager.SetDeviceHidden(dev, hidden)) {
-            LOG_WARN("DevicePanel", "SetDeviceHidden failed for '%s'.", dev.name.c_str());
+            LOG_WARN(kTag, "SetDeviceHidden failed for '%s'.", dev.name.c_str());
         }
     }
 

--- a/src/UI/FontManager.cpp
+++ b/src/UI/FontManager.cpp
@@ -60,7 +60,7 @@ void RebuildFontAtlas()
         base_font = io.Fonts->AddFontFromFileTTF(fontPath.c_str(), themeFontSize);
         loaded_theme_font = (base_font != nullptr);
         if (!loaded_theme_font)
-            LOG_INFO("FontManager", "Font: Failed to load '%s' — falling back to default.",
+            LOG_WARN("FontManager", "Font: Failed to load '%s' — falling back to default.",
                     fontPath.c_str());
     }
     if (!loaded_theme_font)
@@ -97,7 +97,7 @@ void RebuildFontAtlas()
             iconFontPath.c_str(), merge_size, &cfg, icon_ranges);
 
         if (!icons)
-            LOG_INFO("FontManager", "Font: FA6 not found at '%s' — icon glyphs will be missing.",
+            LOG_WARN("FontManager", "Font: FA6 not found at '%s' — icon glyphs will be missing.",
                     iconFontPath.c_str());
     }
 

--- a/src/UI/FontManager.cpp
+++ b/src/UI/FontManager.cpp
@@ -8,6 +8,8 @@
 
 #include <string>
 
+static constexpr const char* kTag = "FontManager";
+
 void UpdateUIScale(SDL_Window*         window,
                    float&              user_ui_scale,
                    float&              user_font_scale,
@@ -60,7 +62,7 @@ void RebuildFontAtlas()
         base_font = io.Fonts->AddFontFromFileTTF(fontPath.c_str(), themeFontSize);
         loaded_theme_font = (base_font != nullptr);
         if (!loaded_theme_font)
-            LOG_WARN("FontManager", "Font: Failed to load '%s' — falling back to default.",
+            LOG_WARN(kTag, "Font: Failed to load '%s' — falling back to default.",
                     fontPath.c_str());
     }
     if (!loaded_theme_font)
@@ -97,7 +99,7 @@ void RebuildFontAtlas()
             iconFontPath.c_str(), merge_size, &cfg, icon_ranges);
 
         if (!icons)
-            LOG_WARN("FontManager", "Font: FA6 not found at '%s' — icon glyphs will be missing.",
+            LOG_WARN(kTag, "Font: FA6 not found at '%s' — icon glyphs will be missing.",
                     iconFontPath.c_str());
     }
 

--- a/src/UI/ThemeManager.cpp
+++ b/src/UI/ThemeManager.cpp
@@ -7,6 +7,8 @@
 #include <algorithm>
 #include <unordered_map>
 
+static constexpr const char* kTag = "ThemeManager";
+
 using json = nlohmann::json;
 namespace fs = std::filesystem;
 using namespace InputBridge;
@@ -30,7 +32,7 @@ void ThemeManager::ScanThemesDirectory(const std::string& basePath) {
 
     fs::path themesDir = fs::path(basePath) / "themes";
     if (!fs::exists(themesDir) || !fs::is_directory(themesDir)) {
-        LOG_INFO("ThemeManager", "Themes directory not found: %s", themesDir.string().c_str());
+        LOG_INFO(kTag, "Themes directory not found: %s", themesDir.string().c_str());
         return;
     }
 
@@ -48,12 +50,12 @@ void ThemeManager::ScanThemesDirectory(const std::string& basePath) {
         if (te.displayName.empty())
             te.displayName = p.stem().string();
         m_entries.push_back(std::move(te));
-        LOG_INFO("ThemeManager", "Found theme: %s (%s)",
+        LOG_INFO(kTag, "Found theme: %s (%s)",
                 m_entries.back().displayName.c_str(),
                 m_entries.back().path.c_str());
     }
 
-    LOG_INFO("ThemeManager", "Scanned %d theme(s) from %s",
+    LOG_INFO(kTag, "Scanned %d theme(s) from %s",
             (int)m_entries.size(), themesDir.string().c_str());
 
     // Refresh the index pointer if the active theme is still present.
@@ -89,11 +91,11 @@ void ThemeManager::ResolveFontPath(const ThemeData& data) {
     if (fs::exists(resolved) && fs::is_regular_file(resolved)) {
         m_resolvedFontPath = resolved.string();
         m_fontSize         = data.fontSize > 0.f ? data.fontSize : 16.f;
-        LOG_INFO("ThemeManager", "Font resolved: %s @ %.1fpx",
+        LOG_INFO(kTag, "Font resolved: %s @ %.1fpx",
                 m_resolvedFontPath.c_str(), m_fontSize);
     } else {
         // File not found — fall back to ImGui default silently.
-        LOG_WARN("ThemeManager", "Font file not found (%s) — using default font.",
+        LOG_WARN(kTag, "Font file not found (%s) — using default font.",
                 resolved.string().c_str());
         m_resolvedFontPath.clear();
         m_fontSize = 16.f;
@@ -108,7 +110,7 @@ Result<bool, std::string> ThemeManager::LoadFromFile(const std::string& path) {
     auto result = ParseFile(path);
     if (result.IsErr()) {
         m_lastError = result.Error();
-        LOG_WARN("ThemeManager", "Failed to load theme '%s': %s",
+        LOG_WARN(kTag, "Failed to load theme '%s': %s",
                 path.c_str(), m_lastError.c_str());
         return Result<bool, std::string>::Err(m_lastError);
     }
@@ -131,7 +133,7 @@ Result<bool, std::string> ThemeManager::LoadFromFile(const std::string& path) {
     ResolveFontPath(m_current);
     m_pendingFontChange = true;
 
-    LOG_INFO("ThemeManager", "Applied theme '%s' from '%s'",
+    LOG_INFO(kTag, "Applied theme '%s' from '%s'",
             m_themeName.c_str(), path.c_str());
     return Result<bool, std::string>::Ok(true);
 }
@@ -229,7 +231,7 @@ void ThemeManager::LoadFromPreferences(PreferencesManager& prefs) {
             if (fs::exists(resonitePath)) {
                 auto result = LoadFromFile(resonitePath.string());
                 if (result.IsOk()) {
-                    LOG_INFO("ThemeManager", "No saved theme — applied Resonite as default.");
+                    LOG_INFO(kTag, "No saved theme — applied Resonite as default.");
                     return;
                 }
             }
@@ -244,7 +246,7 @@ void ThemeManager::LoadFromPreferences(PreferencesManager& prefs) {
 
     auto result = LoadFromFile(path);
     if (result.IsErr()) {
-        LOG_WARN("ThemeManager", "Saved theme could not be restored: %s — using default.",
+        LOG_WARN(kTag, "Saved theme could not be restored: %s — using default.",
                 result.Error().c_str());
         prefs.DeleteKey("Theme", "ThemePath");
     }

--- a/src/UI/ThemeManager.cpp
+++ b/src/UI/ThemeManager.cpp
@@ -93,7 +93,7 @@ void ThemeManager::ResolveFontPath(const ThemeData& data) {
                 m_resolvedFontPath.c_str(), m_fontSize);
     } else {
         // File not found — fall back to ImGui default silently.
-        LOG_INFO("ThemeManager", "Font file not found (%s) — using default font.",
+        LOG_WARN("ThemeManager", "Font file not found (%s) — using default font.",
                 resolved.string().c_str());
         m_resolvedFontPath.clear();
         m_fontSize = 16.f;
@@ -108,7 +108,7 @@ Result<bool, std::string> ThemeManager::LoadFromFile(const std::string& path) {
     auto result = ParseFile(path);
     if (result.IsErr()) {
         m_lastError = result.Error();
-        LOG_INFO("ThemeManager", "Failed to load theme '%s': %s",
+        LOG_WARN("ThemeManager", "Failed to load theme '%s': %s",
                 path.c_str(), m_lastError.c_str());
         return Result<bool, std::string>::Err(m_lastError);
     }
@@ -244,7 +244,7 @@ void ThemeManager::LoadFromPreferences(PreferencesManager& prefs) {
 
     auto result = LoadFromFile(path);
     if (result.IsErr()) {
-        LOG_INFO("ThemeManager", "Saved theme could not be restored: %s — using default.",
+        LOG_WARN("ThemeManager", "Saved theme could not be restored: %s — using default.",
                 result.Error().c_str());
         prefs.DeleteKey("Theme", "ThemePath");
     }

--- a/src/Utils/SDLHandles.h
+++ b/src/Utils/SDLHandles.h
@@ -168,7 +168,7 @@ public:
             m_haptic.Reset(SDL_OpenHapticFromJoystick(m_joystick));
             
             if (!m_haptic) {
-                LOG_INFO("SDLHandles", "Failed to open haptic: %s", SDL_GetError());
+                LOG_WARN("SDLHandles", "Failed to open haptic: %s", SDL_GetError());
                 return false;
             }
             

--- a/src/Utils/SDLHandles.h
+++ b/src/Utils/SDLHandles.h
@@ -4,6 +4,8 @@
 
 namespace InputBridge {
 
+static constexpr const char* kTag = "SDLHandles";
+
 /**
  * @brief RAII wrapper for SDL resource handles with custom deleters
  * 
@@ -168,7 +170,7 @@ public:
             m_haptic.Reset(SDL_OpenHapticFromJoystick(m_joystick));
             
             if (!m_haptic) {
-                LOG_WARN("SDLHandles", "Failed to open haptic: %s", SDL_GetError());
+                LOG_WARN(kTag, "Failed to open haptic: %s", SDL_GetError());
                 return false;
             }
             

--- a/src/Visualizers/FlightStickHapticsVisualizer.cpp
+++ b/src/Visualizers/FlightStickHapticsVisualizer.cpp
@@ -52,6 +52,22 @@ void FlightStickHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager& d
     ImGui::Separator();
     ImGui::Text("Haptics Test");
 
+    // ── Keepalive toggle ─────────────────────────────────────────────────────
+    if (haptic) {
+        bool keepalive = haptic->IsKeepaliveEnabled();
+        if (ImGui::Checkbox("Infinite-effect keepalive", &keepalive)) {
+            deviceManager.SetDeviceKeepalive(dev.instance_id, keepalive);
+        }
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip(
+                "Re-uploads active infinite-duration effects every 30 s.\n"
+                "Required for devices that truncate SDL_HAPTIC_INFINITY to ~65 s\n"
+                "(e.g. Thrustmaster T150). Safe to enable on any device."
+            );
+        }
+        ImGui::Spacing();
+    }
+
     auto* fsHaptics = dynamic_cast<FlightStickHaptics*>(haptic);
     if (!fsHaptics) {
         ImGui::TextDisabled("Flight Stick Haptics not available.");

--- a/src/Visualizers/FlightStickHapticsVisualizer.cpp
+++ b/src/Visualizers/FlightStickHapticsVisualizer.cpp
@@ -53,27 +53,6 @@ void FlightStickHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager& d
     ImGui::Separator();
     ImGui::Text("Haptics Test");
 
-    // ── Keepalive toggle ─────────────────────────────────────────────────────
-    if (haptic) {
-        if (!prefs.IsPreferenceApplied(dev.instance_id)) {
-            haptic->EnableKeepalive(prefs.GetDeviceKeepalive(guid));
-        }
-
-        bool keepalive = haptic->IsKeepaliveEnabled();
-        if (ImGui::Checkbox("Infinite-effect keepalive", &keepalive)) {
-            deviceManager.SetDeviceKeepalive(dev.instance_id, keepalive);
-            prefs.SetDeviceKeepalive(guid, keepalive);
-        }
-        if (ImGui::IsItemHovered()) {
-            ImGui::SetTooltip(
-                "Re-uploads active infinite-duration effects every 30 s.\n"
-                "Required for devices that truncate SDL_HAPTIC_INFINITY to ~65 s\n"
-                "(e.g. Thrustmaster T150). Safe to enable on any device."
-            );
-        }
-        ImGui::Spacing();
-    }
-
     auto* fsHaptics = dynamic_cast<FlightStickHaptics*>(haptic);
     if (!fsHaptics) {
         ImGui::TextDisabled("Flight Stick Haptics not available.");

--- a/src/Visualizers/FlightStickHapticsVisualizer.cpp
+++ b/src/Visualizers/FlightStickHapticsVisualizer.cpp
@@ -3,7 +3,8 @@
 #include "Haptics/FlightStickHaptics.h"
 #include <SDL3/SDL.h>
 
-void FlightStickHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager& deviceManager) {
+void FlightStickHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager& deviceManager,
+                                        PreferencesManager& prefs, const std::string& guid) {
     HapticDevice* haptic = deviceManager.GetHapticDevice(dev.instance_id);
 
     // --- Status bar ---
@@ -54,9 +55,14 @@ void FlightStickHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager& d
 
     // ── Keepalive toggle ─────────────────────────────────────────────────────
     if (haptic) {
+        if (!prefs.IsPreferenceApplied(dev.instance_id)) {
+            haptic->EnableKeepalive(prefs.GetDeviceKeepalive(guid));
+        }
+
         bool keepalive = haptic->IsKeepaliveEnabled();
         if (ImGui::Checkbox("Infinite-effect keepalive", &keepalive)) {
             deviceManager.SetDeviceKeepalive(dev.instance_id, keepalive);
+            prefs.SetDeviceKeepalive(guid, keepalive);
         }
         if (ImGui::IsItemHovered()) {
             ImGui::SetTooltip(

--- a/src/Visualizers/FlightStickHapticsVisualizer.h
+++ b/src/Visualizers/FlightStickHapticsVisualizer.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "Devices/DeviceState.h"
 #include "Devices/DeviceManager.h"
+#include "Preferences/Preferences.h"
 
 /**
  * @class FlightStickHapticsVisualizer
@@ -17,7 +18,8 @@
  */
 class FlightStickHapticsVisualizer {
 public:
-    void Draw(const DeviceState& dev, DeviceManager& deviceManager);
+    void Draw(const DeviceState& dev, DeviceManager& deviceManager,
+              PreferencesManager& prefs, const std::string& guid);
 
 private:
     // --- Constant Force ---

--- a/src/Visualizers/GamepadHapticsVisualizer.cpp
+++ b/src/Visualizers/GamepadHapticsVisualizer.cpp
@@ -1,4 +1,4 @@
-#include "App/Log.h"
+//#include "App/Log.h" // currently unused expect for the adaptive trigger part
 #include "GamepadHapticsVisualizer.h"
 #include "imgui.h"
 #include "Haptics/GamepadHaptics.h"

--- a/src/Visualizers/GamepadHapticsVisualizer.cpp
+++ b/src/Visualizers/GamepadHapticsVisualizer.cpp
@@ -4,6 +4,8 @@
 #include "Haptics/GamepadHaptics.h"
 #include <SDL3/SDL.h>
 
+static constexpr const char* kTag = "GamepadHapticsViz";
+
 void GamepadHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager& deviceManager) {
     HapticDevice* haptic = deviceManager.GetHapticDevice(dev.instance_id);
     if (haptic) {
@@ -301,7 +303,7 @@ void GamepadHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager& devic
                 }
                 
                 int result = gamepadHaptics->PlayDualSenseTrigger("left", leftEffectName, leftParams);
-                LOG_DEBUG("GamepadHapticsViz", "Left trigger effect '%s' result: %d", leftEffectName.c_str(), result);
+                LOG_DEBUG(kTag, "Left trigger effect '%s' result: %d", leftEffectName.c_str(), result);
                 
                 // Send right trigger effect
                 std::map<std::string, int> rightParams;
@@ -346,7 +348,7 @@ void GamepadHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager& devic
                 }
                 
                 result = gamepadHaptics->PlayDualSenseTrigger("right", rightEffectName, rightParams);
-                LOG_DEBUG("GamepadHapticsViz", "Right trigger effect '%s' result: %d", rightEffectName.c_str(), result);
+                LOG_DEBUG(kTag, "Right trigger effect '%s' result: %d", rightEffectName.c_str(), result);
             }
         }
     }

--- a/src/Visualizers/GamepadHapticsVisualizer.cpp
+++ b/src/Visualizers/GamepadHapticsVisualizer.cpp
@@ -38,28 +38,6 @@ void GamepadHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager& devic
     ImGui::Separator();
     ImGui::Text("Haptics Test");
 
-    // ── Keepalive toggle ─────────────────────────────────────────────────────
-    if (haptic) {
-        // Restore saved preference once when the device first appears.
-        if (!prefs.IsPreferenceApplied(dev.instance_id)) {
-            haptic->EnableKeepalive(prefs.GetDeviceKeepalive(guid));
-        }
-
-        bool keepalive = haptic->IsKeepaliveEnabled();
-        if (ImGui::Checkbox("Infinite-effect keepalive", &keepalive)) {
-            deviceManager.SetDeviceKeepalive(dev.instance_id, keepalive);
-            prefs.SetDeviceKeepalive(guid, keepalive);
-        }
-        if (ImGui::IsItemHovered()) {
-            ImGui::SetTooltip(
-                "Re-uploads active infinite-duration effects every 30 s.\n"
-                "Required for devices that truncate SDL_HAPTIC_INFINITY to ~65 s\n"
-                "(e.g. Thrustmaster T150). Safe to enable on any device."
-            );
-        }
-        ImGui::Spacing();
-    }
-
     auto* gamepadHaptics = haptic ? dynamic_cast<GamepadHaptics*>(haptic) : nullptr;
 
     // Slot selector: when it changes, populate fields from the running state.

--- a/src/Visualizers/GamepadHapticsVisualizer.cpp
+++ b/src/Visualizers/GamepadHapticsVisualizer.cpp
@@ -6,7 +6,8 @@
 
 static constexpr const char* kTag = "GamepadHapticsViz";
 
-void GamepadHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager& deviceManager) {
+void GamepadHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager& deviceManager,
+                                    PreferencesManager& prefs, const std::string& guid) {
     HapticDevice* haptic = deviceManager.GetHapticDevice(dev.instance_id);
     if (haptic) {
         if (haptic->IsReady() && dev.joystick) {
@@ -38,12 +39,16 @@ void GamepadHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager& devic
     ImGui::Text("Haptics Test");
 
     // ── Keepalive toggle ─────────────────────────────────────────────────────
-    // Some devices (e.g. Thrustmaster T150) silently truncate SDL_HAPTIC_INFINITY
-    // to ~65 s. When enabled, active INFINITY effects are re-uploaded every 30 s.
     if (haptic) {
+        // Restore saved preference once when the device first appears.
+        if (!prefs.IsPreferenceApplied(dev.instance_id)) {
+            haptic->EnableKeepalive(prefs.GetDeviceKeepalive(guid));
+        }
+
         bool keepalive = haptic->IsKeepaliveEnabled();
         if (ImGui::Checkbox("Infinite-effect keepalive", &keepalive)) {
             deviceManager.SetDeviceKeepalive(dev.instance_id, keepalive);
+            prefs.SetDeviceKeepalive(guid, keepalive);
         }
         if (ImGui::IsItemHovered()) {
             ImGui::SetTooltip(

--- a/src/Visualizers/GamepadHapticsVisualizer.cpp
+++ b/src/Visualizers/GamepadHapticsVisualizer.cpp
@@ -35,26 +35,60 @@ void GamepadHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager& devic
     ImGui::Separator();
     ImGui::Text("Haptics Test");
 
-    ImGui::SliderInt("Slot##rumble", &m_rumble_slot, 0, 7);
-    ImGui::SliderFloat("Low Freq", &m_low_freq, 0.0f, 1.0f);
-    ImGui::SliderFloat("High Freq", &m_high_freq, 0.0f, 1.0f);
-    ImGui::Checkbox("Infinite Duration", &m_infinite_duration);
-    if (!m_infinite_duration) {
-        ImGui::SliderInt("Duration (ms)", &m_duration, 0, 5000);
-    }
+    auto* gamepadHaptics = haptic ? dynamic_cast<GamepadHaptics*>(haptic) : nullptr;
 
-    if (ImGui::Button("Play Rumble")) {
-        if (haptic) {
-            if (auto *gamepadHaptics = dynamic_cast<GamepadHaptics *>(haptic)) {
-                gamepadHaptics->PlayRumble(m_rumble_slot, m_low_freq, m_high_freq,
-                                           m_infinite_duration ? SDL_HAPTIC_INFINITY : (uint32_t)m_duration);
-            }
+    // Slot selector: when it changes, populate fields from the running state.
+    int prev_rumble_slot = m_rumble_slot;
+    ImGui::SliderInt("Slot##rumble", &m_rumble_slot, 0, 7);
+    if (gamepadHaptics && m_rumble_slot != prev_rumble_slot) {
+        auto active_rumbles = gamepadHaptics->GetActiveRumbles();
+        auto it = active_rumbles.find(m_rumble_slot);
+        if (it != active_rumbles.end() && it->second.active) {
+            m_low_freq          = it->second.large_magnitude;
+            m_high_freq         = it->second.small_magnitude;
+            m_infinite_duration = (it->second.duration_ms == SDL_HAPTIC_INFINITY);
+            if (!m_infinite_duration)
+                m_duration = static_cast<int>(it->second.duration_ms);
         }
     }
 
-    if (auto* gamepadHaptics = dynamic_cast<GamepadHaptics*>(haptic)) {
+    bool rumble_changed = false;
+    rumble_changed |= ImGui::SliderFloat("Low Freq",  &m_low_freq,  0.0f, 1.0f);
+    rumble_changed |= ImGui::SliderFloat("High Freq", &m_high_freq, 0.0f, 1.0f);
+    rumble_changed |= ImGui::Checkbox("Infinite Duration", &m_infinite_duration);
+    if (!m_infinite_duration)
+        rumble_changed |= ImGui::SliderInt("Duration (ms)", &m_duration, 0, 5000);
+
+    // Live-update if this slot is already active and any value changed.
+    if (gamepadHaptics && rumble_changed) {
+        auto active_rumbles = gamepadHaptics->GetActiveRumbles();
+        auto it = active_rumbles.find(m_rumble_slot);
+        if (it != active_rumbles.end() && it->second.active) {
+            gamepadHaptics->PlayRumble(m_rumble_slot, m_low_freq, m_high_freq,
+                                       m_infinite_duration ? SDL_HAPTIC_INFINITY
+                                                           : (uint32_t)m_duration);
+        }
+    }
+
+    // Show active indicator for current slot.
+    if (gamepadHaptics) {
+        auto active_rumbles = gamepadHaptics->GetActiveRumbles();
+        auto it = active_rumbles.find(m_rumble_slot);
+        if (it != active_rumbles.end() && it->second.active)
+            ImGui::TextColored(ImVec4(0.0f, 1.0f, 0.0f, 1.0f), "● Slot %d active — editing live", m_rumble_slot);
+    }
+
+    if (ImGui::Button("Play Rumble")) {
+        if (gamepadHaptics) {
+            gamepadHaptics->PlayRumble(m_rumble_slot, m_low_freq, m_high_freq,
+                                       m_infinite_duration ? SDL_HAPTIC_INFINITY : (uint32_t)m_duration);
+        }
+    }
+
+    if (gamepadHaptics) {
         ImGui::Separator();
         ImGui::Text("Active Haptic Effects");
+        ImGui::TextDisabled("Click a slot header to load its values into the editor above.");
         if (ImGui::BeginChild("ActiveHaptics", ImVec2(0, 150), true)) {
             bool anyActive = false;
 
@@ -63,8 +97,22 @@ void GamepadHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager& devic
             for (const auto& [slot, info] : active_rumbles) {
                 if (!info.active) continue;
                 anyActive = true;
-                if (ImGui::TreeNodeEx((void*)(intptr_t)(slot + 1000), ImGuiTreeNodeFlags_DefaultOpen,
-                                     "Rumble [slot %d]", slot)) {
+                bool selected = (m_rumble_slot == slot);
+                ImGui::PushStyleColor(ImGuiCol_Header,        selected ? ImVec4(0.2f,0.6f,0.2f,0.4f) : ImVec4(0,0,0,0));
+                ImGui::PushStyleColor(ImGuiCol_HeaderHovered, ImVec4(0.2f,0.6f,0.2f,0.3f));
+                bool open = ImGui::TreeNodeEx((void*)(intptr_t)(slot + 1000),
+                                             ImGuiTreeNodeFlags_SpanAvailWidth,
+                                             "Rumble [slot %d]", slot);
+                ImGui::PopStyleColor(2);
+                if (ImGui::IsItemClicked()) {
+                    m_rumble_slot       = slot;
+                    m_low_freq          = info.large_magnitude;
+                    m_high_freq         = info.small_magnitude;
+                    m_infinite_duration = (info.duration_ms == SDL_HAPTIC_INFINITY);
+                    if (!m_infinite_duration)
+                        m_duration = static_cast<int>(info.duration_ms);
+                }
+                if (open) {
                     ImGui::Text("Large Motor: %.3f", info.large_magnitude);
                     ImGui::Text("Small Motor: %.3f", info.small_magnitude);
                     if (info.duration_ms == SDL_HAPTIC_INFINITY)

--- a/src/Visualizers/GamepadHapticsVisualizer.cpp
+++ b/src/Visualizers/GamepadHapticsVisualizer.cpp
@@ -37,6 +37,24 @@ void GamepadHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager& devic
     ImGui::Separator();
     ImGui::Text("Haptics Test");
 
+    // ── Keepalive toggle ─────────────────────────────────────────────────────
+    // Some devices (e.g. Thrustmaster T150) silently truncate SDL_HAPTIC_INFINITY
+    // to ~65 s. When enabled, active INFINITY effects are re-uploaded every 30 s.
+    if (haptic) {
+        bool keepalive = haptic->IsKeepaliveEnabled();
+        if (ImGui::Checkbox("Infinite-effect keepalive", &keepalive)) {
+            deviceManager.SetDeviceKeepalive(dev.instance_id, keepalive);
+        }
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip(
+                "Re-uploads active infinite-duration effects every 30 s.\n"
+                "Required for devices that truncate SDL_HAPTIC_INFINITY to ~65 s\n"
+                "(e.g. Thrustmaster T150). Safe to enable on any device."
+            );
+        }
+        ImGui::Spacing();
+    }
+
     auto* gamepadHaptics = haptic ? dynamic_cast<GamepadHaptics*>(haptic) : nullptr;
 
     // Slot selector: when it changes, populate fields from the running state.

--- a/src/Visualizers/GamepadHapticsVisualizer.h
+++ b/src/Visualizers/GamepadHapticsVisualizer.h
@@ -1,10 +1,12 @@
 #pragma once
 #include "Devices/DeviceState.h"
 #include "Devices/DeviceManager.h"
+#include "Preferences/Preferences.h"
 
 class GamepadHapticsVisualizer {
 public:
-    void Draw(const DeviceState& dev, DeviceManager& deviceManager);
+    void Draw(const DeviceState& dev, DeviceManager& deviceManager,
+              PreferencesManager& prefs, const std::string& guid);
 
 private:
     // Rumble

--- a/src/Visualizers/SteeringWheelHapticsVisualizer.cpp
+++ b/src/Visualizers/SteeringWheelHapticsVisualizer.cpp
@@ -4,6 +4,49 @@
 #include "wheel/utils/rpm_mapper.hpp"
 #include <SDL3/SDL.h>
 
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+// Populate the Constant edit fields from an active slot's recorded state.
+void SteeringWheelHapticsVisualizer::LoadConstantFromActive(const ActiveConstantInfo& info) {
+    m_constant_strength          = info.strength;
+    m_constant_infinite_duration = (info.duration_ms == SDL_HAPTIC_INFINITY);
+    if (!m_constant_infinite_duration)
+        m_constant_duration = static_cast<int>(info.duration_ms);
+}
+
+// Populate the Periodic edit fields from an active slot's recorded state.
+void SteeringWheelHapticsVisualizer::LoadPeriodicFromActive(const ActivePeriodicInfo& info) {
+    m_periodic_wave_type         = static_cast<int>(info.wave_type);
+    m_periodic_strength          = info.strength;
+    m_periodic_period            = static_cast<int>(info.period);
+    m_periodic_magnitude         = info.magnitude;
+    m_periodic_offset            = info.offset;
+    m_periodic_phase             = static_cast<int>(info.phase);
+    m_periodic_infinite_duration = (info.duration_ms == SDL_HAPTIC_INFINITY);
+    if (!m_periodic_infinite_duration)
+        m_periodic_duration = static_cast<int>(info.duration_ms);
+}
+
+// Populate the Condition edit fields from an active slot's recorded state.
+void SteeringWheelHapticsVisualizer::LoadConditionFromActive(const ActiveConditionInfo& info) {
+    m_condition_type             = static_cast<int>(info.type);
+    m_condition_right_sat        = info.right_sat;
+    m_condition_left_sat         = info.left_sat;
+    m_condition_right_coeff      = info.right_coeff;
+    m_condition_left_coeff       = info.left_coeff;
+    m_condition_deadband         = info.deadband;
+    m_condition_center           = info.center;
+    m_condition_infinite_duration = (info.duration_ms == SDL_HAPTIC_INFINITY);
+    if (!m_condition_infinite_duration)
+        m_condition_duration = static_cast<int>(info.duration_ms);
+}
+
+// ---------------------------------------------------------------------------
+// Main draw
+// ---------------------------------------------------------------------------
+
 void SteeringWheelHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager& deviceManager) {
     HapticDevice *haptic = deviceManager.GetHapticDevice(dev.instance_id);
     if (haptic) {
@@ -53,16 +96,48 @@ void SteeringWheelHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager&
     ImGui::Text("Haptics Test");
 
     if (auto *wheelHaptics = dynamic_cast<SteeringWheelHaptics *>(haptic)) {
+
+        // ----------------------------------------------------------------
+        // Constant Force
+        // ----------------------------------------------------------------
         if (ImGui::TreeNode("Constant Force")) {
+            auto active_constants = wheelHaptics->GetActiveConstants();
+
+            // When the user moves the slot selector, load the live values for
+            // that slot (if it's running) so they're editing real state.
+            int prev_const_slot = m_constant_slot;
             ImGui::SliderInt("Slot##const", &m_constant_slot, 0, 7);
-            ImGui::SliderFloat("Strength", &m_constant_strength, -1.0f, 1.0f);
-            ImGui::Checkbox("Infinite Duration##const", &m_constant_infinite_duration);
-            if (!m_constant_infinite_duration) {
-                ImGui::SliderInt("Duration (ms)##const", &m_constant_duration, 0, 5000);
+            if (m_constant_slot != prev_const_slot) {
+                auto it = active_constants.find(m_constant_slot);
+                if (it != active_constants.end() && it->second.active)
+                    LoadConstantFromActive(it->second);
             }
+
+            bool const_changed = false;
+            const_changed |= ImGui::SliderFloat("Strength", &m_constant_strength, -1.0f, 1.0f);
+            const_changed |= ImGui::Checkbox("Infinite Duration##const", &m_constant_infinite_duration);
+            if (!m_constant_infinite_duration)
+                const_changed |= ImGui::SliderInt("Duration (ms)##const", &m_constant_duration, 0, 5000);
+
+            // Live-update if this slot is already running and any value changed.
+            bool slot_is_active = false;
+            {
+                auto it = active_constants.find(m_constant_slot);
+                slot_is_active = (it != active_constants.end() && it->second.active);
+            }
+            if (const_changed && slot_is_active) {
+                wheelHaptics->PlayConstant(m_constant_slot, m_constant_strength,
+                                           m_constant_infinite_duration ? SDL_HAPTIC_INFINITY
+                                                                        : (uint32_t)m_constant_duration);
+            }
+
+            if (slot_is_active)
+                ImGui::TextColored(ImVec4(0.0f, 1.0f, 0.0f, 1.0f), "● Slot %d active — editing live", m_constant_slot);
+
             if (ImGui::Button("Play Constant")) {
                 wheelHaptics->PlayConstant(m_constant_slot, m_constant_strength,
-                                           m_constant_infinite_duration ? SDL_HAPTIC_INFINITY : (uint32_t)m_constant_duration);
+                                           m_constant_infinite_duration ? SDL_HAPTIC_INFINITY
+                                                                        : (uint32_t)m_constant_duration);
             }
             ImGui::SameLine();
             if (ImGui::Button("Stop Constant")) {
@@ -71,26 +146,58 @@ void SteeringWheelHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager&
             ImGui::TreePop();
         }
 
+        // ----------------------------------------------------------------
+        // Periodic Effects
+        // ----------------------------------------------------------------
         if (ImGui::TreeNode("Periodic Effects")) {
-            const char* wave_types[] = { "Sine", "Square", "Triangle", "Sawtooth Up", "Sawtooth Down" };
-            ImGui::Combo("Wave Type##p", &m_periodic_wave_type, wave_types, IM_ARRAYSIZE(wave_types));
+            auto active_periodics = wheelHaptics->GetActivePeriodicEffects();
+
+            int prev_periodic_slot = m_periodic_slot;
             ImGui::SliderInt("Slot##periodic", &m_periodic_slot, 0, 7);
-            ImGui::SliderFloat("Strength##p", &m_periodic_strength, 0.0f, 1.0f);
-            ImGui::SliderInt("Period (ms)", &m_periodic_period, 1, 5000);
-            ImGui::SliderFloat("Magnitude", &m_periodic_magnitude, 0.0f, 1.0f);
-            ImGui::SliderFloat("Offset", &m_periodic_offset, -1.0f, 1.0f);
-            ImGui::SliderInt("Phase", &m_periodic_phase, 0, 36000);
-            ImGui::Checkbox("Infinite Duration##periodic", &m_periodic_infinite_duration);
-            if (!m_periodic_infinite_duration) {
-                ImGui::SliderInt("Duration (ms)##periodic", &m_periodic_duration, 0, 5000);
+            if (m_periodic_slot != prev_periodic_slot) {
+                auto it = active_periodics.find(m_periodic_slot);
+                if (it != active_periodics.end() && it->second.active)
+                    LoadPeriodicFromActive(it->second);
             }
+
+            const char* wave_types[] = { "Sine", "Square", "Triangle", "Sawtooth Up", "Sawtooth Down" };
+            bool periodic_changed = false;
+            periodic_changed |= ImGui::Combo("Wave Type##p", &m_periodic_wave_type, wave_types, IM_ARRAYSIZE(wave_types));
+            periodic_changed |= ImGui::SliderFloat("Strength##p", &m_periodic_strength, 0.0f, 1.0f);
+            periodic_changed |= ImGui::SliderInt("Period (ms)", &m_periodic_period, 1, 5000);
+            periodic_changed |= ImGui::SliderFloat("Magnitude", &m_periodic_magnitude, 0.0f, 1.0f);
+            periodic_changed |= ImGui::SliderFloat("Offset", &m_periodic_offset, -1.0f, 1.0f);
+            periodic_changed |= ImGui::SliderInt("Phase", &m_periodic_phase, 0, 36000);
+            periodic_changed |= ImGui::Checkbox("Infinite Duration##periodic", &m_periodic_infinite_duration);
+            if (!m_periodic_infinite_duration)
+                periodic_changed |= ImGui::SliderInt("Duration (ms)##periodic", &m_periodic_duration, 0, 5000);
+
+            bool slot_is_active = false;
+            {
+                auto it = active_periodics.find(m_periodic_slot);
+                slot_is_active = (it != active_periodics.end() && it->second.active);
+            }
+            if (periodic_changed && slot_is_active) {
+                wheelHaptics->PlayPeriodic(m_periodic_slot,
+                                           PeriodicTypeFromIndex(m_periodic_wave_type),
+                                           m_periodic_strength,
+                                           (uint32_t)m_periodic_period, m_periodic_magnitude,
+                                           m_periodic_offset, (uint32_t)m_periodic_phase,
+                                           m_periodic_infinite_duration ? SDL_HAPTIC_INFINITY
+                                                                        : (uint32_t)m_periodic_duration);
+            }
+
+            if (slot_is_active)
+                ImGui::TextColored(ImVec4(0.0f, 1.0f, 0.0f, 1.0f), "● Slot %d active — editing live", m_periodic_slot);
+
             if (ImGui::Button("Play Periodic")) {
                 wheelHaptics->PlayPeriodic(m_periodic_slot,
                                            PeriodicTypeFromIndex(m_periodic_wave_type),
                                            m_periodic_strength,
                                            (uint32_t)m_periodic_period, m_periodic_magnitude,
                                            m_periodic_offset, (uint32_t)m_periodic_phase,
-                                           m_periodic_infinite_duration ? SDL_HAPTIC_INFINITY : (uint32_t)m_periodic_duration);
+                                           m_periodic_infinite_duration ? SDL_HAPTIC_INFINITY
+                                                                        : (uint32_t)m_periodic_duration);
             }
             ImGui::SameLine();
             if (ImGui::Button("Stop Periodic")) {
@@ -99,10 +206,11 @@ void SteeringWheelHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager&
             ImGui::TreePop();
         }
 
+        // ----------------------------------------------------------------
+        // Condition Effects
+        // ----------------------------------------------------------------
         if (ImGui::TreeNode("Condition Effects")) {
-            const char* condition_types[] = { "Spring", "Damper", "Inertia", "Friction" };
-            ImGui::Combo("Type", &m_condition_type, condition_types, IM_ARRAYSIZE(condition_types));
-            ImGui::Separator();
+            auto active_conditions = wheelHaptics->GetActiveConditions();
 
             int max_slots = 1;
             if (dev.joystick) {
@@ -112,18 +220,42 @@ void SteeringWheelHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager&
                     SDL_CloseHaptic(sdl_haptic);
                 }
             }
-            ImGui::SliderInt("Slot##cond", &m_condition_slot, 0, max_slots > 0 ? max_slots - 1 : 0);
 
-            ImGui::SliderFloat("Right Sat",   &m_condition_right_sat,   0.0f,  1.0f);
-            ImGui::SliderFloat("Left Sat",    &m_condition_left_sat,    0.0f,  1.0f);
-            ImGui::SliderFloat("Right Coeff", &m_condition_right_coeff, -1.0f, 1.0f);
-            ImGui::SliderFloat("Left Coeff",  &m_condition_left_coeff,  -1.0f, 1.0f);
-            ImGui::SliderFloat("Deadband",    &m_condition_deadband,    0.0f,  1.0f);
-            ImGui::SliderFloat("Center",      &m_condition_center,      -1.0f, 1.0f);
-            ImGui::Checkbox("Infinite Duration##cond", &m_condition_infinite_duration);
-            if (!m_condition_infinite_duration) {
-                ImGui::SliderInt("Duration (ms)##cond", &m_condition_duration, 0, 10000);
+            int prev_cond_slot = m_condition_slot;
+            ImGui::SliderInt("Slot##cond", &m_condition_slot, 0, max_slots > 0 ? max_slots - 1 : 0);
+            if (m_condition_slot != prev_cond_slot) {
+                auto it = active_conditions.find(m_condition_slot);
+                if (it != active_conditions.end())
+                    LoadConditionFromActive(it->second);
             }
+
+            const char* condition_types[] = { "Spring", "Damper", "Inertia", "Friction" };
+            bool cond_changed = false;
+            cond_changed |= ImGui::Combo("Type", &m_condition_type, condition_types, IM_ARRAYSIZE(condition_types));
+            ImGui::Separator();
+            cond_changed |= ImGui::SliderFloat("Right Sat",   &m_condition_right_sat,   0.0f,  1.0f);
+            cond_changed |= ImGui::SliderFloat("Left Sat",    &m_condition_left_sat,    0.0f,  1.0f);
+            cond_changed |= ImGui::SliderFloat("Right Coeff", &m_condition_right_coeff, -1.0f, 1.0f);
+            cond_changed |= ImGui::SliderFloat("Left Coeff",  &m_condition_left_coeff,  -1.0f, 1.0f);
+            cond_changed |= ImGui::SliderFloat("Deadband",    &m_condition_deadband,    0.0f,  1.0f);
+            cond_changed |= ImGui::SliderFloat("Center",      &m_condition_center,      -1.0f, 1.0f);
+            cond_changed |= ImGui::Checkbox("Infinite Duration##cond", &m_condition_infinite_duration);
+            if (!m_condition_infinite_duration)
+                cond_changed |= ImGui::SliderInt("Duration (ms)##cond", &m_condition_duration, 0, 10000);
+
+            bool slot_is_active = (active_conditions.count(m_condition_slot) > 0);
+            if (cond_changed && slot_is_active) {
+                wheelHaptics->PlayCondition(m_condition_slot,
+                                            ConditionTypeFromIndex(m_condition_type),
+                                            m_condition_right_sat, m_condition_left_sat,
+                                            m_condition_right_coeff, m_condition_left_coeff,
+                                            m_condition_deadband, m_condition_center,
+                                            m_condition_infinite_duration ? SDL_HAPTIC_INFINITY
+                                                                          : (uint32_t)m_condition_duration);
+            }
+
+            if (slot_is_active)
+                ImGui::TextColored(ImVec4(0.0f, 1.0f, 0.0f, 1.0f), "● Slot %d active — editing live", m_condition_slot);
 
             if (ImGui::Button("Play Condition")) {
                 wheelHaptics->PlayCondition(m_condition_slot,
@@ -131,7 +263,8 @@ void SteeringWheelHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager&
                                             m_condition_right_sat, m_condition_left_sat,
                                             m_condition_right_coeff, m_condition_left_coeff,
                                             m_condition_deadband, m_condition_center,
-                                            m_condition_infinite_duration ? SDL_HAPTIC_INFINITY : (uint32_t)m_condition_duration);
+                                            m_condition_infinite_duration ? SDL_HAPTIC_INFINITY
+                                                                          : (uint32_t)m_condition_duration);
             }
             ImGui::SameLine();
             if (ImGui::Button("Stop Condition")) {
@@ -140,8 +273,12 @@ void SteeringWheelHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager&
             ImGui::TreePop();
         }
 
+        // ----------------------------------------------------------------
+        // Active Slots read-out (click a slot label to load its values)
+        // ----------------------------------------------------------------
         ImGui::Separator();
         ImGui::Text("Active Haptic Slots");
+        ImGui::TextDisabled("Click a slot header to load its values into the editor above.");
         if (ImGui::BeginChild("ActiveHaptics", ImVec2(0, 150), true)) {
             bool anyActive = false;
 
@@ -150,7 +287,18 @@ void SteeringWheelHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager&
             for (const auto& [slot, info] : active_constants) {
                 if (!info.active) continue;
                 anyActive = true;
-                if (ImGui::TreeNode((void*)(intptr_t)(slot + 1000), "Constant Force [slot %d]", slot)) {
+                bool selected = (m_constant_slot == slot);
+                ImGui::PushStyleColor(ImGuiCol_Header,        selected ? ImVec4(0.2f,0.6f,0.2f,0.4f) : ImVec4(0,0,0,0));
+                ImGui::PushStyleColor(ImGuiCol_HeaderHovered, ImVec4(0.2f,0.6f,0.2f,0.3f));
+                bool open = ImGui::TreeNodeEx((void*)(intptr_t)(slot + 1000),
+                                              ImGuiTreeNodeFlags_SpanAvailWidth,
+                                              "Constant Force [slot %d]", slot);
+                ImGui::PopStyleColor(2);
+                if (ImGui::IsItemClicked()) {
+                    m_constant_slot = slot;
+                    LoadConstantFromActive(info);
+                }
+                if (open) {
                     ImGui::Text("Strength: %.3f", info.strength);
                     if (info.duration_ms == SDL_HAPTIC_INFINITY)
                         ImGui::Text("Duration: Infinite");
@@ -165,13 +313,24 @@ void SteeringWheelHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager&
             for (const auto& [slot, info] : active_periodics) {
                 if (!info.active) continue;
                 anyActive = true;
-                if (ImGui::TreeNode((void*)(intptr_t)(slot + 2000), "Periodic (%s) [slot %d]", PeriodicTypeName(info.wave_type), slot)) {
-                    ImGui::Text("Wave: %s", PeriodicTypeName(info.wave_type));
-                    ImGui::Text("Strength: %.3f",   info.strength);
-                    ImGui::Text("Period: %u ms",    info.period);
-                    ImGui::Text("Magnitude: %.3f",  info.magnitude);
-                    ImGui::Text("Offset: %.3f",     info.offset);
-                    ImGui::Text("Phase: %u",        info.phase);
+                bool selected = (m_periodic_slot == slot);
+                ImGui::PushStyleColor(ImGuiCol_Header,        selected ? ImVec4(0.2f,0.6f,0.2f,0.4f) : ImVec4(0,0,0,0));
+                ImGui::PushStyleColor(ImGuiCol_HeaderHovered, ImVec4(0.2f,0.6f,0.2f,0.3f));
+                bool open = ImGui::TreeNodeEx((void*)(intptr_t)(slot + 2000),
+                                              ImGuiTreeNodeFlags_SpanAvailWidth,
+                                              "Periodic (%s) [slot %d]", PeriodicTypeName(info.wave_type), slot);
+                ImGui::PopStyleColor(2);
+                if (ImGui::IsItemClicked()) {
+                    m_periodic_slot = slot;
+                    LoadPeriodicFromActive(info);
+                }
+                if (open) {
+                    ImGui::Text("Wave: %s",        PeriodicTypeName(info.wave_type));
+                    ImGui::Text("Strength: %.3f",  info.strength);
+                    ImGui::Text("Period: %u ms",   info.period);
+                    ImGui::Text("Magnitude: %.3f", info.magnitude);
+                    ImGui::Text("Offset: %.3f",    info.offset);
+                    ImGui::Text("Phase: %u",       info.phase);
                     if (info.duration_ms == SDL_HAPTIC_INFINITY)
                         ImGui::Text("Duration: Infinite");
                     else
@@ -184,16 +343,27 @@ void SteeringWheelHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager&
             auto active_conditions = wheelHaptics->GetActiveConditions();
             for (const auto& [slot, info] : active_conditions) {
                 anyActive = true;
-                if (ImGui::TreeNode((void*)(intptr_t)(slot + 3000), "Condition [slot %d]", slot)) {
-                    ImGui::Text("Type: %s", ConditionTypeName(info.type));
+                bool selected = (m_condition_slot == slot);
+                ImGui::PushStyleColor(ImGuiCol_Header,        selected ? ImVec4(0.2f,0.6f,0.2f,0.4f) : ImVec4(0,0,0,0));
+                ImGui::PushStyleColor(ImGuiCol_HeaderHovered, ImVec4(0.2f,0.6f,0.2f,0.3f));
+                bool open = ImGui::TreeNodeEx((void*)(intptr_t)(slot + 3000),
+                                              ImGuiTreeNodeFlags_SpanAvailWidth,
+                                              "Condition (%s) [slot %d]", ConditionTypeName(info.type), slot);
+                ImGui::PopStyleColor(2);
+                if (ImGui::IsItemClicked()) {
+                    m_condition_slot = slot;
+                    LoadConditionFromActive(info);
+                }
+                if (open) {
+                    ImGui::Text("Type: %s",                      ConditionTypeName(info.type));
                     if (info.duration_ms == SDL_HAPTIC_INFINITY)
                         ImGui::Text("Duration: Infinite");
                     else
-                        ImGui::Text("Duration: %u ms", info.duration_ms);
-                    ImGui::Text("Center: %.3f",   info.center);
-                    ImGui::Text("Deadband: %.3f", info.deadband);
-                    ImGui::Text("L/R Coeff: %.3f / %.3f", info.left_coeff,  info.right_coeff);
-                    ImGui::Text("L/R Sat: %.3f / %.3f",   info.left_sat,   info.right_sat);
+                        ImGui::Text("Duration: %u ms",           info.duration_ms);
+                    ImGui::Text("Center: %.3f",                  info.center);
+                    ImGui::Text("Deadband: %.3f",                info.deadband);
+                    ImGui::Text("L/R Coeff: %.3f / %.3f",        info.left_coeff,  info.right_coeff);
+                    ImGui::Text("L/R Sat: %.3f / %.3f",          info.left_sat,    info.right_sat);
                     ImGui::TreePop();
                 }
             }

--- a/src/Visualizers/SteeringWheelHapticsVisualizer.cpp
+++ b/src/Visualizers/SteeringWheelHapticsVisualizer.cpp
@@ -96,27 +96,6 @@ void SteeringWheelHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager&
     ImGui::Separator();
     ImGui::Text("Haptics Test");
 
-    // ── Keepalive toggle ─────────────────────────────────────────────────────
-    if (haptic) {
-        if (!prefs.IsPreferenceApplied(dev.instance_id)) {
-            haptic->EnableKeepalive(prefs.GetDeviceKeepalive(guid));
-        }
-
-        bool keepalive = haptic->IsKeepaliveEnabled();
-        if (ImGui::Checkbox("Infinite-effect keepalive", &keepalive)) {
-            deviceManager.SetDeviceKeepalive(dev.instance_id, keepalive);
-            prefs.SetDeviceKeepalive(guid, keepalive);
-        }
-        if (ImGui::IsItemHovered()) {
-            ImGui::SetTooltip(
-                "Re-uploads active infinite-duration effects every 30 s.\n"
-                "Required for devices that truncate SDL_HAPTIC_INFINITY to ~65 s\n"
-                "(e.g. Thrustmaster T150). Safe to enable on any device."
-            );
-        }
-        ImGui::Spacing();
-    }
-
     if (auto *wheelHaptics = dynamic_cast<SteeringWheelHaptics *>(haptic)) {
 
         // ----------------------------------------------------------------

--- a/src/Visualizers/SteeringWheelHapticsVisualizer.cpp
+++ b/src/Visualizers/SteeringWheelHapticsVisualizer.cpp
@@ -275,6 +275,32 @@ void SteeringWheelHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager&
         }
 
         // ----------------------------------------------------------------
+        // Rumble (simulated via periodic)
+        // ----------------------------------------------------------------
+        if (ImGui::TreeNode("Rumble (Impact)")) {
+            ImGui::TextDisabled("Steering wheels have no rumble motors; this is simulated\n"
+                                "as a low-frequency vibration burst on the wheel's force feedback.");
+            ImGui::SliderInt("Slot##rum", &m_rumble_slot, 0, 7);
+            ImGui::SliderFloat("Large Motor##rum", &m_rumble_large, 0.0f, 1.0f);
+            ImGui::SliderFloat("Small Motor##rum", &m_rumble_small, 0.0f, 1.0f);
+            ImGui::Checkbox("Infinite Duration##rum", &m_rumble_infinite_duration);
+            if (!m_rumble_infinite_duration)
+                ImGui::SliderInt("Duration (ms)##rum", &m_rumble_duration, 0, 2000);
+
+            if (ImGui::Button("Play Rumble##wheel")) {
+                wheelHaptics->PlayRumble(
+                    m_rumble_slot, m_rumble_large, m_rumble_small,
+                    m_rumble_infinite_duration ? SDL_HAPTIC_INFINITY
+                                               : static_cast<uint32_t>(m_rumble_duration));
+            }
+            ImGui::SameLine();
+            if (ImGui::Button("Stop Rumble##wheel"))
+                wheelHaptics->StopPeriodic(m_rumble_slot);  // Rumble reuses periodic slots
+
+            ImGui::TreePop();
+        }
+
+        // ----------------------------------------------------------------
         // Active Slots read-out (click a slot label to load its values)
         // ----------------------------------------------------------------
         ImGui::Separator();

--- a/src/Visualizers/SteeringWheelHapticsVisualizer.cpp
+++ b/src/Visualizers/SteeringWheelHapticsVisualizer.cpp
@@ -95,6 +95,22 @@ void SteeringWheelHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager&
     ImGui::Separator();
     ImGui::Text("Haptics Test");
 
+    // ── Keepalive toggle ─────────────────────────────────────────────────────
+    if (haptic) {
+        bool keepalive = haptic->IsKeepaliveEnabled();
+        if (ImGui::Checkbox("Infinite-effect keepalive", &keepalive)) {
+            deviceManager.SetDeviceKeepalive(dev.instance_id, keepalive);
+        }
+        if (ImGui::IsItemHovered()) {
+            ImGui::SetTooltip(
+                "Re-uploads active infinite-duration effects every 30 s.\n"
+                "Required for devices that truncate SDL_HAPTIC_INFINITY to ~65 s\n"
+                "(e.g. Thrustmaster T150). Safe to enable on any device."
+            );
+        }
+        ImGui::Spacing();
+    }
+
     if (auto *wheelHaptics = dynamic_cast<SteeringWheelHaptics *>(haptic)) {
 
         // ----------------------------------------------------------------

--- a/src/Visualizers/SteeringWheelHapticsVisualizer.cpp
+++ b/src/Visualizers/SteeringWheelHapticsVisualizer.cpp
@@ -47,7 +47,8 @@ void SteeringWheelHapticsVisualizer::LoadConditionFromActive(const ActiveConditi
 // Main draw
 // ---------------------------------------------------------------------------
 
-void SteeringWheelHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager& deviceManager) {
+void SteeringWheelHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager& deviceManager,
+                                          PreferencesManager& prefs, const std::string& guid) {
     HapticDevice *haptic = deviceManager.GetHapticDevice(dev.instance_id);
     if (haptic) {
         if (haptic->IsReady() && dev.joystick) {
@@ -97,9 +98,14 @@ void SteeringWheelHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager&
 
     // ── Keepalive toggle ─────────────────────────────────────────────────────
     if (haptic) {
+        if (!prefs.IsPreferenceApplied(dev.instance_id)) {
+            haptic->EnableKeepalive(prefs.GetDeviceKeepalive(guid));
+        }
+
         bool keepalive = haptic->IsKeepaliveEnabled();
         if (ImGui::Checkbox("Infinite-effect keepalive", &keepalive)) {
             deviceManager.SetDeviceKeepalive(dev.instance_id, keepalive);
+            prefs.SetDeviceKeepalive(guid, keepalive);
         }
         if (ImGui::IsItemHovered()) {
             ImGui::SetTooltip(

--- a/src/Visualizers/SteeringWheelHapticsVisualizer.h
+++ b/src/Visualizers/SteeringWheelHapticsVisualizer.h
@@ -2,10 +2,12 @@
 #include "Devices/DeviceState.h"
 #include "Devices/DeviceManager.h"
 #include "Haptics/HapticDevice.h"
+#include "Preferences/Preferences.h"
 
 class SteeringWheelHapticsVisualizer {
 public:
-    void Draw(const DeviceState& dev, DeviceManager& deviceManager);
+    void Draw(const DeviceState& dev, DeviceManager& deviceManager,
+              PreferencesManager& prefs, const std::string& guid);
 
     // Draw only the RPM LED controls — independent of haptics availability.
     // Safe to call even when the device has no SDL haptic support.

--- a/src/Visualizers/SteeringWheelHapticsVisualizer.h
+++ b/src/Visualizers/SteeringWheelHapticsVisualizer.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "Devices/DeviceState.h"
 #include "Devices/DeviceManager.h"
+#include "Haptics/HapticDevice.h"
 
 class SteeringWheelHapticsVisualizer {
 public:
@@ -11,6 +12,13 @@ public:
     void DrawLEDs(DeviceManager& deviceManager);
 
 private:
+    // Populate edit fields from the recorded live state of an active slot.
+    // Called when the user moves the slot selector onto a running slot, or
+    // clicks a slot label in the "Active Haptic Slots" read-out.
+    void LoadConstantFromActive(const ActiveConstantInfo& info);
+    void LoadPeriodicFromActive(const ActivePeriodicInfo& info);
+    void LoadConditionFromActive(const ActiveConditionInfo& info);
+
     // Constant
     int m_constant_slot = 0;
     float m_constant_strength = 0.5f;

--- a/src/Visualizers/SteeringWheelHapticsVisualizer.h
+++ b/src/Visualizers/SteeringWheelHapticsVisualizer.h
@@ -52,4 +52,11 @@ private:
 
     // RPM LEDs (wheel-rpm-lib)
     float m_rpm_percent = 0.0f;
+
+    // Rumble (simulated via periodic)
+    int   m_rumble_slot              = 0;
+    float m_rumble_large             = 0.5f;
+    float m_rumble_small             = 0.3f;
+    int   m_rumble_duration          = 500;
+    bool  m_rumble_infinite_duration = false;
 };


### PR DESCRIPTION
# Haptics
- Added experimental haptics keepalive support for infinite-duration effects
- Added live updates for active haptic effects and rumble from the Haptic Test UI
- Added steering wheel rumble support to the Haptic Test UI
- Added optional keepalive/workaround toggles for haptics-capable devices
- Added keepalive preference persistence
- Moved haptics workaround settings to a dedicated device tab
- Removed automatic application of the Thrustmaster haptics workaround
# OSC
- Standardized OSC handler path layout
- Added additional OSC message and payload validation
# UI
- Added Steam Controller version indicators to device names
- Improved debug log hover highlighting
- Increased Input Mapper deadzone slider width based on user feedback
# Logging
- Updated log levels for various messages
- Updated logging macros to support string literals
- Removed unused logging includes
# Cleanup
- Removed unused SensorState header