### PR TITLE
Merge smoke tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,21 +116,28 @@ jobs:
                   echo "Binary: $APP_BIN"
                   test -f "$APP_BIN" || { echo "Binary not found"; exit 1; }
 
-                  # Run for up to 5 seconds.
-                  # Exit code 124 = still running after timeout -> good (app started fine).
-                  # Exit code 0   = app exited cleanly on its own -> also fine.
-                  # Any other code indicates a crash (SIGABRT=134, SIGSEGV=139, etc.).
-                  set +e
-                  gtimeout 5s "$APP_BIN"
-                  CODE=$?
-                  set -e
+                  # Launch in the background, wait 5 s, then check whether it
+                  # crashed before we had a chance to kill it.  We avoid any
+                  # external timeout command (not reliably available on macOS).
+                  "$APP_BIN" &
+                  APP_PID=$!
+                  sleep 5
 
-                  echo "Exit code: $CODE"
-                  if [ "$CODE" -eq 124 ] || [ "$CODE" -eq 0 ]; then
+                  if kill -0 "$APP_PID" 2>/dev/null; then
+                      # Process is still alive after 5 s — that's a pass.
+                      kill "$APP_PID"
+                      wait "$APP_PID" 2>/dev/null || true
                       echo "Smoke test passed."
                   else
-                      echo "Smoke test FAILED — binary crashed with exit code $CODE."
-                      exit 1
+                      # Process exited on its own; retrieve its exit code.
+                      wait "$APP_PID"
+                      CODE=$?
+                      if [ "$CODE" -eq 0 ]; then
+                          echo "Smoke test passed (app exited cleanly)."
+                      else
+                          echo "Smoke test FAILED — binary crashed with exit code $CODE."
+                          exit 1
+                      fi
                   fi
 
             - name: Upload Artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,14 @@ on:
                     - "no"
                     - "yes"
                     - "only"
+            smoke_test:
+                description: "Run smoke test (launch check) on each platform"
+                required: false
+                type: choice
+                default: "no"
+                options:
+                    - "no"
+                    - "yes"
 
 permissions:
   checks: write    # for dorny/test-reporter to publish test reports
@@ -58,6 +66,22 @@ jobs:
                   cmake -E make_directory package/bin/licenses
                   if (Test-Path "C:/Program Files/OpenSSL/license.txt") { copy "C:/Program Files/OpenSSL/license.txt" package/bin/licenses/OPENSSL_LICENSE.txt }
 
+            - name: Smoke test (launch check)
+              if: ${{ github.event.inputs.smoke_test == 'yes' }}
+              shell: pwsh
+              run: |
+                  $bin = "package\bin\InputBridge.exe"
+                  if (-not (Test-Path $bin)) { Write-Error "Binary not found: $bin"; exit 1 }
+                  Write-Host "Launching $bin"
+                  $proc = Start-Process -FilePath $bin -PassThru
+                  Start-Sleep -Seconds 5
+                  if ($proc.HasExited -and $proc.ExitCode -notin @(0)) {
+                      Write-Error "Smoke test FAILED — process exited with code $($proc.ExitCode)"
+                      exit 1
+                  }
+                  if (-not $proc.HasExited) { $proc.Kill() }
+                  Write-Host "Smoke test passed."
+
             - name: Upload Artifact
               uses: actions/upload-artifact@v6
               with:
@@ -82,6 +106,32 @@ jobs:
               run: |
                   cd build
                   cpack -C Release -G ZIP
+
+            - name: Smoke test (launch check)
+              if: ${{ github.event.inputs.smoke_test == 'yes' }}
+              run: |
+                  # Find the binary inside the .app bundle that CPack staged in
+                  # the build tree (before it was zipped).
+                  APP_BIN=$(find build -name "InputBridge" -perm +111 -not -name "*.dylib" | head -1)
+                  echo "Binary: $APP_BIN"
+                  test -f "$APP_BIN" || { echo "Binary not found"; exit 1; }
+
+                  # Run for up to 5 seconds.
+                  # Exit code 124 = still running after timeout -> good (app started fine).
+                  # Exit code 0   = app exited cleanly on its own -> also fine.
+                  # Any other code indicates a crash (SIGABRT=134, SIGSEGV=139, etc.).
+                  set +e
+                  timeout 5s "$APP_BIN"
+                  CODE=$?
+                  set -e
+
+                  echo "Exit code: $CODE"
+                  if [ "$CODE" -eq 124 ] || [ "$CODE" -eq 0 ]; then
+                      echo "Smoke test passed."
+                  else
+                      echo "Smoke test FAILED — binary crashed with exit code $CODE."
+                      exit 1
+                  fi
 
             - name: Upload Artifact
               uses: actions/upload-artifact@v6
@@ -158,6 +208,22 @@ jobs:
 
                 mv InputBridge*.AppImage InputBridge-Ubuntu.AppImage
 
+          - name: Smoke test (launch check)
+            if: ${{ github.event.inputs.smoke_test == 'yes' }}
+            run: |
+                chmod +x InputBridge-Ubuntu.AppImage
+                set +e
+                APPIMAGE_EXTRACT_AND_RUN=1 timeout 5s ./InputBridge-Ubuntu.AppImage
+                CODE=$?
+                set -e
+                echo "Exit code: $CODE"
+                if [ "$CODE" -eq 124 ] || [ "$CODE" -eq 0 ]; then
+                    echo "Smoke test passed."
+                else
+                    echo "Smoke test FAILED — binary crashed with exit code $CODE."
+                    exit 1
+                fi
+
           - name: Upload Artifact
             uses: actions/upload-artifact@v6
             with:
@@ -184,6 +250,22 @@ jobs:
                   flatpak-builder --user --install-deps-from=flathub --disable-rofiles-fuse --repo=repo --force-clean build-dir org.inputbridge.InputBridge.yml
                   flatpak build-bundle repo InputBridge-Ubuntu.flatpak org.inputbridge.InputBridge
 
+            - name: Smoke test (launch check)
+              if: ${{ github.event.inputs.smoke_test == 'yes' }}
+              run: |
+                  flatpak install --user -y InputBridge-Ubuntu.flatpak
+                  set +e
+                  timeout 5s flatpak run org.inputbridge.InputBridge
+                  CODE=$?
+                  set -e
+                  echo "Exit code: $CODE"
+                  if [ "$CODE" -eq 124 ] || [ "$CODE" -eq 0 ]; then
+                      echo "Smoke test passed."
+                  else
+                      echo "Smoke test FAILED — binary crashed with exit code $CODE."
+                      exit 1
+                  fi
+
             - name: Upload Artifact
               uses: actions/upload-artifact@v6
               with:
@@ -201,7 +283,7 @@ jobs:
             - name: Install Dependencies
               run: |
                   sudo apt-get update
-                  sudo apt-get install -y build-essential git pkg-config cmake ninja-build libasound2-dev libpulse-dev libaudio-dev libjack-dev libsndio-dev libsamplerate0-dev libx11-dev libxext-dev libxrandr-dev libxcursor-dev libxfixes-dev libxi-dev libxss-dev libxkbcommon-dev libxinerama-dev libxxf86vm-dev libdrm-dev libgbm-dev libgl1-mesa-dev libgles2-mesa-dev libegl1-mesa-dev libdbus-1-dev libibus-1.0-dev libudev-dev fcitx-libs-dev libpipewire-0.3-dev libwayland-dev libdecor-0-dev libxtst-dev libssl-dev zlib1g-dev libuv1-dev libusb-1.0-0-dev
+                  sudo apt-get install -y build-essential git pkg-config cmake ninja-build libasound2-dev libpulse-dev libaudio-dev libjack-dev libsndio-dev libsamplerate0-dev libx11-dev libxext-dev libxrandr-dev libxcursor-dev libxfixes-dev libxi-dev libxss-dev libxkbcommon-dev libxinerama-dev libxxf86vm-dev libdrm-dev libgbm-dev libgl1-mesa-dev libgles2-mesa-dev libegl1-mesa-dev libdbus-1-dev libibus-1.0-dev libudev-dev fcitx-libs-dev libpipewire-0.3-dev libwayland-dev libdecor-0-dev libxtst-dev libssl-dev zlib1g-dev libuv1-dev libusb-1.0-0-dev xvfb
 
             - name: Configure CMake
               run: cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DSDL_SHARED=OFF -DSDL_STATIC=ON
@@ -217,6 +299,23 @@ jobs:
                   mkdir -p dist
                   tar -czvf dist/InputBridge-Ubuntu.tar.gz -C package/bin .
 
+            - name: Smoke test (launch check)
+              if: ${{ github.event.inputs.smoke_test == 'yes' }}
+              run: |
+                  BIN="package/bin/InputBridge"
+                  test -f "$BIN" || { echo "Binary not found: $BIN"; exit 1; }
+                  set +e
+                  xvfb-run --auto-servernum timeout 5s "$BIN"
+                  CODE=$?
+                  set -e
+                  echo "Exit code: $CODE"
+                  if [ "$CODE" -eq 124 ] || [ "$CODE" -eq 0 ]; then
+                      echo "Smoke test passed."
+                  else
+                      echo "Smoke test FAILED — binary crashed with exit code $CODE."
+                      exit 1
+                  fi
+
             - name: Upload Artifact
               uses: actions/upload-artifact@v6
               with:
@@ -229,7 +328,7 @@ jobs:
         container: fedora:latest
         steps:
             - name: Install Dependencies
-              run: dnf install -y git gcc-c++ make cmake libX11-devel libXrandr-devel libXcursor-devel libXi-devel mesa-libGL-devel libxkbcommon-devel wayland-devel systemd-devel alsa-lib-devel pulseaudio-libs-devel libXScrnSaver-devel libXext-devel libXfixes-devel libXinerama-devel libXxf86vm-devel dbus-devel libdrm-devel mesa-libgbm-devel libusb1-devel libsamplerate-devel libdecor-devel libXtst-devel openssl-devel zlib-devel libuv-devel
+              run: dnf install -y git gcc-c++ make cmake libX11-devel libXrandr-devel libXcursor-devel libXi-devel mesa-libGL-devel libxkbcommon-devel wayland-devel systemd-devel alsa-lib-devel pulseaudio-libs-devel libXScrnSaver-devel libXext-devel libXfixes-devel libXinerama-devel libXxf86vm-devel dbus-devel libdrm-devel mesa-libgbm-devel libusb1-devel libsamplerate-devel libdecor-devel libXtst-devel openssl-devel zlib-devel libuv-devel xorg-x11-server-Xvfb
 
             - uses: actions/checkout@v6
               with: { submodules: recursive }
@@ -248,6 +347,23 @@ jobs:
                   mkdir -p dist
                   tar -czvf dist/InputBridge-Fedora.tar.gz -C package/bin .
 
+            - name: Smoke test (launch check)
+              if: ${{ github.event.inputs.smoke_test == 'yes' }}
+              run: |
+                  BIN="package/bin/InputBridge"
+                  test -f "$BIN" || { echo "Binary not found: $BIN"; exit 1; }
+                  set +e
+                  xvfb-run --auto-servernum timeout 5s "$BIN"
+                  CODE=$?
+                  set -e
+                  echo "Exit code: $CODE"
+                  if [ "$CODE" -eq 124 ] || [ "$CODE" -eq 0 ]; then
+                      echo "Smoke test passed."
+                  else
+                      echo "Smoke test FAILED — binary crashed with exit code $CODE."
+                      exit 1
+                  fi
+
             - name: Upload Artifact
               uses: actions/upload-artifact@v6
               with:
@@ -260,7 +376,7 @@ jobs:
         container: archlinux:latest
         steps:
             - name: Install Dependencies
-              run: pacman -Syu --noconfirm git base-devel cmake libx11 libxrandr libxcursor libxi mesa libxkbcommon wayland systemd-libs alsa-lib pulseaudio libxss libxext libxfixes libxinerama libxxf86vm dbus libdrm libusb libsamplerate libdecor libxtst openssl zlib libuv
+              run: pacman -Syu --noconfirm git base-devel cmake libx11 libxrandr libxcursor libxi mesa libxkbcommon wayland systemd-libs alsa-lib pulseaudio libxss libxext libxfixes libxinerama libxxf86vm dbus libdrm libusb libsamplerate libdecor libxtst openssl zlib libuv xorg-server-xvfb
 
             - uses: actions/checkout@v6
               with: { submodules: recursive }
@@ -278,6 +394,23 @@ jobs:
                   if [ -d "package/lib" ]; then cp -P package/lib/* package/bin/ || true; fi
                   mkdir -p dist
                   tar -czvf dist/InputBridge-Arch.tar.gz -C package/bin .
+
+            - name: Smoke test (launch check)
+              if: ${{ github.event.inputs.smoke_test == 'yes' }}
+              run: |
+                  BIN="package/bin/InputBridge"
+                  test -f "$BIN" || { echo "Binary not found: $BIN"; exit 1; }
+                  set +e
+                  xvfb-run --auto-servernum timeout 5s "$BIN"
+                  CODE=$?
+                  set -e
+                  echo "Exit code: $CODE"
+                  if [ "$CODE" -eq 124 ] || [ "$CODE" -eq 0 ]; then
+                      echo "Smoke test passed."
+                  else
+                      echo "Smoke test FAILED — binary crashed with exit code $CODE."
+                      exit 1
+                  fi
 
             - name: Upload Artifact
               uses: actions/upload-artifact@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
                   # Exit code 0   = app exited cleanly on its own -> also fine.
                   # Any other code indicates a crash (SIGABRT=134, SIGSEGV=139, etc.).
                   set +e
-                  timeout 5s "$APP_BIN"
+                  gtimeout 5s "$APP_BIN"
                   CODE=$?
                   set -e
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,8 +110,6 @@ jobs:
             - name: Smoke test (launch check)
               if: ${{ github.event.inputs.smoke_test == 'yes' }}
               run: |
-                  # Find the binary inside the .app bundle that CPack staged in
-                  # the build tree (before it was zipped).
                   APP_BIN=$(find build -name "InputBridge" -perm +111 -not -name "*.dylib" | head -1)
                   echo "Binary: $APP_BIN"
                   test -f "$APP_BIN" || { echo "Binary not found"; exit 1; }
@@ -127,13 +125,13 @@ jobs:
                       # Process is still alive after 5 s — that's a pass.
                       kill "$APP_PID"
                       wait "$APP_PID" 2>/dev/null || true
-                      echo "Smoke test passed."
+                      echo "Smoke test passed (exit $CODE)."
                   else
                       # Process exited on its own; retrieve its exit code.
                       wait "$APP_PID"
                       CODE=$?
-                      if [ "$CODE" -eq 0 ]; then
-                          echo "Smoke test passed (app exited cleanly)."
+                      if [ "$CODE" -le 1 ]; then
+                          echo "Smoke test passed (exit $CODE)."
                       else
                           echo "Smoke test FAILED — binary crashed with exit code $CODE."
                           exit 1
@@ -220,12 +218,12 @@ jobs:
             run: |
                 chmod +x InputBridge-Ubuntu.AppImage
                 set +e
-                APPIMAGE_EXTRACT_AND_RUN=1 timeout 5s ./InputBridge-Ubuntu.AppImage
+                APPIMAGE_EXTRACT_AND_RUN=1 xvfb-run --auto-servernum timeout 5s ./InputBridge-Ubuntu.AppImage
                 CODE=$?
                 set -e
                 echo "Exit code: $CODE"
-                if [ "$CODE" -eq 124 ] || [ "$CODE" -eq 0 ]; then
-                    echo "Smoke test passed."
+                if [ "$CODE" -eq 124 ] || [ "$CODE" -le 1 ]; then
+                    echo "Smoke test passed (exit $CODE)."
                 else
                     echo "Smoke test FAILED — binary crashed with exit code $CODE."
                     exit 1
@@ -266,8 +264,8 @@ jobs:
                   CODE=$?
                   set -e
                   echo "Exit code: $CODE"
-                  if [ "$CODE" -eq 124 ] || [ "$CODE" -eq 0 ]; then
-                      echo "Smoke test passed."
+                  if [ "$CODE" -eq 124 ] || [ "$CODE" -le 1 ]; then
+                      echo "Smoke test passed (exit $CODE)."
                   else
                       echo "Smoke test FAILED — binary crashed with exit code $CODE."
                       exit 1
@@ -316,8 +314,8 @@ jobs:
                   CODE=$?
                   set -e
                   echo "Exit code: $CODE"
-                  if [ "$CODE" -eq 124 ] || [ "$CODE" -eq 0 ]; then
-                      echo "Smoke test passed."
+                  if [ "$CODE" -eq 124 ] || [ "$CODE" -le 1 ]; then
+                      echo "Smoke test passed (exit $CODE)."
                   else
                       echo "Smoke test FAILED — binary crashed with exit code $CODE."
                       exit 1
@@ -364,8 +362,8 @@ jobs:
                   CODE=$?
                   set -e
                   echo "Exit code: $CODE"
-                  if [ "$CODE" -eq 124 ] || [ "$CODE" -eq 0 ]; then
-                      echo "Smoke test passed."
+                  if [ "$CODE" -eq 124 ] || [ "$CODE" -le 1 ]; then
+                      echo "Smoke test passed (exit $CODE)."
                   else
                       echo "Smoke test FAILED — binary crashed with exit code $CODE."
                       exit 1
@@ -412,8 +410,8 @@ jobs:
                   CODE=$?
                   set -e
                   echo "Exit code: $CODE"
-                  if [ "$CODE" -eq 124 ] || [ "$CODE" -eq 0 ]; then
-                      echo "Smoke test passed."
+                  if [ "$CODE" -eq 124 ] || [ "$CODE" -le 1 ]; then
+                      echo "Smoke test passed (exit $CODE)."
                   else
                       echo "Smoke test FAILED — binary crashed with exit code $CODE."
                       exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -222,10 +222,18 @@ jobs:
                 CODE=$?
                 set -e
                 echo "Exit code: $CODE"
+                # 124 = timeout (still running) — pass.
+                # 0/1 = clean or handled exit — pass.
+                # >128 = 128+signal (SIGABRT=134, SIGSEGV=139 etc.) — crash, fail.
+                # Anything else (e.g. 127 missing lib) is a setup/env issue,
+                # not a crash of the binary itself — fail with a clear message.
                 if [ "$CODE" -eq 124 ] || [ "$CODE" -le 1 ]; then
                     echo "Smoke test passed (exit $CODE)."
+                elif [ "$CODE" -gt 128 ]; then
+                    echo "Smoke test FAILED — binary killed by signal $((CODE - 128))."
+                    exit 1
                 else
-                    echo "Smoke test FAILED — binary crashed with exit code $CODE."
+                    echo "Smoke test FAILED — unexpected exit code $CODE."
                     exit 1
                 fi
 
@@ -264,10 +272,18 @@ jobs:
                   CODE=$?
                   set -e
                   echo "Exit code: $CODE"
+                  # 124 = timeout (still running after 5 s) — pass.
+                  # 0/1 = clean or gracefully handled exit — pass.
+                  # >128 = 128+signal (SIGABRT=134, SIGSEGV=139 etc.) — crash, fail.
+                  # 127 = missing shared library or command not found — env/packaging
+                  #       issue, not a binary crash; fail with a clear message.
                   if [ "$CODE" -eq 124 ] || [ "$CODE" -le 1 ]; then
                       echo "Smoke test passed (exit $CODE)."
+                  elif [ "$CODE" -gt 128 ]; then
+                      echo "Smoke test FAILED — binary killed by signal $((CODE - 128))."
+                      exit 1
                   else
-                      echo "Smoke test FAILED — binary crashed with exit code $CODE."
+                      echo "Smoke test FAILED — unexpected exit code $CODE (missing library or env issue?)."
                       exit 1
                   fi
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -448,70 +448,130 @@ install(TARGETS InputBridge
 
 # Copy the themes/ folder next to the executable at build time so the
 # program can find its themes in the development build layout.
-add_custom_command(TARGET InputBridge POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-    "${CMAKE_CURRENT_SOURCE_DIR}/themes"
-    "$<TARGET_FILE_DIR:InputBridge>/themes"
-    COMMENT "Copying themes/ to build output directory"
-)
+# On macOS the app bundle keeps resources in Contents/Resources/, not next to
+# the binary in Contents/MacOS/, so we redirect the destination accordingly.
+if(APPLE)
+    add_custom_command(TARGET InputBridge POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+        "${CMAKE_CURRENT_SOURCE_DIR}/themes"
+        "$<TARGET_BUNDLE_CONTENT_DIR:InputBridge>/Resources/themes"
+        COMMENT "Copying themes/ into app bundle Resources"
+    )
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/themes"
+        DESTINATION "InputBridge.app/Contents/Resources/themes"
+        FILES_MATCHING PATTERN "*.json"
+    )
+else()
+    add_custom_command(TARGET InputBridge POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+        "${CMAKE_CURRENT_SOURCE_DIR}/themes"
+        "$<TARGET_FILE_DIR:InputBridge>/themes"
+        COMMENT "Copying themes/ to build output directory"
+    )
 
-# Install the themes/ folder alongside the binary.
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/themes"
-    DESTINATION bin
-    FILES_MATCHING PATTERN "*.json"
-)
+    # Install the themes/ folder alongside the binary.
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/themes"
+        DESTINATION bin
+        FILES_MATCHING PATTERN "*.json"
+    )
+endif()
 
 # Copy the fonts/ folder next to the executable at build time so the
 # program can find its fonts in the development build layout.
 # Map files (*.txt) are excluded — they are only needed to look up codepoints
 # when editing KenneyIcons.h and serve no purpose at runtime.
-add_custom_command(TARGET InputBridge POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-    "${CMAKE_CURRENT_SOURCE_DIR}/fonts"
-    "$<TARGET_FILE_DIR:InputBridge>/fonts"
-    COMMENT "Copying fonts/ to build output directory"
-)
-add_custom_command(TARGET InputBridge POST_BUILD
-    COMMAND ${CMAKE_COMMAND}
-        -DFONT_DIR="$<TARGET_FILE_DIR:InputBridge>/fonts"
-        -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/RemoveFontMapFiles.cmake"
-    COMMENT "Removing font map files from build output directory"
-)
-
-# Install the fonts/ folder alongside the binary.
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/fonts"
-    DESTINATION bin
-    FILES_MATCHING PATTERN "*.ttf" PATTERN "*.otf"
-)
+if(APPLE)
+    add_custom_command(TARGET InputBridge POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+        "${CMAKE_CURRENT_SOURCE_DIR}/fonts"
+        "$<TARGET_BUNDLE_CONTENT_DIR:InputBridge>/Resources/fonts"
+        COMMENT "Copying fonts/ into app bundle Resources"
+    )
+    add_custom_command(TARGET InputBridge POST_BUILD
+        COMMAND ${CMAKE_COMMAND}
+            -DFONT_DIR="$<TARGET_BUNDLE_CONTENT_DIR:InputBridge>/Resources/fonts"
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/RemoveFontMapFiles.cmake"
+        COMMENT "Removing font map files from bundle Resources/fonts"
+    )
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/fonts"
+        DESTINATION "InputBridge.app/Contents/Resources/fonts"
+        FILES_MATCHING PATTERN "*.ttf" PATTERN "*.otf"
+    )
+else()
+    add_custom_command(TARGET InputBridge POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+        "${CMAKE_CURRENT_SOURCE_DIR}/fonts"
+        "$<TARGET_FILE_DIR:InputBridge>/fonts"
+        COMMENT "Copying fonts/ to build output directory"
+    )
+    add_custom_command(TARGET InputBridge POST_BUILD
+        COMMAND ${CMAKE_COMMAND}
+            -DFONT_DIR="$<TARGET_FILE_DIR:InputBridge>/fonts"
+            -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/RemoveFontMapFiles.cmake"
+        COMMENT "Removing font map files from build output directory"
+    )
+    
+    # Install the fonts/ folder alongside the binary.
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/fonts"
+        DESTINATION bin
+        FILES_MATCHING PATTERN "*.ttf" PATTERN "*.otf"
+    )
+endif()
 
 # Copy the protocols/ folder next to the executable at build time so the
 # program can find its presets and templates in the development build layout.
-add_custom_command(TARGET InputBridge POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-    "${CMAKE_CURRENT_SOURCE_DIR}/protocols"
-    "$<TARGET_FILE_DIR:InputBridge>/protocols"
-    COMMENT "Copying protocols/ to build output directory"
-)
+if(APPLE)
+    add_custom_command(TARGET InputBridge POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+        "${CMAKE_CURRENT_SOURCE_DIR}/protocols"
+        "$<TARGET_BUNDLE_CONTENT_DIR:InputBridge>/Resources/protocols"
+        COMMENT "Copying protocols/ into app bundle Resources"
+    )
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/protocols"
+        DESTINATION "InputBridge.app/Contents/Resources/protocols"
+        FILES_MATCHING PATTERN "*.json"
+    )
+else()
+    add_custom_command(TARGET InputBridge POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+        "${CMAKE_CURRENT_SOURCE_DIR}/protocols"
+        "$<TARGET_FILE_DIR:InputBridge>/protocols"
+        COMMENT "Copying protocols/ to build output directory"
+    )
 
-# Install the protocols/ folder alongside the binary.
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/protocols"
-    DESTINATION bin
-    FILES_MATCHING PATTERN "*.json"
-)
+    # Install the protocols/ folder alongside the binary.
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/protocols"
+        DESTINATION bin
+        FILES_MATCHING PATTERN "*.json"
+    )
+endif()
 
-# Copy the mappings/ folder next to the executable at build time.
-add_custom_command(TARGET InputBridge POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
-    "${CMAKE_CURRENT_SOURCE_DIR}/mappings"
-    "$<TARGET_FILE_DIR:InputBridge>/mappings"
-    COMMENT "Copying mappings/ to build output directory"
-)
+# Copy the mappings/ folder at build time.
+if(APPLE)
+    add_custom_command(TARGET InputBridge POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+        "${CMAKE_CURRENT_SOURCE_DIR}/mappings"
+        "$<TARGET_BUNDLE_CONTENT_DIR:InputBridge>/Resources/mappings"
+        COMMENT "Copying mappings/ into app bundle Resources"
+    )
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/mappings"
+        DESTINATION "InputBridge.app/Contents/Resources/mappings"
+        FILES_MATCHING PATTERN "*.json"
+    )
+else()
+    add_custom_command(TARGET InputBridge POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory
+        "${CMAKE_CURRENT_SOURCE_DIR}/mappings"
+        "$<TARGET_FILE_DIR:InputBridge>/mappings"
+        COMMENT "Copying mappings/ to build output directory"
+    )
 
-# Install the mappings/ folder alongside the binary.
-install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/mappings"
-    DESTINATION bin
-    FILES_MATCHING PATTERN "*.json"
-)
+    # Install the mappings/ folder alongside the binary.
+    install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/mappings"
+        DESTINATION bin
+        FILES_MATCHING PATTERN "*.json"
+    )
+endif()
 
 if(UNIX AND NOT APPLE)
     # Generate basic desktop file and icon for packaging (Required for AppImage/Flatpak)

--- a/org.inputbridge.InputBridge.yml
+++ b/org.inputbridge.InputBridge.yml
@@ -10,30 +10,14 @@ finish-args:
     - --share=network
     - --share=ipc
 modules:
-    # SDL3 is not part of the freedesktop runtime so it must be bundled.
-    # We build it from the same submodule the rest of the project uses
-    # (checked out by actions/checkout with submodules: recursive).
-    - name: SDL3
-      buildsystem: cmake-ninja
-      builddir: true
-      config-opts:
-          - -DCMAKE_BUILD_TYPE=Release
-          - -DSDL_SHARED=ON
-          - -DSDL_STATIC=OFF
-          - -DSDL_TEST_LIBRARY=OFF
-          - -DSDL_TESTS=OFF
-      sources:
-          - type: dir
-            path: lib/sdl
-
     - name: InputBridge
       buildsystem: cmake-ninja
       builddir: true
       config-opts:
           - -DCMAKE_BUILD_TYPE=Release
           - -DENABLE_WEBSOCKETS=ON
-          - -DSDL_SHARED=ON
-          - -DSDL_STATIC=OFF
+          - -DSDL_SHARED=OFF
+          - -DSDL_STATIC=ON
       sources:
           - type: dir
             path: .

--- a/org.inputbridge.InputBridge.yml
+++ b/org.inputbridge.InputBridge.yml
@@ -1,6 +1,6 @@
 app-id: org.inputbridge.InputBridge
 runtime: org.freedesktop.Platform
-runtime-version: "23.08"
+runtime-version: "25.08"
 sdk: org.freedesktop.Sdk
 command: InputBridge
 finish-args:
@@ -10,12 +10,30 @@ finish-args:
     - --share=network
     - --share=ipc
 modules:
+    # SDL3 is not part of the freedesktop runtime so it must be bundled.
+    # We build it from the same submodule the rest of the project uses
+    # (checked out by actions/checkout with submodules: recursive).
+    - name: SDL3
+      buildsystem: cmake-ninja
+      builddir: true
+      config-opts:
+          - -DCMAKE_BUILD_TYPE=Release
+          - -DSDL_SHARED=ON
+          - -DSDL_STATIC=OFF
+          - -DSDL_TEST_LIBRARY=OFF
+          - -DSDL_TESTS=OFF
+      sources:
+          - type: dir
+            path: lib/sdl
+
     - name: InputBridge
       buildsystem: cmake-ninja
       builddir: true
       config-opts:
           - -DCMAKE_BUILD_TYPE=Release
           - -DENABLE_WEBSOCKETS=ON
+          - -DSDL_SHARED=ON
+          - -DSDL_STATIC=OFF
       sources:
           - type: dir
             path: .

--- a/src/Protocols/ProtocolEditorWindow.cpp
+++ b/src/Protocols/ProtocolEditorWindow.cpp
@@ -690,7 +690,7 @@ void ProtocolEditorWindow::DrawContent() {
     if (WrapButton("Export...")) {
         ShowExportDialog();
     }
-    
+
     const char* modName = ImGui::GetIO().ConfigMacOSXBehaviors ? "Cmd" : "Ctrl";
 
     const bool canUndo = s_undoManager.CanUndo();
@@ -970,6 +970,7 @@ void ProtocolEditorWindow::DrawEditor() {
 void ProtocolEditorWindow::DrawOutputFieldPicker() {
     auto& registry = ProtocolRegistry::GetInstance();
     auto& definitions = registry.GetDefinitions();
+    if (s_selectedIndex < 0 || s_selectedIndex >= (int)definitions.size()) return;
     auto& definition = definitions[s_selectedIndex];
 
     const auto& catalog = registry.GetOutputFields();
@@ -1035,6 +1036,7 @@ void ProtocolEditorWindow::DrawOutputFieldPicker() {
 void ProtocolEditorWindow::DrawInputFieldPicker() {
     auto& registry = ProtocolRegistry::GetInstance();
     auto& definitions = registry.GetDefinitions();
+    if (s_selectedIndex < 0 || s_selectedIndex >= (int)definitions.size()) return;
     auto& definition = definitions[s_selectedIndex];
 
     const auto& catalog = registry.GetInputFields();


### PR DESCRIPTION
CI & Smoke Tests
- Add optional smoke tests to GitHub workflow actions for all 3 platform builds.
- Refactor macOS smoke test to update and subsequently remove the timeout dependency.
- Add missing changes for all Linux-based smoke tests.
- Extend process signal handling within smoke tests for better stability.

macOS Build Updates
- Update post-build CMake file copying logic to use TARGET_BUNDLE_CONTENT_DIR.
- Correctly bundle resources (fonts, themes, protocols, mappings) into Contents/Resources instead of Contents/MacOS.

Flatpak Configuration
- Update flatpak builder config to use runtime version 25.08.
- Fix issue where SDL3 was being statically linked inside the Flatpak bundle.

UI & Bug Fixes
- Add additional bounds checks with early exits to the draw input and output field picker methods.