### PR TITLE
Renamed input and output to send and receive for OSC and WebSocket protocols

### DIFF
--- a/src/Core/ProtocolValidator.cpp
+++ b/src/Core/ProtocolValidator.cpp
@@ -25,6 +25,10 @@ namespace {
 
     const std::string VAL_TRANSPORT_OSC = "osc";
     const std::string VAL_TRANSPORT_WEBSOCKET = "websocket";
+    const std::string VAL_DIRECTION_SEND = "send";
+    const std::string VAL_DIRECTION_RECEIVE = "receive";
+    // Legacy terms, still accepted so protocol files exported by older
+    // builds continue to validate correctly.
     const std::string VAL_DIRECTION_OUTPUT = "output";
     const std::string VAL_DIRECTION_INPUT = "input";
 
@@ -108,7 +112,7 @@ ValidationResult ProtocolValidator::ValidateProtocolDefinition(const ProtocolDef
             result.AddError(hostError);
         }
 
-        if (definition.direction == ProtocolDirection::Output) {
+        if (definition.direction == ProtocolDirection::Send) {
             std::string portError = ValidatePort(definition.oscSendPort, PORT_TYPE_OSC_SEND);
             if (!portError.empty()) {
                 result.AddError(portError);
@@ -197,8 +201,9 @@ ValidationResult ProtocolValidator::ValidateProtocolJSON(const json& j) {
     // Validate direction
     if (j.contains(KEY_DIRECTION)) {
         std::string direction = j[KEY_DIRECTION];
-        if (direction != VAL_DIRECTION_OUTPUT && direction != VAL_DIRECTION_INPUT) {
-            result.AddError("Invalid direction: must be '" + VAL_DIRECTION_OUTPUT + "' or '" + VAL_DIRECTION_INPUT + "'");
+        if (direction != VAL_DIRECTION_SEND && direction != VAL_DIRECTION_RECEIVE &&
+            direction != VAL_DIRECTION_OUTPUT && direction != VAL_DIRECTION_INPUT) {
+            result.AddError("Invalid direction: must be '" + VAL_DIRECTION_SEND + "' or '" + VAL_DIRECTION_RECEIVE + "'");
         }
     }
 

--- a/src/Mappers/InputMapping/InputMapperUI.cpp
+++ b/src/Mappers/InputMapping/InputMapperUI.cpp
@@ -228,12 +228,12 @@ void InputMapperUI::DrawOutputProtocolSelector() {
     bool changed = false;
 
     if (m_Store.SelectedProtocolView() == 0) {
-        changed |= DrawProtocolDefinitionCombo("OSC Output##out", profile->oscOutputProtocolId,
-                                                ProtocolTransport::OSC, ProtocolDirection::Output, 200.f);
+        changed |= DrawProtocolDefinitionCombo("OSC Send##out", profile->oscOutputProtocolId,
+                                                ProtocolTransport::OSC, ProtocolDirection::Send, 200.f);
     } else {
 #ifdef ENABLE_WEBSOCKETS
-        changed |= DrawProtocolDefinitionCombo("WS Output##out", profile->wsOutputProtocolId,
-                                                ProtocolTransport::WebSocket, ProtocolDirection::Output, 200.f);
+        changed |= DrawProtocolDefinitionCombo("WS Send##out", profile->wsOutputProtocolId,
+                                                ProtocolTransport::WebSocket, ProtocolDirection::Send, 200.f);
 #else
         ImGui::TextDisabled("WebSockets disabled.");
 #endif
@@ -262,12 +262,12 @@ void InputMapperUI::DrawInputProtocolSelector() {
                              changed);
 
     if (m_Store.SelectedProtocolView() == 0) {
-        changed |= DrawProtocolDefinitionCombo("OSC Input", profile->oscInputProtocolId, ProtocolTransport::OSC,
-                                                ProtocolDirection::Input);
+        changed |= DrawProtocolDefinitionCombo("OSC Receive", profile->oscInputProtocolId, ProtocolTransport::OSC,
+                                                ProtocolDirection::Receive);
     } else {
 #ifdef ENABLE_WEBSOCKETS
-        changed |= DrawProtocolDefinitionCombo("WebSocket Input", profile->wsInputProtocolId,
-                                                ProtocolTransport::WebSocket, ProtocolDirection::Input);
+        changed |= DrawProtocolDefinitionCombo("WebSocket Receive", profile->wsInputProtocolId,
+                                                ProtocolTransport::WebSocket, ProtocolDirection::Receive);
 #else
         ImGui::TextDisabled("WebSockets are disabled in this build.");
 #endif
@@ -658,12 +658,12 @@ void InputMapperUI::DrawMappingContent() {
                              changed);
 
     if (m_Store.SelectedProtocolView() == 0) {
-        changed |= DrawProtocolDefinitionCombo("OSC Output", profile.oscOutputProtocolId, ProtocolTransport::OSC,
-                                                ProtocolDirection::Output);
+        changed |= DrawProtocolDefinitionCombo("OSC Send", profile.oscOutputProtocolId, ProtocolTransport::OSC,
+                                                ProtocolDirection::Send);
     } else {
 #ifdef ENABLE_WEBSOCKETS
-        changed |= DrawProtocolDefinitionCombo("WebSocket Output", profile.wsOutputProtocolId,
-                                                ProtocolTransport::WebSocket, ProtocolDirection::Output);
+        changed |= DrawProtocolDefinitionCombo("WebSocket Send", profile.wsOutputProtocolId,
+                                                ProtocolTransport::WebSocket, ProtocolDirection::Send);
 #else
         ImGui::TextDisabled("WebSockets are disabled in this build.");
 #endif

--- a/src/Network/OSCServer.cpp
+++ b/src/Network/OSCServer.cpp
@@ -943,7 +943,7 @@ void OSCServer::DrawContent() {
         }
     };
 
-    // ── Output protocol (server → client) ─────────────────────────────────────
+    // ── Send protocol (server → client) ─────────────────────────────────────────
     {
         if (ImGui::Checkbox("##osc_out_en", &outputEnabled)) {
             SetOutputEnabled(outputEnabled);
@@ -951,10 +951,10 @@ void OSCServer::DrawContent() {
         }
         ImGui::SameLine();
         if (!outputEnabled) ImGui::BeginDisabled();
-        auto entries = buildEntries(ProtocolDirection::Output);
+        auto entries = buildEntries(ProtocolDirection::Send);
         int curIdx = findIdx(entries, outDefId, currentProto);
         int newIdx = curIdx;
-        ImGui::Text("Output (send to client)");
+        ImGui::Text("Send (to client)");
         drawCombo("##osc_out", entries, curIdx, newIdx);
         if (newIdx != curIdx && !entries[newIdx].isSeparator) {
             const auto& c = entries[newIdx];
@@ -966,7 +966,7 @@ void OSCServer::DrawContent() {
         if (!outputEnabled) ImGui::EndDisabled();
     }
 
-    // ── Input protocol (client → server) ──────────────────────────────────────
+    // ── Receive protocol (client → server) ──────────────────────────────────────
     {
         if (ImGui::Checkbox("##osc_in_en", &inputEnabled)) {
             SetInputEnabled(inputEnabled);
@@ -974,10 +974,10 @@ void OSCServer::DrawContent() {
         }
         ImGui::SameLine();
         if (!inputEnabled) ImGui::BeginDisabled();
-        auto entries = buildEntries(ProtocolDirection::Input);
+        auto entries = buildEntries(ProtocolDirection::Receive);
         int curIdx = findIdx(entries, inDefId, currentInputProto);
         int newIdx = curIdx;
-        ImGui::Text("Input (receive from client)");
+        ImGui::Text("Receive (from client)");
         drawCombo("##osc_in", entries, curIdx, newIdx);
         if (newIdx != curIdx && !entries[newIdx].isSeparator) {
             const auto& c = entries[newIdx];

--- a/src/Network/WebSocketServer.cpp
+++ b/src/Network/WebSocketServer.cpp
@@ -651,7 +651,7 @@ void WebSocketServer::DrawContent() {
         }
     };
 
-    // ── Output protocol (server → client) ────────────────────────────────────
+    // ── Send protocol (server → client) ──────────────────────────────────────
     {
         if (ImGui::Checkbox("##ws_out_en", &outputEnabled)) {
             SetOutputEnabled(outputEnabled);
@@ -659,10 +659,10 @@ void WebSocketServer::DrawContent() {
         }
         ImGui::SameLine();
         if (!outputEnabled) ImGui::BeginDisabled();
-        auto entries = buildEntries(ProtocolDirection::Output);
+        auto entries = buildEntries(ProtocolDirection::Send);
         int curIdx = findIdx(entries, outDefId);
         int newIdx = curIdx;
-        ImGui::Text("Output (send to clients)");
+        ImGui::Text("Send (to clients)");
         drawCombo("##out_proto", entries, curIdx, newIdx);
         if (newIdx != curIdx && !entries[newIdx].isSeparator) {
             const auto& c = entries[newIdx];
@@ -674,7 +674,7 @@ void WebSocketServer::DrawContent() {
         if (!outputEnabled) ImGui::EndDisabled();
     }
 
-    // ── Input protocol (client → server) ─────────────────────────────────────
+    // ── Receive protocol (client → server) ───────────────────────────────────
     {
         if (ImGui::Checkbox("##ws_in_en", &inputEnabled)) {
             SetInputEnabled(inputEnabled);
@@ -682,10 +682,10 @@ void WebSocketServer::DrawContent() {
         }
         ImGui::SameLine();
         if (!inputEnabled) ImGui::BeginDisabled();
-        auto entries = buildEntries(ProtocolDirection::Input);
+        auto entries = buildEntries(ProtocolDirection::Receive);
         int curIdx = findIdx(entries, inDefId);
         int newIdx = curIdx;
-        ImGui::Text("Input (receive from clients)");
+        ImGui::Text("Receive (from clients)");
         drawCombo("##in_proto", entries, curIdx, newIdx);
         if (newIdx != curIdx && !entries[newIdx].isSeparator) {
             const auto& c = entries[newIdx];

--- a/src/Protocols/ProtocolDefinition.h
+++ b/src/Protocols/ProtocolDefinition.h
@@ -40,8 +40,8 @@ struct ProtocolField {
 // ─── Protocol direction ─────────────────────────────────────────────────────
 
 enum class ProtocolDirection {
-    Output, // server → client  (send input / sensor data)
-    Input   // client → server  (receive haptic / command data)
+    Send,    // server → client  (send input / sensor data)
+    Receive  // client → server  (receive haptic / command data)
 };
 
 // ─── Transport type ─────────────────────────────────────────────────────────
@@ -57,7 +57,7 @@ struct ProtocolDefinition {
     std::string        id;          // unique UUID / slug (generated on creation)
     std::string        name;        // user-facing name, e.g. "Sim Racing OSC Out"
     ProtocolTransport  transport  = ProtocolTransport::OSC;
-    ProtocolDirection  direction  = ProtocolDirection::Output;
+    ProtocolDirection  direction  = ProtocolDirection::Send;
 
     // OSC-specific
     std::string oscHost     = "127.0.0.1";

--- a/src/Protocols/ProtocolEditorWindow.cpp
+++ b/src/Protocols/ProtocolEditorWindow.cpp
@@ -833,7 +833,7 @@ void ProtocolEditorWindow::DrawProtocolList() {
         const char* icon = (definition.transport == ProtocolTransport::OSC) ? "[OSC] " : "[WS]  ";
 
         // Direction indicator
-        const char* direction = (definition.direction == ProtocolDirection::Output) ? "↑" : "↓";
+        const char* direction = (definition.direction == ProtocolDirection::Send) ? "↑" : "↓";
 
         std::string label = std::string(icon) + direction + " " + definition.name + "##" + definition.id;
 
@@ -909,7 +909,7 @@ void ProtocolEditorWindow::DrawEditor() {
     ImGui::Text("Transport: %s",
                 definition.transport == ProtocolTransport::OSC ? "OSC" : "WebSocket");
     ImGui::Text("Direction: %s",
-                definition.direction == ProtocolDirection::Output ? "Output" : "Input");
+                definition.direction == ProtocolDirection::Send ? "Send" : "Receive");
 
     // ── Transport-specific settings ──────────────────────────────────────────
     if (definition.transport == ProtocolTransport::OSC) {
@@ -924,7 +924,7 @@ void ProtocolEditorWindow::DrawEditor() {
             needsSave = true;
         }
 
-        if (definition.direction == ProtocolDirection::Output) {
+        if (definition.direction == ProtocolDirection::Send) {
             ImGui::AlignTextToFramePadding();
             ImGui::TextUnformatted("Send Port:");
             if (ImGui::GetContentRegionAvail().x > 300.0f) ImGui::SameLine();
@@ -954,7 +954,7 @@ void ProtocolEditorWindow::DrawEditor() {
     ImGui::Separator();
 
     // ── Field selection ──────────────────────────────────────────────────────
-    if (definition.direction == ProtocolDirection::Output) {
+    if (definition.direction == ProtocolDirection::Send) {
         DrawOutputFieldPicker();
     } else {
         DrawInputFieldPicker();
@@ -1381,7 +1381,7 @@ void ProtocolEditorWindow::DrawNewProtocolModal() {
         const char* transports[] = {"OSC", "WebSocket"};
         ImGui::Combo("Transport", &s_newTransport, transports, 2);
 
-        const char* directions[] = {"Output", "Input"};
+        const char* directions[] = {"Send", "Receive"};
         ImGui::Combo("Direction", &s_newDirection, directions, 2);
 
         // Template selection - templates and presets are the same thing.
@@ -1399,7 +1399,7 @@ void ProtocolEditorWindow::DrawNewProtocolModal() {
             ProtocolTransport transport = (s_newTransport == 0) ?
                 ProtocolTransport::OSC : ProtocolTransport::WebSocket;
             ProtocolDirection direction = (s_newDirection == 0) ?
-                ProtocolDirection::Output : ProtocolDirection::Input;
+                ProtocolDirection::Send : ProtocolDirection::Receive;
 
             std::string newId = ProtocolRegistry::GetInstance().CreateDefinition(
                 s_newName, transport, direction);
@@ -2301,7 +2301,7 @@ void ProtocolEditorWindow::DrawHideCategoryModal() {
             ImGui::Separator();
 
             // Build the full category list for the relevant catalog.
-            bool isOutput = (def.direction == ProtocolDirection::Output);
+            bool isOutput = (def.direction == ProtocolDirection::Send);
             const auto& catalog = isOutput ? registry.GetOutputFields()
                                            : registry.GetInputFields();
             std::vector<std::string> cats;
@@ -2390,7 +2390,7 @@ void ProtocolEditorWindow::DrawSaveTemplateModal() {
                     j["protocol_id"]      = def.id;
                     j["protocol_name"]    = def.name;
                     j["transport"]        = (def.transport == ProtocolTransport::OSC) ? "OSC" : "WebSocket";
-                    j["direction"]        = (def.direction == ProtocolDirection::Output) ? "Output" : "Input";
+                    j["direction"]        = (def.direction == ProtocolDirection::Send) ? "Send" : "Receive";
                     json fieldsArr = json::array();
                     for (const auto& pf : def.fields) {
                         if (!pf.enabled) continue;

--- a/src/Protocols/ProtocolRegistry.cpp
+++ b/src/Protocols/ProtocolRegistry.cpp
@@ -197,7 +197,7 @@ bool ProtocolRegistry::ExportDefinition(const std::string& id, const std::string
     j["id"]        = def->id;
     j["name"]      = def->name;
     j["transport"] = (def->transport == ProtocolTransport::OSC) ? "osc" : "websocket";
-    j["direction"] = (def->direction == ProtocolDirection::Output) ? "output" : "input";
+    j["direction"] = (def->direction == ProtocolDirection::Send) ? "send" : "receive";
     j["active"]    = false; // Don't activate exported protocols by default
 
     j["osc"]["host"]     = def->oscHost;
@@ -257,10 +257,14 @@ std::string ProtocolRegistry::ImportDefinition(const std::string& path) {
         std::string ts = j.value("transport", "osc");
         def.transport = (ts == "websocket") ? ProtocolTransport::WebSocket : ProtocolTransport::OSC;
 
-        std::string dir_s = j.value("direction", "output");
-        def.direction = (dir_s == "input") ? ProtocolDirection::Input : ProtocolDirection::Output;
-
         def.active = false;
+
+        // Accept both the current "send"/"receive" terms and the legacy
+        // "output"/"input" terms so protocol files exported by older builds
+        // still import correctly.
+        std::string dir_s = j.value("direction", "send");
+        def.direction = (dir_s == "receive" || dir_s == "input")
+                            ? ProtocolDirection::Receive : ProtocolDirection::Send;
 
         if (j.contains("osc")) {
             def.oscHost     = j["osc"].value("host",     "127.0.0.1");
@@ -297,7 +301,7 @@ std::string ProtocolRegistry::ImportDefinition(const std::string& path) {
                 // Auto-register the field in the catalog when it is unknown so
                 // that the editor can display and manipulate it without requiring
                 // a matching entry in input_fields.json.
-                auto& catalog = (def.direction == ProtocolDirection::Output)
+                auto& catalog = (def.direction == ProtocolDirection::Send)
                                  ? m_outputFields : m_inputFields;
 
                 // Check both catalogs: a field may legitimately live in the
@@ -369,7 +373,7 @@ void ProtocolRegistry::SaveDefinition(const ProtocolDefinition& def) {
     j["id"]        = def.id;
     j["name"]      = def.name;
     j["transport"] = (def.transport == ProtocolTransport::OSC) ? "osc" : "websocket";
-    j["direction"] = (def.direction == ProtocolDirection::Output) ? "output" : "input";
+    j["direction"] = (def.direction == ProtocolDirection::Send) ? "send" : "receive";
     j["active"]    = def.active;
 
     j["osc"]["host"]     = def.oscHost;
@@ -449,7 +453,7 @@ const char* ProtocolRegistry::TransportLabel(ProtocolTransport t) {
 }
 
 const char* ProtocolRegistry::DirectionLabel(ProtocolDirection d) {
-    return d == ProtocolDirection::Output ? "Output (server → client)" : "Input (client → server)";
+    return d == ProtocolDirection::Send ? "Send (server → client)" : "Receive (client → server)";
 }
 
 // --- Private helpers ---------------------------------------------------------
@@ -654,8 +658,12 @@ void ProtocolRegistry::LoadDefinitionFiles() {
             std::string ts = j.value("transport", "osc");
             def.transport = (ts == "websocket") ? ProtocolTransport::WebSocket : ProtocolTransport::OSC;
 
-            std::string dir_s = j.value("direction", "output");
-            def.direction = (dir_s == "input") ? ProtocolDirection::Input : ProtocolDirection::Output;
+            // Accept both "send"/"receive" (current) and "output"/"input"
+            // (legacy) so definition files saved by older builds still load
+            // with the correct direction.
+            std::string dir_s = j.value("direction", "send");
+            def.direction = (dir_s == "receive" || dir_s == "input")
+                                ? ProtocolDirection::Receive : ProtocolDirection::Send;
 
             def.active = j.value("active", false);
 
@@ -689,7 +697,7 @@ void ProtocolRegistry::LoadDefinitionFiles() {
                     def.fields.push_back(f);
 
                     // Auto-register unknown fields so the editor shows them.
-                    auto& catalog = (def.direction == ProtocolDirection::Output)
+                    auto& catalog = (def.direction == ProtocolDirection::Send)
                                      ? m_outputFields : m_inputFields;
                     // Check both catalogs before synthesising an entry; the
                     // field may already be registered on the opposite side.

--- a/tests/test_protocol_data.cpp
+++ b/tests/test_protocol_data.cpp
@@ -11,9 +11,9 @@ TEST(ProtocolDefinition, DefaultTransportIsOSC) {
     EXPECT_EQ(def.transport, ProtocolTransport::OSC);
 }
 
-TEST(ProtocolDefinition, DefaultDirectionIsOutput) {
+TEST(ProtocolDefinition, DefaultDirectionIsSend) {
     ProtocolDefinition def;
-    EXPECT_EQ(def.direction, ProtocolDirection::Output);
+    EXPECT_EQ(def.direction, ProtocolDirection::Send);
 }
 
 TEST(ProtocolDefinition, DefaultOSCHost) {
@@ -62,10 +62,10 @@ TEST(ProtocolDefinition, CanSetTransportToWebSocket) {
     EXPECT_EQ(def.transport, ProtocolTransport::WebSocket);
 }
 
-TEST(ProtocolDefinition, CanSetDirectionToInput) {
+TEST(ProtocolDefinition, CanSetDirectionToReceive) {
     ProtocolDefinition def;
-    def.direction = ProtocolDirection::Input;
-    EXPECT_EQ(def.direction, ProtocolDirection::Input);
+    def.direction = ProtocolDirection::Receive;
+    EXPECT_EQ(def.direction, ProtocolDirection::Receive);
 }
 
 TEST(ProtocolDefinition, CanAddField) {

--- a/tests/test_protocol_validator.cpp
+++ b/tests/test_protocol_validator.cpp
@@ -247,19 +247,19 @@ TEST(ValidateFieldId, Over64CharsIsError) {
 // ═════════════════════════════════════════════════════════════════════════════
 
 TEST(ValidateProtocolJSON, MissingIdIsError) {
-    json j = { {"name","Test"}, {"transport","osc"}, {"direction","output"} };
+    json j = { {"name","Test"}, {"transport","osc"}, {"direction","send"} };
     auto r = ProtocolValidator::ValidateProtocolJSON(j);
     EXPECT_FALSE(r.IsValid());
 }
 
 TEST(ValidateProtocolJSON, MissingNameIsError) {
-    json j = { {"id","abc"}, {"transport","osc"}, {"direction","output"} };
+    json j = { {"id","abc"}, {"transport","osc"}, {"direction","send"} };
     auto r = ProtocolValidator::ValidateProtocolJSON(j);
     EXPECT_FALSE(r.IsValid());
 }
 
 TEST(ValidateProtocolJSON, MissingTransportIsError) {
-    json j = { {"id","abc"}, {"name","Test"}, {"direction","output"} };
+    json j = { {"id","abc"}, {"name","Test"}, {"direction","send"} };
     auto r = ProtocolValidator::ValidateProtocolJSON(j);
     EXPECT_FALSE(r.IsValid());
 }
@@ -271,7 +271,7 @@ TEST(ValidateProtocolJSON, MissingDirectionIsError) {
 }
 
 TEST(ValidateProtocolJSON, InvalidTransportIsError) {
-    json j = { {"id","abc"}, {"name","Test"}, {"transport","serial"}, {"direction","output"} };
+    json j = { {"id","abc"}, {"name","Test"}, {"transport","serial"}, {"direction","send"} };
     auto r = ProtocolValidator::ValidateProtocolJSON(j);
     EXPECT_FALSE(r.IsValid());
 }
@@ -282,9 +282,19 @@ TEST(ValidateProtocolJSON, InvalidDirectionIsError) {
     EXPECT_FALSE(r.IsValid());
 }
 
+TEST(ValidateProtocolJSON, LegacyOutputInputDirectionStillValid) {
+    // Files exported by older builds use "output"/"input" instead of the
+    // current "send"/"receive" - both must keep validating.
+    json outJ = { {"id","abc"}, {"name","Test"}, {"transport","osc"}, {"direction","output"} };
+    EXPECT_TRUE(ProtocolValidator::ValidateProtocolJSON(outJ).IsValid());
+
+    json inJ = { {"id","abc"}, {"name","Test"}, {"transport","osc"}, {"direction","input"} };
+    EXPECT_TRUE(ProtocolValidator::ValidateProtocolJSON(inJ).IsValid());
+}
+
 TEST(ValidateProtocolJSON, ValidMinimalOSCIsValid) {
     json j = {
-        {"id","abc"}, {"name","Test"}, {"transport","osc"}, {"direction","output"},
+        {"id","abc"}, {"name","Test"}, {"transport","osc"}, {"direction","send"},
         {"oscHost","127.0.0.1"}, {"oscSendPort",9066}, {"fields", json::array()}
     };
     auto r = ProtocolValidator::ValidateProtocolJSON(j);
@@ -293,7 +303,7 @@ TEST(ValidateProtocolJSON, ValidMinimalOSCIsValid) {
 
 TEST(ValidateProtocolJSON, ValidMinimalWebSocketIsValid) {
     json j = {
-        {"id","abc"}, {"name","Test"}, {"transport","websocket"}, {"direction","input"},
+        {"id","abc"}, {"name","Test"}, {"transport","websocket"}, {"direction","receive"},
         {"wssPort",4269}, {"fields", json::array()}
     };
     auto r = ProtocolValidator::ValidateProtocolJSON(j);
@@ -302,7 +312,7 @@ TEST(ValidateProtocolJSON, ValidMinimalWebSocketIsValid) {
 
 TEST(ValidateProtocolJSON, MissingOSCHostProducesWarningNotError) {
     json j = {
-        {"id","abc"}, {"name","Test"}, {"transport","osc"}, {"direction","output"},
+        {"id","abc"}, {"name","Test"}, {"transport","osc"}, {"direction","send"},
         {"fields", json::array()}
     };
     auto r = ProtocolValidator::ValidateProtocolJSON(j);
@@ -312,7 +322,7 @@ TEST(ValidateProtocolJSON, MissingOSCHostProducesWarningNotError) {
 
 TEST(ValidateProtocolJSON, EmptyFieldsArrayProducesWarning) {
     json j = {
-        {"id","abc"}, {"name","Test"}, {"transport","osc"}, {"direction","output"},
+        {"id","abc"}, {"name","Test"}, {"transport","osc"}, {"direction","send"},
         {"oscHost","127.0.0.1"}, {"oscSendPort",9066},
         {"fields", json::array()}
     };
@@ -330,7 +340,7 @@ TEST(ValidateProtocolDefinition, ValidOSCDefinitionPasses) {
     def.id        = "test-osc";
     def.name      = "Test OSC";
     def.transport = ProtocolTransport::OSC;
-    def.direction = ProtocolDirection::Output;
+    def.direction = ProtocolDirection::Send;
     def.oscHost   = "127.0.0.1";
     def.oscSendPort = 9066;
 
@@ -343,7 +353,7 @@ TEST(ValidateProtocolDefinition, ValidWebSocketDefinitionPasses) {
     def.id        = "test-ws";
     def.name      = "Test WS";
     def.transport = ProtocolTransport::WebSocket;
-    def.direction = ProtocolDirection::Input;
+    def.direction = ProtocolDirection::Receive;
     def.wssPort   = 4269;
 
     auto r = ProtocolValidator::ValidateProtocolDefinition(def);
@@ -355,7 +365,7 @@ TEST(ValidateProtocolDefinition, InvalidPortIsError) {
     def.id        = "bad-port";
     def.name      = "Bad Port";
     def.transport = ProtocolTransport::OSC;
-    def.direction = ProtocolDirection::Output;
+    def.direction = ProtocolDirection::Send;
     def.oscHost   = "127.0.0.1";
     def.oscSendPort = 0;  // invalid
 
@@ -368,7 +378,7 @@ TEST(ValidateProtocolDefinition, EmptyIdIsError) {
     def.id        = "";  // empty
     def.name      = "No ID";
     def.transport = ProtocolTransport::WebSocket;
-    def.direction = ProtocolDirection::Output;
+    def.direction = ProtocolDirection::Send;
     def.wssPort   = 4269;
 
     auto r = ProtocolValidator::ValidateProtocolDefinition(def);


### PR DESCRIPTION
Renamed protocol direction Output/Input to Send/Receive
Reads and Validation still accept legacy "output"/"input" strings, so existing config and protocol files keep working
Updated  and added coverage for both changes, including legacy-value backward compatibility