### PR TITLE
Adaptive trigger rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Incoming haptic paths - both short and long forms are always active:
 
 Subchannel paths encode the slot in the URL (`/haptic/rumble/0`, `/haptic/rumble/1`, …) for hosts like Resonite that allow only one message per path per frame.
 
-DualSense adaptive triggers use `/inputbridge/haptics/dualsense/trigger/{left|right}/{feedback|weapon|vibration|off}`.
+DualSense adaptive triggers use `/haptic/dualsense_trigger_{left|right}_{feedback|weapon|vibration|bow|galloping|machine|off}`.
 
 ### WebSocket Server
 

--- a/src/Core/ProtocolValidator.cpp
+++ b/src/Core/ProtocolValidator.cpp
@@ -25,6 +25,10 @@ namespace {
 
     const std::string VAL_TRANSPORT_OSC = "osc";
     const std::string VAL_TRANSPORT_WEBSOCKET = "websocket";
+    const std::string VAL_DIRECTION_SEND = "send";
+    const std::string VAL_DIRECTION_RECEIVE = "receive";
+    // Legacy terms, still accepted so protocol files exported by older
+    // builds continue to validate correctly.
     const std::string VAL_DIRECTION_OUTPUT = "output";
     const std::string VAL_DIRECTION_INPUT = "input";
 
@@ -108,7 +112,7 @@ ValidationResult ProtocolValidator::ValidateProtocolDefinition(const ProtocolDef
             result.AddError(hostError);
         }
 
-        if (definition.direction == ProtocolDirection::Output) {
+        if (definition.direction == ProtocolDirection::Send) {
             std::string portError = ValidatePort(definition.oscSendPort, PORT_TYPE_OSC_SEND);
             if (!portError.empty()) {
                 result.AddError(portError);
@@ -197,8 +201,9 @@ ValidationResult ProtocolValidator::ValidateProtocolJSON(const json& j) {
     // Validate direction
     if (j.contains(KEY_DIRECTION)) {
         std::string direction = j[KEY_DIRECTION];
-        if (direction != VAL_DIRECTION_OUTPUT && direction != VAL_DIRECTION_INPUT) {
-            result.AddError("Invalid direction: must be '" + VAL_DIRECTION_OUTPUT + "' or '" + VAL_DIRECTION_INPUT + "'");
+        if (direction != VAL_DIRECTION_SEND && direction != VAL_DIRECTION_RECEIVE &&
+            direction != VAL_DIRECTION_OUTPUT && direction != VAL_DIRECTION_INPUT) {
+            result.AddError("Invalid direction: must be '" + VAL_DIRECTION_SEND + "' or '" + VAL_DIRECTION_RECEIVE + "'");
         }
     }
 

--- a/src/Haptics/DualSenseController.cpp
+++ b/src/Haptics/DualSenseController.cpp
@@ -47,7 +47,10 @@ void DualSense::OutputState::Reset() {
 
 InputBridge::Result<bool, InputBridge::HapticError> DualSenseController::Init() {
     m_connectionTypeDetected = false;
-    m_outputState.Reset();
+    {
+        std::lock_guard<std::mutex> lock(m_outputStateMutex);
+        m_outputState.Reset();
+    }
     
     // Call base class init
     auto result = HapticDevice::Init();
@@ -169,11 +172,14 @@ int DualSenseController::SetTriggerEffect(const std::string& trigger,
     
     // Apply effect to appropriate trigger(s)
     bool success = true;
-    if (updateLeft) {
-        success &= ApplyTriggerEffect(m_outputState.leftTriggerEffect.data(), effectType, params);
-    }
-    if (updateRight) {
-        success &= ApplyTriggerEffect(m_outputState.rightTriggerEffect.data(), effectType, params);
+    {
+        std::lock_guard<std::mutex> lock(m_outputStateMutex);
+        if (updateLeft) {
+            success &= ApplyTriggerEffect(m_outputState.leftTriggerEffect.data(), effectType, params);
+        }
+        if (updateRight) {
+            success &= ApplyTriggerEffect(m_outputState.rightTriggerEffect.data(), effectType, params);
+        }
     }
     
     if (!success) {
@@ -250,32 +256,40 @@ bool DualSenseController::ApplyTriggerEffect(uint8_t* triggerData,
 }
 
 void DualSenseController::DisableTriggerEffects() {
-    ExtendInput::DataTools::DualSense::DualSenseTriggerEffectGenerator::Off(m_outputState.leftTriggerEffect.data(), 0);
-    ExtendInput::DataTools::DualSense::DualSenseTriggerEffectGenerator::Off(m_outputState.rightTriggerEffect.data(), 0);
+    {
+        std::lock_guard<std::mutex> lock(m_outputStateMutex);
+        ExtendInput::DataTools::DualSense::DualSenseTriggerEffectGenerator::Off(m_outputState.leftTriggerEffect.data(), 0);
+        ExtendInput::DataTools::DualSense::DualSenseTriggerEffectGenerator::Off(m_outputState.rightTriggerEffect.data(), 0);
+    }
     ApplyOutputState();
 }
 
 // ==================== LED Control ====================
 
 void DualSenseController::SetLEDColor(const DualSense::RGBColor& color) {
+    std::lock_guard<std::mutex> lock(m_outputStateMutex);
     m_outputState.ledColor = color;
 }
 
 void DualSenseController::SetLEDBrightness(uint8_t brightness) {
+    std::lock_guard<std::mutex> lock(m_outputStateMutex);
     m_outputState.ledBrightness = brightness;
 }
 
 void DualSenseController::SetPlayerLEDs(uint8_t playerMask) {
+    std::lock_guard<std::mutex> lock(m_outputStateMutex);
     m_outputState.playerLEDs = playerMask & 0x1F;  // 5-bit mask
 }
 
 void DualSenseController::SetMuteLED(uint8_t state) {
+    std::lock_guard<std::mutex> lock(m_outputStateMutex);
     m_outputState.muteLED = state;
 }
 
 // ==================== Rumble Motors ====================
 
 void DualSenseController::SetRumble(uint8_t leftIntensity, uint8_t rightIntensity) {
+    std::lock_guard<std::mutex> lock(m_outputStateMutex);
     m_outputState.leftRumble = leftIntensity;
     m_outputState.rightRumble = rightIntensity;
 }
@@ -300,54 +314,60 @@ bool DualSenseController::SendOutput() {
     // Bluetooth, so one buffer works for both connection types.
     std::array<uint8_t, EFFECTS_PAYLOAD_SIZE> data{};
 
-    // ucEnableBits1 (offset 0): rumble + which trigger(s) we're driving.
-    // The MODIFY_RIGHT/LEFT_TRIGGER bits are what actually tell the firmware
-    // to apply rgucRightTriggerEffect/rgucLeftTriggerEffect - without them the
-    // trigger effect bytes are silently ignored.
-    uint8_t enableBits1 = ENABLE1_MODIFY_RIGHT_TRIGGER | ENABLE1_MODIFY_LEFT_TRIGGER;
-    if (m_outputState.leftRumble != 0 || m_outputState.rightRumble != 0) {
-        enableBits1 |= ENABLE1_RUMBLE_EMULATION | ENABLE1_DISABLE_AUDIO_HAPTICS;
+    {
+        std::lock_guard<std::mutex> lock(m_outputStateMutex);
+
+        // ucEnableBits1 (offset 0): rumble + which trigger(s) we're driving.
+        // The MODIFY_RIGHT/LEFT_TRIGGER bits are what actually tell the firmware
+        // to apply rgucRightTriggerEffect/rgucLeftTriggerEffect - without them the
+        // trigger effect bytes are silently ignored.
+        uint8_t enableBits1 = ENABLE1_MODIFY_RIGHT_TRIGGER | ENABLE1_MODIFY_LEFT_TRIGGER;
+        if (m_outputState.leftRumble != 0 || m_outputState.rightRumble != 0) {
+            enableBits1 |= ENABLE1_RUMBLE_EMULATION | ENABLE1_DISABLE_AUDIO_HAPTICS;
+        }
+        data[0] = enableBits1;
+
+        // ucEnableBits2 (offset 1): LED color / player lights.
+        uint8_t enableBits2 = 0;
+        const bool ledSet = (m_outputState.ledColor.red != 0 ||
+                              m_outputState.ledColor.green != 0 ||
+                              m_outputState.ledColor.blue != 0);
+        if (ledSet) {
+            enableBits2 |= ENABLE2_LED_COLOR;
+        }
+        if (m_outputState.playerLEDs != 0) {
+            enableBits2 |= ENABLE2_PLAYER_LIGHTS;
+        }
+        data[1] = enableBits2;
+
+        // ucRumbleRight / ucRumbleLeft (offsets 2-3)
+        data[2] = m_outputState.rightRumble;
+        data[3] = m_outputState.leftRumble;
+
+        // ucMicLightMode (offset 8) - reuse muteLED state for the mic/mute light
+        data[8] = m_outputState.muteLED;
+
+        // rgucRightTriggerEffect / rgucLeftTriggerEffect (offsets 10 / 21)
+        std::memcpy(&data[RIGHT_TRIGGER_OFFSET], m_outputState.rightTriggerEffect.data(), 11);
+        std::memcpy(&data[LEFT_TRIGGER_OFFSET], m_outputState.leftTriggerEffect.data(), 11);
+
+        // ucLedBrightness (offset 42), ucPadLights (offset 43),
+        // ucLedRed/Green/Blue (offsets 44-46)
+        data[LED_BRIGHTNESS_OFFSET] = m_outputState.ledBrightness;
+        data[PAD_LIGHTS_OFFSET] = m_outputState.playerLEDs;
+        data[LED_RED_OFFSET] = m_outputState.ledColor.red;
+        data[LED_GREEN_OFFSET] = m_outputState.ledColor.green;
+        data[LED_BLUE_OFFSET] = m_outputState.ledColor.blue;
     }
-    data[0] = enableBits1;
-
-    // ucEnableBits2 (offset 1): LED color / player lights.
-    uint8_t enableBits2 = 0;
-    const bool ledSet = (m_outputState.ledColor.red != 0 ||
-                          m_outputState.ledColor.green != 0 ||
-                          m_outputState.ledColor.blue != 0);
-    if (ledSet) {
-        enableBits2 |= ENABLE2_LED_COLOR;
-    }
-    if (m_outputState.playerLEDs != 0) {
-        enableBits2 |= ENABLE2_PLAYER_LIGHTS;
-    }
-    data[1] = enableBits2;
-
-    // ucRumbleRight / ucRumbleLeft (offsets 2-3)
-    data[2] = m_outputState.rightRumble;
-    data[3] = m_outputState.leftRumble;
-
-    // ucMicLightMode (offset 8) - reuse muteLED state for the mic/mute light
-    data[8] = m_outputState.muteLED;
-
-    // rgucRightTriggerEffect / rgucLeftTriggerEffect (offsets 10 / 21)
-    std::memcpy(&data[RIGHT_TRIGGER_OFFSET], m_outputState.rightTriggerEffect.data(), 11);
-    std::memcpy(&data[LEFT_TRIGGER_OFFSET], m_outputState.leftTriggerEffect.data(), 11);
-
-    // ucLedBrightness (offset 42), ucPadLights (offset 43),
-    // ucLedRed/Green/Blue (offsets 44-46)
-    data[LED_BRIGHTNESS_OFFSET] = m_outputState.ledBrightness;
-    data[PAD_LIGHTS_OFFSET] = m_outputState.playerLEDs;
-    data[LED_RED_OFFSET] = m_outputState.ledColor.red;
-    data[LED_GREEN_OFFSET] = m_outputState.ledColor.green;
-    data[LED_BLUE_OFFSET] = m_outputState.ledColor.blue;
+    // Lock released - everything below reads only the local `data` copy, not
+    // m_outputState, so it can't race with a subsequent writer.
 
     LOG_DEBUG(kTag, "Sending effects payload, size=%zu (connection=%s)", data.size(),
               GetConnectionType() == DualSense::ConnectionType::USB ? "USB" : "Bluetooth");
     LOG_DEBUG(kTag, "  EnableBits: [0]=0x%02X [1]=0x%02X", data[0], data[1]);
     LOG_DEBUG(kTag, "  Rumble: L=%d R=%d", data[3], data[2]);
     LOG_DEBUG(kTag, "  Triggers: R[0]=0x%02X L[0]=0x%02X",
-           m_outputState.rightTriggerEffect[0], m_outputState.leftTriggerEffect[0]);
+           data[RIGHT_TRIGGER_OFFSET], data[LEFT_TRIGGER_OFFSET]);
 
     if (!SDL_SendJoystickEffect(m_joystick, data.data(), data.size())) {
         LOG_WARN(kTag, "DualSense: Send failed - %s", SDL_GetError());

--- a/src/Haptics/DualSenseController.cpp
+++ b/src/Haptics/DualSenseController.cpp
@@ -47,7 +47,6 @@ void DualSense::OutputState::Reset() {
 
 InputBridge::Result<bool, InputBridge::HapticError> DualSenseController::Init() {
     m_connectionTypeDetected = false;
-    m_bluetoothSequence = 0;
     m_outputState.Reset();
     
     // Call base class init
@@ -285,154 +284,76 @@ void DualSenseController::SetRumble(uint8_t leftIntensity, uint8_t rightIntensit
 
 void DualSenseController::ApplyOutputState() {
     RunAsync([this]() {
-        const DualSense::ConnectionType connType = GetConnectionType();
-        
-        bool success = false;
-        if (connType == DualSense::ConnectionType::USB) {
-            success = SendUSBOutput();
-        } else {
-            success = SendBluetoothOutput();
-        }
-        
-        if (!success) {
+        if (!SendOutput()) {
             LOG_WARN(kTag, "Failed to send output state");
         }
     });
 }
 
-bool DualSenseController::SendUSBOutput() {
-    // USB report is 63 bytes (bluetooth 48)
-    std::array<uint8_t, USB_REPORT_SIZE> data{};
-    
-    data[0] = USB_REPORT_ID;  // 0x02
-    
-    // Feature flags byte 1 (offset 1)
-    // Enable HID mode and rumble
-    data[1] = USB_FLAG_ENABLE_HID | USB_FLAG_ENABLE_RUMBLE;
-    
-    // Feature flags byte 2 (offset 2)
-    // Only enable LED/player flags if they're actually being set
-    uint8_t flags2 = FLAG2_ENABLE_HAPTICS;  // Always enable haptics for triggers
-    
-    // Only enable LED if not black
-    if (m_outputState.ledColor.red != 0 || 
-        m_outputState.ledColor.green != 0 || 
-        m_outputState.ledColor.blue != 0) {
-        flags2 |= FLAG2_ENABLE_LED_COLOR;
-    }
-    
-    // Only enable player LEDs if set
-    if (m_outputState.playerLEDs != 0) {
-        flags2 |= FLAG2_ENABLE_PLAYER_LEDS;
-    }
-    
-    data[2] = flags2;
-    
-    // Rumble motors (offset 3-4)
-    data[3] = m_outputState.rightRumble;
-    data[4] = m_outputState.leftRumble;
-    
-    // Mute LED (offset 9)
-    data[9] = m_outputState.muteLED;
-    
-    // Right trigger at offset 11
-    std::memcpy(&data[USB_RIGHT_TRIGGER_OFFSET], m_outputState.rightTriggerEffect.data(), 11);
-    
-    // Left trigger at offset 22
-    std::memcpy(&data[USB_LEFT_TRIGGER_OFFSET], m_outputState.leftTriggerEffect.data(), 11);
-    
-    // LED color (offset 39-41)
-    data[39] = m_outputState.ledColor.red;
-    data[40] = m_outputState.ledColor.green;
-    data[41] = m_outputState.ledColor.blue;
-    
-    // Player LEDs (offset 42)
-    data[42] = m_outputState.playerLEDs;
-    
-    // LED brightness (offset 43)
-    data[43] = m_outputState.ledBrightness;
-    
-    LOG_DEBUG(kTag, "USB: Sending report, size=%zu", data.size());
-    LOG_DEBUG(kTag, "  Flags: [1]=0x%02X [2]=0x%02X", data[1], data[2]);
-    LOG_DEBUG(kTag, "  Rumble: L=%d R=%d", data[4], data[3]);
-    LOG_DEBUG(kTag, "  Triggers: R[0]=0x%02X L[0]=0x%02X", 
-           m_outputState.rightTriggerEffect[0], m_outputState.leftTriggerEffect[0]);
-    
-    if (!SDL_SendJoystickEffect(m_joystick, data.data(), data.size())) {
-        LOG_WARN(kTag, "DualSense USB: Send failed - %s", SDL_GetError());
-        return false;
-    }
-    
-    LOG_DEBUG(kTag, "USB: Report sent successfully");
-    return true;
-}
+bool DualSenseController::SendOutput() {
+    // This buffer is ONLY the DS5EffectsState_t-equivalent payload (47 bytes),
+    // starting at ucEnableBits1. SDL's PS5 HIDAPI driver prepends the report
+    // ID itself (and, on Bluetooth, a sequence/tag byte plus a trailing CRC),
+    // so this must NOT include a report ID/sequence byte of our own - doing so
+    // shifts every field (including the trigger effect bytes) out of place and
+    // silently breaks adaptive triggers. SDL also auto-detects USB vs
+    // Bluetooth, so one buffer works for both connection types.
+    std::array<uint8_t, EFFECTS_PAYLOAD_SIZE> data{};
 
-bool DualSenseController::SendBluetoothOutput() {
-    // Bluetooth report is 78 bytes
-    std::array<uint8_t, BT_REPORT_SIZE> data{};
-    
-    data[0] = BT_REPORT_ID;  // 0x31
-    
-    // Sequence byte (offset 1)
-    // Increment sequence counter (0-15) and set enable flag
-    m_bluetoothSequence = (m_bluetoothSequence + 1) & 0x0F;
-    data[1] = 0x10 | m_bluetoothSequence;  // 0x10 = enable flag
-    
-    // Feature flags byte 1 (offset 2)
-    data[2] = BT_FLAG_ENABLE_RUMBLE_EMULATION;
-    
-    // Feature flags byte 2 (offset 3)
-    // Only enable LED/player flags if they're actually being set
-    uint8_t flags2 = FLAG2_ENABLE_HAPTICS;  // Always enable haptics for triggers
-    
-    // Only enable LED if not black
-    if (m_outputState.ledColor.red != 0 || 
-        m_outputState.ledColor.green != 0 || 
-        m_outputState.ledColor.blue != 0) {
-        flags2 |= FLAG2_ENABLE_LED_COLOR;
+    // ucEnableBits1 (offset 0): rumble + which trigger(s) we're driving.
+    // The MODIFY_RIGHT/LEFT_TRIGGER bits are what actually tell the firmware
+    // to apply rgucRightTriggerEffect/rgucLeftTriggerEffect - without them the
+    // trigger effect bytes are silently ignored.
+    uint8_t enableBits1 = ENABLE1_MODIFY_RIGHT_TRIGGER | ENABLE1_MODIFY_LEFT_TRIGGER;
+    if (m_outputState.leftRumble != 0 || m_outputState.rightRumble != 0) {
+        enableBits1 |= ENABLE1_RUMBLE_EMULATION | ENABLE1_DISABLE_AUDIO_HAPTICS;
     }
-    
-    // Only enable player LEDs if set
+    data[0] = enableBits1;
+
+    // ucEnableBits2 (offset 1): LED color / player lights.
+    uint8_t enableBits2 = 0;
+    const bool ledSet = (m_outputState.ledColor.red != 0 ||
+                          m_outputState.ledColor.green != 0 ||
+                          m_outputState.ledColor.blue != 0);
+    if (ledSet) {
+        enableBits2 |= ENABLE2_LED_COLOR;
+    }
     if (m_outputState.playerLEDs != 0) {
-        flags2 |= FLAG2_ENABLE_PLAYER_LEDS;
+        enableBits2 |= ENABLE2_PLAYER_LIGHTS;
     }
-    
-    data[3] = flags2;
-    
-    // Rumble motors (offset 4-5)
-    data[4] = m_outputState.rightRumble;
-    data[5] = m_outputState.leftRumble;
-    
-    // Mute LED (offset 9)
-    data[9] = m_outputState.muteLED;
-    
-    // Bluetooth uses different offsets!
-    // Right trigger at offset 22 (not 23!)
-    std::memcpy(&data[BT_RIGHT_TRIGGER_OFFSET], m_outputState.rightTriggerEffect.data(), 11);
-    
-    // Left trigger at offset 33 (not 34!)
-    std::memcpy(&data[BT_LEFT_TRIGGER_OFFSET], m_outputState.leftTriggerEffect.data(), 11);
-    
-    // LED color (offset 45-47)
-    data[45] = m_outputState.ledColor.red;
-    data[46] = m_outputState.ledColor.green;
-    data[47] = m_outputState.ledColor.blue;
-    
-    // Player LEDs (offset 44)
-    data[44] = m_outputState.playerLEDs;
-    
-    LOG_DEBUG(kTag, "BT: Sending report, size=%zu, seq=%d", data.size(), m_bluetoothSequence);
-    LOG_DEBUG(kTag, "  Flags: [1]=0x%02X [2]=0x%02X [3]=0x%02X", data[1], data[2], data[3]);
-    LOG_DEBUG(kTag, "  Rumble: L=%d R=%d", data[5], data[4]);
-    LOG_DEBUG(kTag, "  Triggers: R[0]=0x%02X L[0]=0x%02X", 
+    data[1] = enableBits2;
+
+    // ucRumbleRight / ucRumbleLeft (offsets 2-3)
+    data[2] = m_outputState.rightRumble;
+    data[3] = m_outputState.leftRumble;
+
+    // ucMicLightMode (offset 8) - reuse muteLED state for the mic/mute light
+    data[8] = m_outputState.muteLED;
+
+    // rgucRightTriggerEffect / rgucLeftTriggerEffect (offsets 10 / 21)
+    std::memcpy(&data[RIGHT_TRIGGER_OFFSET], m_outputState.rightTriggerEffect.data(), 11);
+    std::memcpy(&data[LEFT_TRIGGER_OFFSET], m_outputState.leftTriggerEffect.data(), 11);
+
+    // ucLedBrightness (offset 42), ucPadLights (offset 43),
+    // ucLedRed/Green/Blue (offsets 44-46)
+    data[LED_BRIGHTNESS_OFFSET] = m_outputState.ledBrightness;
+    data[PAD_LIGHTS_OFFSET] = m_outputState.playerLEDs;
+    data[LED_RED_OFFSET] = m_outputState.ledColor.red;
+    data[LED_GREEN_OFFSET] = m_outputState.ledColor.green;
+    data[LED_BLUE_OFFSET] = m_outputState.ledColor.blue;
+
+    LOG_DEBUG(kTag, "Sending effects payload, size=%zu (connection=%s)", data.size(),
+              GetConnectionType() == DualSense::ConnectionType::USB ? "USB" : "Bluetooth");
+    LOG_DEBUG(kTag, "  EnableBits: [0]=0x%02X [1]=0x%02X", data[0], data[1]);
+    LOG_DEBUG(kTag, "  Rumble: L=%d R=%d", data[3], data[2]);
+    LOG_DEBUG(kTag, "  Triggers: R[0]=0x%02X L[0]=0x%02X",
            m_outputState.rightTriggerEffect[0], m_outputState.leftTriggerEffect[0]);
-    
-    // SDL handles CRC32 for Bluetooth automatically
+
     if (!SDL_SendJoystickEffect(m_joystick, data.data(), data.size())) {
-        LOG_WARN(kTag, "DualSense BT: Send failed - %s", SDL_GetError());
+        LOG_WARN(kTag, "DualSense: Send failed - %s", SDL_GetError());
         return false;
     }
-    
-    LOG_DEBUG(kTag, "BT: Report sent successfully");
+
+    LOG_DEBUG(kTag, "Effects payload sent successfully");
     return true;
 }

--- a/src/Haptics/DualSenseController.h
+++ b/src/Haptics/DualSenseController.h
@@ -212,20 +212,27 @@ private:
     /**
      * @brief Detect USB vs Bluetooth connection
      * @return Connection type
+     *
+     * Informational only (used for logging/UI) - SDL_SendJoystickEffect's
+     * underlying HIDAPI driver auto-detects and handles the USB vs Bluetooth
+     * report framing itself, so this class does not need to branch on it
+     * when building the effects payload.
      */
     DualSense::ConnectionType DetectConnectionType() const;
 
     /**
-     * @brief Send output state via USB protocol
+     * @brief Build and send the DualSense "effects" output payload
+     *
+     * IMPORTANT: SDL's PS5 HIDAPI driver (SDL_hidapi_ps5.c) builds the raw
+     * HID report itself - it prepends the report ID (and, on Bluetooth, the
+     * sequence/tag byte and trailing CRC) around whatever buffer is passed to
+     * SDL_SendJoystickEffect(). The buffer passed here must therefore contain
+     * ONLY the "DS5EffectsState_t"-equivalent payload starting at
+     * ucEnableBits1 - it must NOT include a report ID byte, or every field
+     * ends up shifted by one (or more) bytes once SDL adds its own header.
      * @return true on success
      */
-    bool SendUSBOutput();
-
-    /**
-     * @brief Send output state via Bluetooth protocol
-     * @return true on success
-     */
-    bool SendBluetoothOutput();
+    bool SendOutput();
 
     /**
      * @brief Apply trigger effect to trigger data array
@@ -243,7 +250,6 @@ private:
     DualSense::OutputState m_outputState;
     DualSense::ConnectionType m_connectionType;
     mutable bool m_connectionTypeDetected;
-    uint8_t m_bluetoothSequence;  ///< Bluetooth sequence counter
 
     // ==================== Protocol Constants ====================
 
@@ -252,31 +258,28 @@ private:
     static constexpr uint16_t DUALSENSE_PRODUCT_ID = 0x0CE6;
     static constexpr uint16_t DUALSENSE_EDGE_PRODUCT_ID = 0x0DF2;
 
-    // USB Protocol
-    static constexpr uint8_t USB_REPORT_ID = 0x02;
-    static constexpr size_t USB_REPORT_SIZE = 63;
-    static constexpr size_t USB_RIGHT_TRIGGER_OFFSET = 11;
-    static constexpr size_t USB_LEFT_TRIGGER_OFFSET = 22;
+    // ==================== Effects Payload Layout ====================
+    // Mirrors SDL's DS5EffectsState_t (src/joystick/hidapi/SDL_hidapi_ps5.c),
+    // and Sony DualSense/Data_Structures' SetStateData - NOT including any
+    // report ID byte, which SDL adds on our behalf.
+    static constexpr size_t EFFECTS_PAYLOAD_SIZE = 47;
+    static constexpr size_t RIGHT_TRIGGER_OFFSET = 10;   // rgucRightTriggerEffect[11]
+    static constexpr size_t LEFT_TRIGGER_OFFSET = 21;    // rgucLeftTriggerEffect[11]
+    static constexpr size_t LED_BRIGHTNESS_OFFSET = 42;  // ucLedBrightness
+    static constexpr size_t PAD_LIGHTS_OFFSET = 43;      // ucPadLights (player LEDs)
+    static constexpr size_t LED_RED_OFFSET = 44;         // ucLedRed
+    static constexpr size_t LED_GREEN_OFFSET = 45;       // ucLedGreen
+    static constexpr size_t LED_BLUE_OFFSET = 46;        // ucLedBlue
 
-    // Bluetooth Protocol
-    static constexpr uint8_t BT_REPORT_ID = 0x31;
-    static constexpr size_t BT_REPORT_SIZE = 78;
-    static constexpr size_t BT_RIGHT_TRIGGER_OFFSET = 22;
-    static constexpr size_t BT_LEFT_TRIGGER_OFFSET = 33;
+    // ucEnableBits1 (payload offset 0)
+    static constexpr uint8_t ENABLE1_RUMBLE_EMULATION = 0x01;
+    static constexpr uint8_t ENABLE1_DISABLE_AUDIO_HAPTICS = 0x02;
+    static constexpr uint8_t ENABLE1_MODIFY_RIGHT_TRIGGER = 0x04; ///< Required for right adaptive trigger effect to take effect
+    static constexpr uint8_t ENABLE1_MODIFY_LEFT_TRIGGER = 0x08;  ///< Required for left adaptive trigger effect to take effect
 
-    // Feature flags (USB byte 1)
-    static constexpr uint8_t USB_FLAG_ENABLE_HID = 0x01;
-    static constexpr uint8_t USB_FLAG_ENABLE_RUMBLE = 0x02;
-    static constexpr uint8_t USB_FLAG_ENABLE_HAPTICS = 0x04;
-    static constexpr uint8_t USB_FLAG_USE_RUMBLE_NOT_HAPTICS = 0x08;
-
-    // Feature flags (BT byte 1)
-    static constexpr uint8_t BT_FLAG_ENABLE_RUMBLE_EMULATION = 0x01;
-    static constexpr uint8_t BT_FLAG_USE_RUMBLE_NOT_HAPTICS = 0x02;
-
-    // Feature flags byte 2 (both USB and BT)
-    static constexpr uint8_t FLAG2_ENABLE_LED_COLOR = 0x04;
-    static constexpr uint8_t FLAG2_ENABLE_PLAYER_LEDS = 0x10;
-    static constexpr uint8_t FLAG2_ENABLE_HAPTICS = 0x01;
-    static constexpr uint8_t FLAG2_ENABLE_LIGHTBAR = 0x02;
+    // ucEnableBits2 (payload offset 1)
+    static constexpr uint8_t ENABLE2_MIC_LIGHT = 0x01;
+    static constexpr uint8_t ENABLE2_LED_COLOR = 0x04;
+    static constexpr uint8_t ENABLE2_LED_RESET = 0x08;
+    static constexpr uint8_t ENABLE2_PLAYER_LIGHTS = 0x10;
 };

--- a/src/Haptics/DualSenseController.h
+++ b/src/Haptics/DualSenseController.h
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <array>
 #include <map>
+#include <mutex>
 #include <string>
 
 /**
@@ -248,6 +249,12 @@ private:
     // ==================== State ====================
     
     DualSense::OutputState m_outputState;
+    // Guards m_outputState: writers (SetTriggerEffect, SetRumble, SetLED*,
+    // SetMuteLED, SetPlayerLEDs, DisableTriggerEffects) can run on whatever
+    // thread calls them (OSC/WebSocket/UI), while SendOutput() reads it from
+    // the async worker thread queued via RunAsync(). Without this, a read
+    // and a write can interleave mid-struct, producing a torn HID report.
+    mutable std::mutex m_outputStateMutex;
     DualSense::ConnectionType m_connectionType;
     mutable bool m_connectionTypeDetected;
 

--- a/src/Haptics/GamepadHaptics.cpp
+++ b/src/Haptics/GamepadHaptics.cpp
@@ -11,6 +11,27 @@ static constexpr const char* kTag = "GamepadHaptics";
 GamepadHaptics::~GamepadHaptics() {
 }
 
+void GamepadHaptics::StopAll() {
+    // Send the "off" adaptive trigger command first (synchronous HID write).
+    // The base class only clears the m_activeDualSenseTriggers tracking map
+    // used for UI display - it never tells the controller hardware to
+    // release trigger tension, so a DualSense would otherwise stay
+    // physically resisted after effects are "stopped" (e.g. on app
+    // shutdown, via StopAllHapticEffects()). No-op on non-DualSense
+    // controllers.
+    if (m_dualSense) {
+        PlayDualSenseTrigger("both", "off", {});
+    }
+
+    // Clears rumble/constant/periodic/condition effects and their SDL
+    // effect IDs, plus the m_activeDualSenseTriggers tracking map. This
+    // runs asynchronously on the device's worker thread, so it's queued
+    // after (not before) the synchronous off-command above - otherwise the
+    // "off" entry PlayDualSenseTrigger just recorded could be cleared out
+    // of order and leave a stale entry in the tracking map.
+    HapticDevice::StopAll();
+}
+
 // ==================== Initialization ====================
 
 InputBridge::Result<bool, InputBridge::HapticError> GamepadHaptics::Init() {

--- a/src/Haptics/GamepadHaptics.h
+++ b/src/Haptics/GamepadHaptics.h
@@ -66,6 +66,21 @@ public:
     bool IsReady() const override;
 
     /**
+     * @brief Stop all active haptic effects on this gamepad.
+     *
+     * In addition to the base HapticDevice::StopAll() behaviour (clearing
+     * rumble/constant/periodic/condition effects and their SDL effect IDs),
+     * this also sends an explicit "off" adaptive-trigger effect to both
+     * DualSense triggers. The base implementation only clears the in-memory
+     * m_activeDualSenseTriggers tracking map for UI display purposes - it
+     * never actually tells the controller hardware to release trigger
+     * tension, so a DualSense would otherwise stay physically resisted
+     * after InputBridge closes or a "Stop All Effects" is issued.
+     * No-op on non-DualSense controllers.
+     */
+    void StopAll() override;
+
+    /**
      * @brief Advertise gamepad capabilities: rumble always; adaptive triggers
      *        only when a DualSense is connected.
      */

--- a/src/Mappers/InputMapping/InputMapperUI.cpp
+++ b/src/Mappers/InputMapping/InputMapperUI.cpp
@@ -228,12 +228,12 @@ void InputMapperUI::DrawOutputProtocolSelector() {
     bool changed = false;
 
     if (m_Store.SelectedProtocolView() == 0) {
-        changed |= DrawProtocolDefinitionCombo("OSC Output##out", profile->oscOutputProtocolId,
-                                                ProtocolTransport::OSC, ProtocolDirection::Output, 200.f);
+        changed |= DrawProtocolDefinitionCombo("OSC Send##out", profile->oscOutputProtocolId,
+                                                ProtocolTransport::OSC, ProtocolDirection::Send, 200.f);
     } else {
 #ifdef ENABLE_WEBSOCKETS
-        changed |= DrawProtocolDefinitionCombo("WS Output##out", profile->wsOutputProtocolId,
-                                                ProtocolTransport::WebSocket, ProtocolDirection::Output, 200.f);
+        changed |= DrawProtocolDefinitionCombo("WS Send##out", profile->wsOutputProtocolId,
+                                                ProtocolTransport::WebSocket, ProtocolDirection::Send, 200.f);
 #else
         ImGui::TextDisabled("WebSockets disabled.");
 #endif
@@ -262,12 +262,12 @@ void InputMapperUI::DrawInputProtocolSelector() {
                              changed);
 
     if (m_Store.SelectedProtocolView() == 0) {
-        changed |= DrawProtocolDefinitionCombo("OSC Input", profile->oscInputProtocolId, ProtocolTransport::OSC,
-                                                ProtocolDirection::Input);
+        changed |= DrawProtocolDefinitionCombo("OSC Receive", profile->oscInputProtocolId, ProtocolTransport::OSC,
+                                                ProtocolDirection::Receive);
     } else {
 #ifdef ENABLE_WEBSOCKETS
-        changed |= DrawProtocolDefinitionCombo("WebSocket Input", profile->wsInputProtocolId,
-                                                ProtocolTransport::WebSocket, ProtocolDirection::Input);
+        changed |= DrawProtocolDefinitionCombo("WebSocket Receive", profile->wsInputProtocolId,
+                                                ProtocolTransport::WebSocket, ProtocolDirection::Receive);
 #else
         ImGui::TextDisabled("WebSockets are disabled in this build.");
 #endif
@@ -658,12 +658,12 @@ void InputMapperUI::DrawMappingContent() {
                              changed);
 
     if (m_Store.SelectedProtocolView() == 0) {
-        changed |= DrawProtocolDefinitionCombo("OSC Output", profile.oscOutputProtocolId, ProtocolTransport::OSC,
-                                                ProtocolDirection::Output);
+        changed |= DrawProtocolDefinitionCombo("OSC Send", profile.oscOutputProtocolId, ProtocolTransport::OSC,
+                                                ProtocolDirection::Send);
     } else {
 #ifdef ENABLE_WEBSOCKETS
-        changed |= DrawProtocolDefinitionCombo("WebSocket Output", profile.wsOutputProtocolId,
-                                                ProtocolTransport::WebSocket, ProtocolDirection::Output);
+        changed |= DrawProtocolDefinitionCombo("WebSocket Send", profile.wsOutputProtocolId,
+                                                ProtocolTransport::WebSocket, ProtocolDirection::Send);
 #else
         ImGui::TextDisabled("WebSockets are disabled in this build.");
 #endif

--- a/src/Mappers/InputMapping/MappingProfileStore.cpp
+++ b/src/Mappers/InputMapping/MappingProfileStore.cpp
@@ -98,6 +98,7 @@ void ParseHapticTargets(const json& data, MappingProfile& p) {
         t.enable_constant = item.value("enable_constant", true);
         t.enable_periodic = item.value("enable_periodic", true);
         t.enable_condition = item.value("enable_condition", true);
+        t.enable_dualsense_trigger = item.value("enable_dualsense_trigger", true);
         p.hapticTargets.push_back(t);
     }
 }
@@ -227,6 +228,7 @@ void SerializeHapticTargets(const MappingProfile& profile, json& data) {
             {"virtual_id", t.virtual_id}, {"name", t.name}, {"device_guid", t.device_guid},
             {"enable_rumble", t.enable_rumble}, {"enable_constant", t.enable_constant},
             {"enable_periodic", t.enable_periodic}, {"enable_condition", t.enable_condition},
+            {"enable_dualsense_trigger", t.enable_dualsense_trigger},
         });
     }
 }

--- a/src/Mappers/InputMapping/MappingTypes.h
+++ b/src/Mappers/InputMapping/MappingTypes.h
@@ -27,6 +27,7 @@ struct HapticTarget {
     bool enable_constant = true;
     bool enable_periodic = true;
     bool enable_condition = true;
+    bool enable_dualsense_trigger = true;
 
     // Cached Effect IDs
     int constant_effect_id = -1;

--- a/src/Mappers/OutputMapper.cpp
+++ b/src/Mappers/OutputMapper.cpp
@@ -179,6 +179,7 @@ void OutputMapper::DrawContentOnly() {
                 bool has_constant = false;
                 bool has_periodic = false;
                 bool has_condition = false;
+                bool has_adaptive_trigger = false;
 
                 if (target.haptic_device) {
                     unsigned int features = SDL_GetHapticFeatures(target.haptic_device);
@@ -189,6 +190,15 @@ void OutputMapper::DrawContentOnly() {
                 } else {
                     // Assume Gamepad supports rumble
                     has_rumble = true;
+                }
+
+                // Adaptive triggers are exposed via the DeviceManager's HapticDevice
+                // abstraction (only present for gamepads), not through raw SDL_Haptic
+                // features, since they're a DualSense-specific extension.
+                if (target.instance_id != 0) {
+                    if (auto* hapticDevice = m_DeviceManager.GetHapticDevice(target.instance_id)) {
+                        has_adaptive_trigger = hapticDevice->caps().adaptiveTriggers;
+                    }
                 }
 
                 ImGuiStyle& style = ImGui::GetStyle();
@@ -217,6 +227,7 @@ void OutputMapper::DrawContentOnly() {
                 DrawEffect("Constant", &target.enable_constant, has_constant);
                 DrawEffect("Periodic", &target.enable_periodic, has_periodic);
                 DrawEffect("Condition", &target.enable_condition, has_condition);
+                DrawEffect("Adaptive Trigger", &target.enable_dualsense_trigger, has_adaptive_trigger);
 
             } else if (!target.device_guid.empty()) {
                 ImGui::TextColored(ImVec4(1,0,0,1), "Missing");
@@ -694,6 +705,7 @@ void OutputMapper::TriggerDualSenseTrigger(int virtual_id, const char* trigger, 
     GetTargets(virtual_id, targets);
     for (auto* target : targets) {
         if (!target || target->instance_id == 0) continue;
+        if (!target->enable_dualsense_trigger) continue;
 
         // Get the haptic device - for DualSense, we need to access GamepadHaptics
         auto* hapticDevice = m_DeviceManager.GetHapticDevice(target->instance_id);

--- a/src/Network/HapticDispatcher.cpp
+++ b/src/Network/HapticDispatcher.cpp
@@ -86,3 +86,111 @@ void HapticDispatcher::DispatchGain(lo_arg** argv, int argc, OutputMapper* mappe
     const int gain = argv[1]->i;
     mapper->QueueSetGain(id, gain);
 }
+
+void HapticDispatcher::DispatchDualSenseFeedback(lo_arg** argv, int argc, OutputMapper* mapper, const char* trigger)
+{
+    if (!mapper || argc < 3) return;
+    for (int i = 0; i < 3; ++i) { if (!argv[i]) return; }
+    const int id       = argv[0]->i;
+    const int position = argv[1]->i;
+    const int strength = argv[2]->i;
+    mapper->QueueDualSenseTrigger(id, trigger, "feedback",
+                                   position, strength, /*end_position*/0,
+                                   /*amplitude*/0, /*frequency*/0, /*snap_force*/0,
+                                   /*first_foot*/0, /*second_foot*/0, /*period*/0,
+                                   /*amplitude_a*/0, /*amplitude_b*/0);
+}
+
+void HapticDispatcher::DispatchDualSenseWeapon(lo_arg** argv, int argc, OutputMapper* mapper, const char* trigger)
+{
+    if (!mapper || argc < 4) return;
+    for (int i = 0; i < 4; ++i) { if (!argv[i]) return; }
+    const int id             = argv[0]->i;
+    const int start_position = argv[1]->i;
+    const int end_position   = argv[2]->i;
+    const int strength       = argv[3]->i;
+    // "position" doubles as "start_position" downstream (see OutputMapper::TriggerDualSenseTrigger).
+    mapper->QueueDualSenseTrigger(id, trigger, "weapon",
+                                   start_position, strength, end_position,
+                                   /*amplitude*/0, /*frequency*/0, /*snap_force*/0,
+                                   /*first_foot*/0, /*second_foot*/0, /*period*/0,
+                                   /*amplitude_a*/0, /*amplitude_b*/0);
+}
+
+void HapticDispatcher::DispatchDualSenseVibration(lo_arg** argv, int argc, OutputMapper* mapper, const char* trigger)
+{
+    if (!mapper || argc < 4) return;
+    for (int i = 0; i < 4; ++i) { if (!argv[i]) return; }
+    const int id        = argv[0]->i;
+    const int position  = argv[1]->i;
+    const int amplitude = argv[2]->i;
+    const int frequency = argv[3]->i;
+    mapper->QueueDualSenseTrigger(id, trigger, "vibration",
+                                   position, /*strength*/0, /*end_position*/0,
+                                   amplitude, frequency, /*snap_force*/0,
+                                   /*first_foot*/0, /*second_foot*/0, /*period*/0,
+                                   /*amplitude_a*/0, /*amplitude_b*/0);
+}
+
+void HapticDispatcher::DispatchDualSenseBow(lo_arg** argv, int argc, OutputMapper* mapper, const char* trigger)
+{
+    if (!mapper || argc < 5) return;
+    for (int i = 0; i < 5; ++i) { if (!argv[i]) return; }
+    const int id             = argv[0]->i;
+    const int start_position = argv[1]->i;
+    const int end_position   = argv[2]->i;
+    const int strength       = argv[3]->i;
+    const int snap_force     = argv[4]->i;
+    mapper->QueueDualSenseTrigger(id, trigger, "bow",
+                                   start_position, strength, end_position,
+                                   /*amplitude*/0, /*frequency*/0, snap_force,
+                                   /*first_foot*/0, /*second_foot*/0, /*period*/0,
+                                   /*amplitude_a*/0, /*amplitude_b*/0);
+}
+
+void HapticDispatcher::DispatchDualSenseGalloping(lo_arg** argv, int argc, OutputMapper* mapper, const char* trigger)
+{
+    if (!mapper || argc < 6) return;
+    for (int i = 0; i < 6; ++i) { if (!argv[i]) return; }
+    const int id             = argv[0]->i;
+    const int start_position = argv[1]->i;
+    const int end_position   = argv[2]->i;
+    const int first_foot     = argv[3]->i;
+    const int second_foot    = argv[4]->i;
+    const int frequency      = argv[5]->i;
+    mapper->QueueDualSenseTrigger(id, trigger, "galloping",
+                                   start_position, /*strength*/0, end_position,
+                                   /*amplitude*/0, frequency, /*snap_force*/0,
+                                   first_foot, second_foot, /*period*/0,
+                                   /*amplitude_a*/0, /*amplitude_b*/0);
+}
+
+void HapticDispatcher::DispatchDualSenseMachine(lo_arg** argv, int argc, OutputMapper* mapper, const char* trigger)
+{
+    if (!mapper || argc < 7) return;
+    for (int i = 0; i < 7; ++i) { if (!argv[i]) return; }
+    const int id             = argv[0]->i;
+    const int start_position = argv[1]->i;
+    const int end_position   = argv[2]->i;
+    const int amplitude_a    = argv[3]->i;
+    const int amplitude_b    = argv[4]->i;
+    const int frequency      = argv[5]->i;
+    const int period         = argv[6]->i;
+    mapper->QueueDualSenseTrigger(id, trigger, "machine",
+                                   start_position, /*strength*/0, end_position,
+                                   /*amplitude*/0, frequency, /*snap_force*/0,
+                                   /*first_foot*/0, /*second_foot*/0, period,
+                                   amplitude_a, amplitude_b);
+}
+
+void HapticDispatcher::DispatchDualSenseOff(lo_arg** argv, int argc, OutputMapper* mapper, const char* trigger)
+{
+    if (!mapper || argc < 1) return;
+    if (!argv[0]) return;
+    const int id = argv[0]->i;
+    mapper->QueueDualSenseTrigger(id, trigger, "off",
+                                   /*position*/0, /*strength*/0, /*end_position*/0,
+                                   /*amplitude*/0, /*frequency*/0, /*snap_force*/0,
+                                   /*first_foot*/0, /*second_foot*/0, /*period*/0,
+                                   /*amplitude_a*/0, /*amplitude_b*/0);
+}

--- a/src/Network/HapticDispatcher.h
+++ b/src/Network/HapticDispatcher.h
@@ -19,6 +19,17 @@ class OutputMapper;
  *                      left_coeff, deadband, center, duration_ms
  * Gain      ii      id, gain
  *
+ * DualSense adaptive trigger effects arrive on one fixed OSC path per
+ * side x effect (see DispatchDualSense* below), each carrying only the
+ * arguments that effect actually uses:
+ *   feedback   iii       id, position, strength
+ *   weapon     iiii      id, start_position, end_position, strength
+ *   vibration  iiii      id, position, amplitude, frequency
+ *   bow        iiiii     id, start_position, end_position, strength, snap_force
+ *   galloping  iiiiii    id, start_position, end_position, first_foot, second_foot, frequency
+ *   machine    iiiiiii   id, start_position, end_position, amplitude_a, amplitude_b, frequency, period
+ *   off        i         id
+ *
  * All methods are no-ops when mapper is nullptr or argc is insufficient,
  * so callers need no null-guards beyond passing the right mapper pointer.
  */
@@ -65,4 +76,57 @@ public:
      * Accepted format:  ii  (id, gain 0–100)
      */
     static void DispatchGain(lo_arg** argv, int argc, OutputMapper* mapper);
+
+    /**
+     * @brief Parse a DualSense adaptive trigger "feedback" message and queue it.
+     *
+     * Accepted format:  iii  (id, position, strength).  trigger must be
+     * "left" or "right" - passed in by the caller since the OSC path
+     * (.../left/feedback or .../right/feedback) determines the side.
+     */
+    static void DispatchDualSenseFeedback(lo_arg** argv, int argc, OutputMapper* mapper, const char* trigger);
+
+    /**
+     * @brief Parse a DualSense adaptive trigger "weapon" message and queue it.
+     *
+     * Accepted format:  iiii  (id, start_position, end_position, strength)
+     */
+    static void DispatchDualSenseWeapon(lo_arg** argv, int argc, OutputMapper* mapper, const char* trigger);
+
+    /**
+     * @brief Parse a DualSense adaptive trigger "vibration" message and queue it.
+     *
+     * Accepted format:  iiii  (id, position, amplitude, frequency)
+     */
+    static void DispatchDualSenseVibration(lo_arg** argv, int argc, OutputMapper* mapper, const char* trigger);
+
+    /**
+     * @brief Parse a DualSense adaptive trigger "bow" message and queue it.
+     *
+     * Accepted format:  iiiii  (id, start_position, end_position, strength, snap_force)
+     */
+    static void DispatchDualSenseBow(lo_arg** argv, int argc, OutputMapper* mapper, const char* trigger);
+
+    /**
+     * @brief Parse a DualSense adaptive trigger "galloping" message and queue it.
+     *
+     * Accepted format:  iiiiii  (id, start_position, end_position, first_foot,
+     *                            second_foot, frequency)
+     */
+    static void DispatchDualSenseGalloping(lo_arg** argv, int argc, OutputMapper* mapper, const char* trigger);
+
+    /**
+     * @brief Parse a DualSense adaptive trigger "machine" message and queue it.
+     *
+     * Accepted format:  iiiiiii  (id, start_position, end_position, amplitude_a,
+     *                             amplitude_b, frequency, period)
+     */
+    static void DispatchDualSenseMachine(lo_arg** argv, int argc, OutputMapper* mapper, const char* trigger);
+
+    /**
+     * @brief Parse a DualSense adaptive trigger "off" message and queue it.
+     *
+     * Accepted format:  i  (id)
+     */
+    static void DispatchDualSenseOff(lo_arg** argv, int argc, OutputMapper* mapper, const char* trigger);
 };

--- a/src/Network/HapticParser.cpp
+++ b/src/Network/HapticParser.cpp
@@ -23,6 +23,7 @@ namespace {
     const char* const kEffectConstant  = "constant";
     const char* const kEffectPeriodic  = "periodic";
     const char* const kEffectCondition = "condition";
+    const char* const kEffectDualSenseTrigger = "dualsense_trigger";
 
     // Rumble params
     const char* const kRumbleLow      = "low";
@@ -54,6 +55,7 @@ namespace {
     const char* const kTrigger        = "trigger";
     const char* const kEffectType     = "effect_type";
     const char* const kDSPosition     = "position";
+    const char* const kDSStartPosition = "start_position";
     const char* const kDSEndPosition  = "end_position";
     const char* const kDSAmplitude    = "amplitude";
     const char* const kDSFrequency    = "frequency";
@@ -162,7 +164,11 @@ namespace {
     void dispatchDualSenseTrigger(const nlohmann::json& data, const std::string& trigger,
                                    const std::string& effect_type, int device, OutputMapper* mapper)
     {
-        int position     = data.value(kDSPosition,      0);
+        // "position" is used by feedback/vibration; weapon/bow/galloping/machine
+        // use "start_position" instead (see OSCBaseProtocol's DualSense docs).
+        // Prefer start_position when present so both naming conventions work.
+        int position     = data.contains(kDSStartPosition) ? data.value(kDSStartPosition, 0)
+                                                           : data.value(kDSPosition, 0);
         int strength     = data.value(kConstantStrength, 0);
         int end_position = data.value(kDSEndPosition,   0);
         int amplitude    = data.value(kDSAmplitude,     0);
@@ -346,7 +352,14 @@ void HapticParser::Parse(std::string_view message, OutputMapper* mapper) {
             std::string effect = json.value(kEffect, "");
             int device = json.value(kDevice, 0);
             const auto& data = get_params_obj(json);
-            dispatch(json, data, effect, device, mapper);
+
+            if (effect == kEffectDualSenseTrigger) {
+                std::string trigger     = data.value(kTrigger,    std::string{});
+                std::string effect_type = data.value(kEffectType, std::string{});
+                dispatchDualSenseTrigger(data, trigger, effect_type, device, mapper);
+            } else {
+                dispatch(json, data, effect, device, mapper);
+            }
         }
 
     } catch (...) {

--- a/src/Network/HapticParser.cpp
+++ b/src/Network/HapticParser.cpp
@@ -51,8 +51,19 @@ namespace {
     const char* const kConditionCenter    = "center";
 
     // DualSense params
-    const char* const kTrigger     = "trigger";
-    const char* const kEffectType  = "effect_type";
+    const char* const kTrigger        = "trigger";
+    const char* const kEffectType     = "effect_type";
+    const char* const kDSPosition     = "position";
+    const char* const kDSEndPosition  = "end_position";
+    const char* const kDSAmplitude    = "amplitude";
+    const char* const kDSFrequency    = "frequency";
+    const char* const kDSSnapForce    = "snap_force";
+    const char* const kDSFirstFoot    = "first_foot";
+    const char* const kDSSecondFoot   = "second_foot";
+    const char* const kDSAmplitudeA   = "amplitude_a";
+    const char* const kDSAmplitudeB   = "amplitude_b";
+    // Note: DualSense "strength" and "period" reuse kConstantStrength / kPeriodicPeriod
+    // below since the JSON key text is identical for those fields.
 
     // Shared slot key used by all slotted effect types
     const char* const kSlot = "slot";
@@ -143,6 +154,31 @@ namespace {
                 data.value(kConditionCenter,     0.0f),
                 duration);
         }
+    }
+
+    // Dispatch a DualSense adaptive trigger effect. Handled separately from the
+    // generic dispatch() above since it goes through QueueDualSenseTrigger rather
+    // than the four standard SDL haptic effect queues.
+    void dispatchDualSenseTrigger(const nlohmann::json& data, const std::string& trigger,
+                                   const std::string& effect_type, int device, OutputMapper* mapper)
+    {
+        int position     = data.value(kDSPosition,      0);
+        int strength     = data.value(kConstantStrength, 0);
+        int end_position = data.value(kDSEndPosition,   0);
+        int amplitude    = data.value(kDSAmplitude,     0);
+        int frequency    = data.value(kDSFrequency,     0);
+        int snap_force   = data.value(kDSSnapForce,     0);
+        int first_foot   = data.value(kDSFirstFoot,     0);
+        int second_foot  = data.value(kDSSecondFoot,    0);
+        int period       = data.value(kPeriodicPeriod,  0);
+        int amplitude_a  = data.value(kDSAmplitudeA,    0);
+        int amplitude_b  = data.value(kDSAmplitudeB,    0);
+
+        mapper->QueueDualSenseTrigger(device, trigger.c_str(), effect_type.c_str(),
+                                       position, strength, end_position,
+                                       amplitude, frequency, snap_force,
+                                       first_foot, second_foot, period,
+                                       amplitude_a, amplitude_b);
     }
 
     // Sniff a flat JSON object (the top-level payload *or* its params sub-object)
@@ -293,12 +329,12 @@ void HapticParser::Parse(std::string_view message, OutputMapper* mapper) {
 
             const auto& data = get_params_obj(json);
 
-            // DualSense triggers are not handled through the standard dispatch()
-            // helper since they use QueueDualSenseTrigger, not the generic effects.
-            // For now we fall through to the standard JSON path when a DualSense
-            // trigger is auto-detected (the caller must still set "type" explicitly
-            // for DualSense - auto-detect only covers the four SDL effect classes).
-            if (det.kind != DetectedEffect::Kind::DualSenseTrigger) {
+            // DualSense triggers go through QueueDualSenseTrigger rather than the
+            // generic dispatch() used by the four standard SDL haptic effects.
+            if (det.kind == DetectedEffect::Kind::DualSenseTrigger) {
+                dispatchDualSenseTrigger(data.empty() ? json : data,
+                                          det.trigger, det.effect_type, det.device, mapper);
+            } else {
                 dispatch(json, data.empty() ? json : data,
                          kind_to_effect_string(det.kind), det.device, mapper);
             }

--- a/src/Network/OSCServer.cpp
+++ b/src/Network/OSCServer.cpp
@@ -48,6 +48,31 @@ namespace {
     const char* const kHapticConditionPath = "/haptic/condition";
     const char* const kHapticGainPath = "/haptic/gain";
 
+    // DualSense adaptive trigger paths, one per side x effect, only carrying
+    // the arguments that effect actually uses (see HapticDispatcher.h).
+    const char* const kDsFeedbackLeftPath   = "/haptic/dualsense/trigger/left/feedback";
+    const char* const kDsFeedbackRightPath  = "/haptic/dualsense/trigger/right/feedback";
+    const char* const kDsWeaponLeftPath     = "/haptic/dualsense/trigger/left/weapon";
+    const char* const kDsWeaponRightPath    = "/haptic/dualsense/trigger/right/weapon";
+    const char* const kDsVibrationLeftPath  = "/haptic/dualsense/trigger/left/vibration";
+    const char* const kDsVibrationRightPath = "/haptic/dualsense/trigger/right/vibration";
+    const char* const kDsBowLeftPath        = "/haptic/dualsense/trigger/left/bow";
+    const char* const kDsBowRightPath       = "/haptic/dualsense/trigger/right/bow";
+    const char* const kDsGallopingLeftPath  = "/haptic/dualsense/trigger/left/galloping";
+    const char* const kDsGallopingRightPath = "/haptic/dualsense/trigger/right/galloping";
+    const char* const kDsMachineLeftPath    = "/haptic/dualsense/trigger/left/machine";
+    const char* const kDsMachineRightPath   = "/haptic/dualsense/trigger/right/machine";
+    const char* const kDsOffLeftPath        = "/haptic/dualsense/trigger/left/off";
+    const char* const kDsOffRightPath       = "/haptic/dualsense/trigger/right/off";
+
+    // Shared by all haptic_dualsense_*_handler functions: reads the trigger
+    // side off the tail of the OSC path so one handler can serve both the
+    // /left/ and /right/ path variants for a given effect.
+    const char* dualsense_trigger_side_from_path(const char* path) {
+        std::string_view p(path);
+        return (p.find("/right/") != std::string_view::npos) ? "right" : "left";
+    }
+
     const char* const kWheelSteerPath = "/wheel/steer";
     const char* const kWheelBrakePath = "/wheel/brake";
     const char* const kWheelThrottlePath = "/wheel/throttle";
@@ -137,6 +162,76 @@ int OSCServer::haptic_gain_handler(const char *path, const char *types, lo_arg *
         auto* server = static_cast<OSCServer*>(user_data);
         if (!server || !server->m_running || !server->m_OutputMapper) return 0;
         HapticDispatcher::DispatchGain(argv, argc, server->m_OutputMapper);
+    } catch (...) {}
+    return 0;
+}
+
+int OSCServer::haptic_dualsense_feedback_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message msg, void *user_data) {
+    try {
+        if (s_isDestroyed) return 0;
+        auto* server = static_cast<OSCServer*>(user_data);
+        if (!server || !server->m_running || !server->m_OutputMapper) return 0;
+        HapticDispatcher::DispatchDualSenseFeedback(argv, argc, server->m_OutputMapper, dualsense_trigger_side_from_path(path));
+    } catch (...) {}
+    return 0;
+}
+
+int OSCServer::haptic_dualsense_weapon_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message msg, void *user_data) {
+    try {
+        if (s_isDestroyed) return 0;
+        auto* server = static_cast<OSCServer*>(user_data);
+        if (!server || !server->m_running || !server->m_OutputMapper) return 0;
+        HapticDispatcher::DispatchDualSenseWeapon(argv, argc, server->m_OutputMapper, dualsense_trigger_side_from_path(path));
+    } catch (...) {}
+    return 0;
+}
+
+int OSCServer::haptic_dualsense_vibration_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message msg, void *user_data) {
+    try {
+        if (s_isDestroyed) return 0;
+        auto* server = static_cast<OSCServer*>(user_data);
+        if (!server || !server->m_running || !server->m_OutputMapper) return 0;
+        HapticDispatcher::DispatchDualSenseVibration(argv, argc, server->m_OutputMapper, dualsense_trigger_side_from_path(path));
+    } catch (...) {}
+    return 0;
+}
+
+int OSCServer::haptic_dualsense_bow_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message msg, void *user_data) {
+    try {
+        if (s_isDestroyed) return 0;
+        auto* server = static_cast<OSCServer*>(user_data);
+        if (!server || !server->m_running || !server->m_OutputMapper) return 0;
+        HapticDispatcher::DispatchDualSenseBow(argv, argc, server->m_OutputMapper, dualsense_trigger_side_from_path(path));
+    } catch (...) {}
+    return 0;
+}
+
+int OSCServer::haptic_dualsense_galloping_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message msg, void *user_data) {
+    try {
+        if (s_isDestroyed) return 0;
+        auto* server = static_cast<OSCServer*>(user_data);
+        if (!server || !server->m_running || !server->m_OutputMapper) return 0;
+        HapticDispatcher::DispatchDualSenseGalloping(argv, argc, server->m_OutputMapper, dualsense_trigger_side_from_path(path));
+    } catch (...) {}
+    return 0;
+}
+
+int OSCServer::haptic_dualsense_machine_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message msg, void *user_data) {
+    try {
+        if (s_isDestroyed) return 0;
+        auto* server = static_cast<OSCServer*>(user_data);
+        if (!server || !server->m_running || !server->m_OutputMapper) return 0;
+        HapticDispatcher::DispatchDualSenseMachine(argv, argc, server->m_OutputMapper, dualsense_trigger_side_from_path(path));
+    } catch (...) {}
+    return 0;
+}
+
+int OSCServer::haptic_dualsense_off_handler(const char *path, const char *types, lo_arg **argv, int argc, lo_message msg, void *user_data) {
+    try {
+        if (s_isDestroyed) return 0;
+        auto* server = static_cast<OSCServer*>(user_data);
+        if (!server || !server->m_running || !server->m_OutputMapper) return 0;
+        HapticDispatcher::DispatchDualSenseOff(argv, argc, server->m_OutputMapper, dualsense_trigger_side_from_path(path));
     } catch (...) {}
     return 0;
 }
@@ -233,6 +328,23 @@ bool OSCServer::Start(const std::string& send_host, int send_port, int recv_port
     lo_server_thread_add_method(m_server_thread, kHapticPeriodicPath,    "iififfii",    haptic_periodic_handler,  this);  // legacy, no wave_type
     lo_server_thread_add_method(m_server_thread, kHapticConditionPath,   "iiiffffffi",  haptic_condition_handler, this);
     lo_server_thread_add_method(m_server_thread, kHapticGainPath,        "ii",          haptic_gain_handler,      this);
+
+    // DualSense adaptive trigger paths: one per side x effect, each with only
+    // the args that effect uses (see HapticDispatcher.h for formats).
+    lo_server_thread_add_method(m_server_thread, kDsFeedbackLeftPath,   "iii",     haptic_dualsense_feedback_handler,  this);
+    lo_server_thread_add_method(m_server_thread, kDsFeedbackRightPath,  "iii",     haptic_dualsense_feedback_handler,  this);
+    lo_server_thread_add_method(m_server_thread, kDsWeaponLeftPath,     "iiii",    haptic_dualsense_weapon_handler,    this);
+    lo_server_thread_add_method(m_server_thread, kDsWeaponRightPath,    "iiii",    haptic_dualsense_weapon_handler,    this);
+    lo_server_thread_add_method(m_server_thread, kDsVibrationLeftPath,  "iiii",    haptic_dualsense_vibration_handler, this);
+    lo_server_thread_add_method(m_server_thread, kDsVibrationRightPath, "iiii",    haptic_dualsense_vibration_handler, this);
+    lo_server_thread_add_method(m_server_thread, kDsBowLeftPath,        "iiiii",   haptic_dualsense_bow_handler,       this);
+    lo_server_thread_add_method(m_server_thread, kDsBowRightPath,       "iiiii",   haptic_dualsense_bow_handler,       this);
+    lo_server_thread_add_method(m_server_thread, kDsGallopingLeftPath,  "iiiiii",  haptic_dualsense_galloping_handler, this);
+    lo_server_thread_add_method(m_server_thread, kDsGallopingRightPath, "iiiiii",  haptic_dualsense_galloping_handler, this);
+    lo_server_thread_add_method(m_server_thread, kDsMachineLeftPath,    "iiiiiii", haptic_dualsense_machine_handler,   this);
+    lo_server_thread_add_method(m_server_thread, kDsMachineRightPath,   "iiiiiii", haptic_dualsense_machine_handler,   this);
+    lo_server_thread_add_method(m_server_thread, kDsOffLeftPath,        "i",       haptic_dualsense_off_handler,       this);
+    lo_server_thread_add_method(m_server_thread, kDsOffRightPath,       "i",       haptic_dualsense_off_handler,       this);
     // Subchannel handler: catches /haptic/<effect>/<slot> paths (slot in path, no slot arg).
     // Registered before the generic catch-all so it runs first for subchannel messages.
     lo_server_thread_add_method(m_server_thread, nullptr, nullptr, haptic_subchannel_handler, this);

--- a/src/Network/OSCServer.cpp
+++ b/src/Network/OSCServer.cpp
@@ -943,7 +943,7 @@ void OSCServer::DrawContent() {
         }
     };
 
-    // ── Output protocol (server → client) ─────────────────────────────────────
+    // ── Send protocol (server → client) ─────────────────────────────────────────
     {
         if (ImGui::Checkbox("##osc_out_en", &outputEnabled)) {
             SetOutputEnabled(outputEnabled);
@@ -951,10 +951,10 @@ void OSCServer::DrawContent() {
         }
         ImGui::SameLine();
         if (!outputEnabled) ImGui::BeginDisabled();
-        auto entries = buildEntries(ProtocolDirection::Output);
+        auto entries = buildEntries(ProtocolDirection::Send);
         int curIdx = findIdx(entries, outDefId, currentProto);
         int newIdx = curIdx;
-        ImGui::Text("Output (send to client)");
+        ImGui::Text("Send (to client)");
         drawCombo("##osc_out", entries, curIdx, newIdx);
         if (newIdx != curIdx && !entries[newIdx].isSeparator) {
             const auto& c = entries[newIdx];
@@ -966,7 +966,7 @@ void OSCServer::DrawContent() {
         if (!outputEnabled) ImGui::EndDisabled();
     }
 
-    // ── Input protocol (client → server) ──────────────────────────────────────
+    // ── Receive protocol (client → server) ──────────────────────────────────────
     {
         if (ImGui::Checkbox("##osc_in_en", &inputEnabled)) {
             SetInputEnabled(inputEnabled);
@@ -974,10 +974,10 @@ void OSCServer::DrawContent() {
         }
         ImGui::SameLine();
         if (!inputEnabled) ImGui::BeginDisabled();
-        auto entries = buildEntries(ProtocolDirection::Input);
+        auto entries = buildEntries(ProtocolDirection::Receive);
         int curIdx = findIdx(entries, inDefId, currentInputProto);
         int newIdx = curIdx;
-        ImGui::Text("Input (receive from client)");
+        ImGui::Text("Receive (from client)");
         drawCombo("##osc_in", entries, curIdx, newIdx);
         if (newIdx != curIdx && !entries[newIdx].isSeparator) {
             const auto& c = entries[newIdx];

--- a/src/Network/OSCServer.cpp
+++ b/src/Network/OSCServer.cpp
@@ -567,8 +567,11 @@ int OSCServer::generic_handler(const char* path, const char* types, lo_arg** arg
                 bool handled = oscProtocol->handle_osc_message(path, types, argv, argc);
                 if (!handled) {
                     std::lock_guard<std::mutex> errLock(server->m_mutex);
-                    server->m_logs.push_back({"Invalid OSC path: " + std::string(path), true});
-                    if (server->m_logs.size() > 100) server->m_logs.pop_front();
+                    // Mark the "Recv:" entry logged for this exact message (pushed
+                    // above, always the most recent entry - liblo dispatches one
+                    // message at a time on this thread, so there's no race) as
+                    // invalid instead of appending a second, duplicate line.
+                    if (!server->m_logs.empty()) server->m_logs.back().isError = true;
                 }
             }
         } else if (handlerCopy) {
@@ -948,8 +951,21 @@ void OSCServer::DrawContent() {
     }
     ImGui::Separator();
     ImGui::Text("Log");
+    ImGui::SameLine();
+    ImGui::Checkbox("Valid##log_valid", &m_showValidMessages);
+    ImGui::SameLine();
+    ImGui::Checkbox("Invalid##log_invalid", &m_showInvalidMessages);
     if (ImGui::BeginChild("Log", ImVec2(0, 150), true)) {
+        // Filter only applies to per-message "Recv:" entries - server
+        // lifecycle/status lines (started, stopped, client timeout, etc.)
+        // aren't received messages, so they always stay visible.
+        static constexpr const char* kRecvPrefix = "Recv: ";
         for (const auto& l : logs) {
+            bool isRecvEntry = l.text.compare(0, std::strlen(kRecvPrefix), kRecvPrefix) == 0;
+            if (isRecvEntry) {
+                if (l.isError && !m_showInvalidMessages) continue;
+                if (!l.isError && !m_showValidMessages) continue;
+            }
             if (l.isError)
                 ImGui::TextColored(ImVec4(1.0f, 0.5f, 0.5f, 1.0f), "%s", l.text.c_str());
             else

--- a/src/Network/OSCServer.h
+++ b/src/Network/OSCServer.h
@@ -156,6 +156,8 @@ private:
     std::string m_inputDefinitionId;  // selected input  (client→server) definition
     struct LogEntry { std::string text; bool isError = false; };
     std::deque<LogEntry> m_logs;
+    bool m_showValidMessages = true;    // UI filter: show "Recv:" entries that were successfully handled
+    bool m_showInvalidMessages = true;  // UI filter: show "Recv:" entries that didn't match a known OSC path
     std::set<std::string> m_clients;
     uint64_t m_lastMessageTime = 0;
     OutputMapper* m_OutputMapper = nullptr;
@@ -175,4 +177,4 @@ private:
     // main/UI thread.  Stored (not detached) so the destructor can join it
     // and guarantee the thread finishes before members are destroyed.
     std::thread m_cleanupThread;
-};
+};

--- a/src/Network/OSCServer.h
+++ b/src/Network/OSCServer.h
@@ -123,6 +123,19 @@ private:
     static int haptic_condition_handler(const char* path, const char* types, lo_arg** argv, int argc, lo_message msg, void* user_data);
     static int haptic_gain_handler(const char* path, const char* types, lo_arg** argv, int argc, lo_message msg, void* user_data);
 
+    // DualSense adaptive trigger handlers: one per effect shape, shared between
+    // the /left/ and /right/ path variants. Each determines which side fired
+    // by inspecting the incoming OSC path, since the argument list itself
+    // carries no trigger field (see HapticDispatcher for the per-effect
+    // argument formats).
+    static int haptic_dualsense_feedback_handler(const char* path, const char* types, lo_arg** argv, int argc, lo_message msg, void* user_data);
+    static int haptic_dualsense_weapon_handler(const char* path, const char* types, lo_arg** argv, int argc, lo_message msg, void* user_data);
+    static int haptic_dualsense_vibration_handler(const char* path, const char* types, lo_arg** argv, int argc, lo_message msg, void* user_data);
+    static int haptic_dualsense_bow_handler(const char* path, const char* types, lo_arg** argv, int argc, lo_message msg, void* user_data);
+    static int haptic_dualsense_galloping_handler(const char* path, const char* types, lo_arg** argv, int argc, lo_message msg, void* user_data);
+    static int haptic_dualsense_machine_handler(const char* path, const char* types, lo_arg** argv, int argc, lo_message msg, void* user_data);
+    static int haptic_dualsense_off_handler(const char* path, const char* types, lo_arg** argv, int argc, lo_message msg, void* user_data);
+
     // Handles subchannel paths of the form /haptic/<effect>/<slot>
     // where the slot is encoded in the path instead of as a message argument.
     // This allows multiple effects of the same type to be sent in the same
@@ -169,7 +182,7 @@ private:
     bool m_outputEnabled = true;  // send OSC messages to clients
     bool m_inputEnabled  = true;  // receive OSC messages from clients
 
-    // Inactivity timeout - persisted to prefs.
+    // Inactivity timeout persisted to prefs.
     bool     m_inactivityTimeoutEnabled = true;
     uint64_t m_inactivityTimeoutMs      = 5000;
 
@@ -177,4 +190,4 @@ private:
     // main/UI thread.  Stored (not detached) so the destructor can join it
     // and guarantee the thread finishes before members are destroyed.
     std::thread m_cleanupThread;
-};
+};

--- a/src/Network/WebSocketServer.cpp
+++ b/src/Network/WebSocketServer.cpp
@@ -651,7 +651,7 @@ void WebSocketServer::DrawContent() {
         }
     };
 
-    // ── Output protocol (server → client) ────────────────────────────────────
+    // ── Send protocol (server → client) ──────────────────────────────────────
     {
         if (ImGui::Checkbox("##ws_out_en", &outputEnabled)) {
             SetOutputEnabled(outputEnabled);
@@ -659,10 +659,10 @@ void WebSocketServer::DrawContent() {
         }
         ImGui::SameLine();
         if (!outputEnabled) ImGui::BeginDisabled();
-        auto entries = buildEntries(ProtocolDirection::Output);
+        auto entries = buildEntries(ProtocolDirection::Send);
         int curIdx = findIdx(entries, outDefId);
         int newIdx = curIdx;
-        ImGui::Text("Output (send to clients)");
+        ImGui::Text("Send (to clients)");
         drawCombo("##out_proto", entries, curIdx, newIdx);
         if (newIdx != curIdx && !entries[newIdx].isSeparator) {
             const auto& c = entries[newIdx];
@@ -674,7 +674,7 @@ void WebSocketServer::DrawContent() {
         if (!outputEnabled) ImGui::EndDisabled();
     }
 
-    // ── Input protocol (client → server) ─────────────────────────────────────
+    // ── Receive protocol (client → server) ───────────────────────────────────
     {
         if (ImGui::Checkbox("##ws_in_en", &inputEnabled)) {
             SetInputEnabled(inputEnabled);
@@ -682,10 +682,10 @@ void WebSocketServer::DrawContent() {
         }
         ImGui::SameLine();
         if (!inputEnabled) ImGui::BeginDisabled();
-        auto entries = buildEntries(ProtocolDirection::Input);
+        auto entries = buildEntries(ProtocolDirection::Receive);
         int curIdx = findIdx(entries, inDefId);
         int newIdx = curIdx;
-        ImGui::Text("Input (receive from clients)");
+        ImGui::Text("Receive (from clients)");
         drawCombo("##in_proto", entries, curIdx, newIdx);
         if (newIdx != curIdx && !entries[newIdx].isSeparator) {
             const auto& c = entries[newIdx];

--- a/src/Protocols/OSCBaseProtocol.cpp
+++ b/src/Protocols/OSCBaseProtocol.cpp
@@ -50,6 +50,24 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
         return (fieldId == fid) || (fieldId.empty() && path_sv == legacyPath);
     };
 
+    // Like match(), but for fields that cover a whole family of sub-addresses
+    // (e.g. DualSense trigger's .../left|right/effect) rather than one fixed
+    // address. Returns the base path to match against as a prefix: the
+    // field's configured oscPath if the active definition customizes it,
+    // otherwise the legacy hardcoded default.
+    auto resolveBase = [&](const char* legacyBase, const char* fid) {
+        std::string base = legacyBase;
+        if (def) {
+            for (const auto& field : def->fields) {
+                if (field.enabled && field.fieldId == fid) {
+                    base = field.oscPath;
+                    break;
+                }
+            }
+        }
+        return base;
+    };
+
     bool handled = false;
 
     // /inputbridge/haptics/rumble  iiffi  (deviceId, slot, low_freq, high_freq, duration_ms)
@@ -167,7 +185,10 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
         });
     }
     // DualSense Trigger Effects
-    // /inputbridge/haptics/dualsense/trigger/{left|right}/{feedback|weapon|vibration|bow|galloping|machine|off}
+    // {base}/{left|right}/{feedback|weapon|vibration|bow|galloping|machine|off}
+    // where {base} defaults to /inputbridge/haptics/dualsense/trigger but can
+    // be customized per-protocol via the "DualSense Adaptive Trigger" field
+    // in the Protocol Editor.
     //   feedback:  iii     (deviceId, position, strength)
     //   weapon:    iiii    (deviceId, start_position, end_position, strength)
     //   vibration: iiii    (deviceId, position, amplitude, frequency)
@@ -175,7 +196,7 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
     //   galloping: iiiiii  (deviceId, start_position, end_position, first_foot, second_foot, frequency)
     //   machine:   iiiiiii (deviceId, start_position, end_position, amplitude_a, amplitude_b, frequency, period)
     //   off:       (no args required)
-    else if (path_sv.find("/inputbridge/haptics/dualsense/trigger/") != std::string_view::npos) {
+    else if (path_sv.starts_with(resolveBase("/inputbridge/haptics/dualsense/trigger", "haptic_dualsense_trigger") + "/")) {
         handled = true;
         DispatchHapticCommand<GamepadHaptics>([&](GamepadHaptics* gamepad) {
             std::string trigger = (path_sv.find("/left/") != std::string_view::npos) ? "left" : "right";

--- a/src/Protocols/OSCBaseProtocol.cpp
+++ b/src/Protocols/OSCBaseProtocol.cpp
@@ -50,10 +50,9 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
         return (fieldId == fid) || (fieldId.empty() && path_sv == legacyPath);
     };
 
-    // DualSense adaptive trigger senders, one per effect shape,
-    // parameterized by trigger side ("left"/"right").
-    // Defined here so they're available to the per-side/per-effect
-    // match() branches below (one Protocol Editor
+    // DualSense adaptive trigger senders, one per effect shape, parameterized
+    // by trigger side ("left"/"right"). Defined here so they're available to
+    // the per-side/per-effect match() branches below (one Protocol Editor
     // field per side x effect, see "Adaptive Trigger" category).
     auto sendFeedback = [&](const char* trig) {
         if (std::strcmp(types, "iii") != 0 || argc != 3) return;
@@ -245,7 +244,10 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
     // DualSense Trigger Effects - one Protocol Editor field per trigger side
     // x effect (see "Adaptive Trigger" category), each independently
     // customizable since they're distinct addresses/arg signatures rather
-    // than variations on one message shape:
+    // than variations on one message shape. Addresses follow the same flat
+    // single-segment convention as the other Haptic fields above
+    // (/inputbridge/haptics/{name}) rather than nesting left/right and the
+    // effect name as separate path segments.
     //   feedback:  iii     (deviceId, position, strength)
     //   weapon:    iiii    (deviceId, start_position, end_position, strength)
     //   vibration: iiii    (deviceId, position, amplitude, frequency)
@@ -253,20 +255,20 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
     //   galloping: iiiiii  (deviceId, start_position, end_position, first_foot, second_foot, frequency)
     //   machine:   iiiiiii (deviceId, start_position, end_position, amplitude_a, amplitude_b, frequency, period)
     //   off:       (no args required)
-    else if (match("/inputbridge/haptics/dualsense/trigger/left/feedback",   "ds_trigger_left_feedback"))   { handled = true; sendFeedback("left"); }
-    else if (match("/inputbridge/haptics/dualsense/trigger/right/feedback",  "ds_trigger_right_feedback"))  { handled = true; sendFeedback("right"); }
-    else if (match("/inputbridge/haptics/dualsense/trigger/left/weapon",     "ds_trigger_left_weapon"))     { handled = true; sendWeapon("left"); }
-    else if (match("/inputbridge/haptics/dualsense/trigger/right/weapon",    "ds_trigger_right_weapon"))    { handled = true; sendWeapon("right"); }
-    else if (match("/inputbridge/haptics/dualsense/trigger/left/vibration",  "ds_trigger_left_vibration"))  { handled = true; sendVibration("left"); }
-    else if (match("/inputbridge/haptics/dualsense/trigger/right/vibration", "ds_trigger_right_vibration")) { handled = true; sendVibration("right"); }
-    else if (match("/inputbridge/haptics/dualsense/trigger/left/bow",        "ds_trigger_left_bow"))        { handled = true; sendBow("left"); }
-    else if (match("/inputbridge/haptics/dualsense/trigger/right/bow",       "ds_trigger_right_bow"))       { handled = true; sendBow("right"); }
-    else if (match("/inputbridge/haptics/dualsense/trigger/left/galloping",  "ds_trigger_left_galloping"))  { handled = true; sendGalloping("left"); }
-    else if (match("/inputbridge/haptics/dualsense/trigger/right/galloping", "ds_trigger_right_galloping")) { handled = true; sendGalloping("right"); }
-    else if (match("/inputbridge/haptics/dualsense/trigger/left/machine",    "ds_trigger_left_machine"))    { handled = true; sendMachine("left"); }
-    else if (match("/inputbridge/haptics/dualsense/trigger/right/machine",   "ds_trigger_right_machine"))   { handled = true; sendMachine("right"); }
-    else if (match("/inputbridge/haptics/dualsense/trigger/left/off",        "ds_trigger_left_off"))        { handled = true; sendOff("left"); }
-    else if (match("/inputbridge/haptics/dualsense/trigger/right/off",       "ds_trigger_right_off"))       { handled = true; sendOff("right"); }
+    else if (match("/haptics/dualsense/trigger/left/feedback",   "ds_trigger_left_feedback"))   { handled = true; sendFeedback("left"); }
+    else if (match("/haptics/dualsense/trigger/right/feedback",  "ds_trigger_right_feedback"))  { handled = true; sendFeedback("right"); }
+    else if (match("/haptics/dualsense/trigger/left/weapon",     "ds_trigger_left_weapon"))     { handled = true; sendWeapon("left"); }
+    else if (match("/haptics/dualsense/trigger/right/weapon",    "ds_trigger_right_weapon"))    { handled = true; sendWeapon("right"); }
+    else if (match("/haptics/dualsense/trigger/left/vibration",  "ds_trigger_left_vibration"))  { handled = true; sendVibration("left"); }
+    else if (match("/haptics/dualsense/trigger/right/vibration", "ds_trigger_right_vibration")) { handled = true; sendVibration("right"); }
+    else if (match("/haptics/dualsense/trigger/left/bow",        "ds_trigger_left_bow"))        { handled = true; sendBow("left"); }
+    else if (match("/haptics/dualsense/trigger/right/bow",       "ds_trigger_right_bow"))       { handled = true; sendBow("right"); }
+    else if (match("/haptics/dualsense/trigger/left/galloping",  "ds_trigger_left_galloping"))  { handled = true; sendGalloping("left"); }
+    else if (match("/haptics/dualsense/trigger/right/galloping", "ds_trigger_right_galloping")) { handled = true; sendGalloping("right"); }
+    else if (match("/haptics/dualsense/trigger/left/machine",    "ds_trigger_left_machine"))    { handled = true; sendMachine("left"); }
+    else if (match("/haptics/dualsense/trigger/right/machine",   "ds_trigger_right_machine"))   { handled = true; sendMachine("right"); }
+    else if (match("/haptics/dualsense/trigger/left/off",        "ds_trigger_left_off"))        { handled = true; sendOff("left"); }
+    else if (match("/haptics/dualsense/trigger/right/off",       "ds_trigger_right_off"))       { handled = true; sendOff("right"); }
     // /inputbridge/wheel/led_rpm  f  (rpm_percent 0.0–1.0)
     else if (path_sv == "/inputbridge/wheel/led_rpm" && std::strcmp(types, "f") == 0 && argc == 1) {
         handled = true;

--- a/src/Protocols/OSCBaseProtocol.cpp
+++ b/src/Protocols/OSCBaseProtocol.cpp
@@ -50,22 +50,80 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
         return (fieldId == fid) || (fieldId.empty() && path_sv == legacyPath);
     };
 
-    // Like match(), but for fields that cover a whole family of sub-addresses
-    // (e.g. DualSense trigger's .../left|right/effect) rather than one fixed
-    // address. Returns the base path to match against as a prefix: the
-    // field's configured oscPath if the active definition customizes it,
-    // otherwise the legacy hardcoded default.
-    auto resolveBase = [&](const char* legacyBase, const char* fid) {
-        std::string base = legacyBase;
-        if (def) {
-            for (const auto& field : def->fields) {
-                if (field.enabled && field.fieldId == fid) {
-                    base = field.oscPath;
-                    break;
-                }
-            }
-        }
-        return base;
+    // DualSense adaptive trigger senders, one per effect shape,
+    // parameterized by trigger side ("left"/"right").
+    // Defined here so they're available to the per-side/per-effect
+    // match() branches below (one Protocol Editor
+    // field per side x effect, see "Adaptive Trigger" category).
+    auto sendFeedback = [&](const char* trig) {
+        if (std::strcmp(types, "iii") != 0 || argc != 3) return;
+        std::map<std::string, int> params;
+        params["position"] = ClampDSPosition(argv[1]->i, path_sv);
+        params["strength"] = ClampDSStrength(argv[2]->i, path_sv);
+        DispatchHapticCommand<GamepadHaptics>([&, trig](GamepadHaptics* gamepad) {
+            gamepad->SendDualSenseTrigger(trig, "feedback", params);
+        });
+    };
+    auto sendWeapon = [&](const char* trig) {
+        if (std::strcmp(types, "iiii") != 0 || argc != 4) return;
+        std::map<std::string, int> params;
+        params["start_position"] = ClampDSStartPos(argv[1]->i, path_sv);
+        params["end_position"]   = ClampDSEndPos(argv[2]->i,   path_sv);
+        params["strength"]       = ClampDSStrength(argv[3]->i, path_sv);
+        DispatchHapticCommand<GamepadHaptics>([&, trig](GamepadHaptics* gamepad) {
+            gamepad->SendDualSenseTrigger(trig, "weapon", params);
+        });
+    };
+    auto sendVibration = [&](const char* trig) {
+        if (std::strcmp(types, "iiii") != 0 || argc != 4) return;
+        std::map<std::string, int> params;
+        params["position"]  = ClampDSPosition(argv[1]->i,  path_sv);
+        params["amplitude"] = ClampDSAmplitude(argv[2]->i, path_sv);
+        params["frequency"] = ClampDSFrequency(argv[3]->i, path_sv);
+        DispatchHapticCommand<GamepadHaptics>([&, trig](GamepadHaptics* gamepad) {
+            gamepad->SendDualSenseTrigger(trig, "vibration", params);
+        });
+    };
+    auto sendBow = [&](const char* trig) {
+        if (std::strcmp(types, "iiiii") != 0 || argc != 5) return;
+        std::map<std::string, int> params;
+        params["start_position"] = ClampDSBowPos(argv[1]->i,    path_sv);
+        params["end_position"]   = ClampDSBowPos(argv[2]->i,    path_sv);
+        params["strength"]       = ClampDSStrength(argv[3]->i,  path_sv);
+        params["snap_force"]     = ClampDSSnapForce(argv[4]->i, path_sv);
+        DispatchHapticCommand<GamepadHaptics>([&, trig](GamepadHaptics* gamepad) {
+            gamepad->SendDualSenseTrigger(trig, "bow", params);
+        });
+    };
+    auto sendGalloping = [&](const char* trig) {
+        if (std::strcmp(types, "iiiiii") != 0 || argc != 6) return;
+        std::map<std::string, int> params;
+        params["start_position"] = ClampDSGallopingPos(argv[1]->i, path_sv);
+        params["end_position"]   = ClampDSGallopingPos(argv[2]->i, path_sv);
+        params["first_foot"]     = ClampDSFirstFoot(argv[3]->i,    path_sv);
+        params["second_foot"]    = ClampDSSecondFoot(argv[4]->i,   path_sv);
+        params["frequency"]      = ClampDSFrequency(argv[5]->i,    path_sv);
+        DispatchHapticCommand<GamepadHaptics>([&, trig](GamepadHaptics* gamepad) {
+            gamepad->SendDualSenseTrigger(trig, "galloping", params);
+        });
+    };
+    auto sendMachine = [&](const char* trig) {
+        if (std::strcmp(types, "iiiiiii") != 0 || argc != 7) return;
+        std::map<std::string, int> params;
+        params["start_position"] = ClampDSMachinePos(argv[1]->i,  path_sv);
+        params["end_position"]   = ClampDSMachinePos(argv[2]->i,  path_sv);
+        params["amplitude_a"]    = ClampDSAmplitudeAB(argv[3]->i, path_sv);
+        params["amplitude_b"]    = ClampDSAmplitudeAB(argv[4]->i, path_sv);
+        params["frequency"]      = ClampDSFrequency(argv[5]->i,   path_sv);
+        params["period"]         = ClampDSPeriod(argv[6]->i,      path_sv);
+        DispatchHapticCommand<GamepadHaptics>([&, trig](GamepadHaptics* gamepad) {
+            gamepad->SendDualSenseTrigger(trig, "machine", params);
+        });
+    };
+    auto sendOff = [&](const char* trig) {
+        DispatchHapticCommand<GamepadHaptics>([&, trig](GamepadHaptics* gamepad) {
+            gamepad->SendDualSenseTrigger(trig, "off", {});
+        });
     };
 
     bool handled = false;
@@ -184,11 +242,10 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
             wheel->SetGain(gain);
         });
     }
-    // DualSense Trigger Effects
-    // {base}/{left|right}/{feedback|weapon|vibration|bow|galloping|machine|off}
-    // where {base} defaults to /inputbridge/haptics/dualsense/trigger but can
-    // be customized per-protocol via the "DualSense Adaptive Trigger" field
-    // in the Protocol Editor.
+    // DualSense Trigger Effects - one Protocol Editor field per trigger side
+    // x effect (see "Adaptive Trigger" category), each independently
+    // customizable since they're distinct addresses/arg signatures rather
+    // than variations on one message shape:
     //   feedback:  iii     (deviceId, position, strength)
     //   weapon:    iiii    (deviceId, start_position, end_position, strength)
     //   vibration: iiii    (deviceId, position, amplitude, frequency)
@@ -196,57 +253,20 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
     //   galloping: iiiiii  (deviceId, start_position, end_position, first_foot, second_foot, frequency)
     //   machine:   iiiiiii (deviceId, start_position, end_position, amplitude_a, amplitude_b, frequency, period)
     //   off:       (no args required)
-    else if (path_sv.starts_with(resolveBase("/inputbridge/haptics/dualsense/trigger", "haptic_dualsense_trigger") + "/")) {
-        handled = true;
-        DispatchHapticCommand<GamepadHaptics>([&](GamepadHaptics* gamepad) {
-            std::string trigger = (path_sv.find("/left/") != std::string_view::npos) ? "left" : "right";
-            std::string effect = "off";
-            std::map<std::string, int> params;
-
-            if (path_sv.ends_with("/feedback") && std::strcmp(types, "iii") == 0 && argc == 3) {
-                effect = "feedback";
-                params["position"] = ClampDSPosition(argv[1]->i, path_sv);
-                params["strength"] = ClampDSStrength(argv[2]->i, path_sv);
-            } else if (path_sv.ends_with("/weapon") && std::strcmp(types, "iiii") == 0 && argc == 4) {
-                effect = "weapon";
-                params["start_position"] = ClampDSStartPos(argv[1]->i, path_sv);
-                params["end_position"]   = ClampDSEndPos(argv[2]->i,   path_sv);
-                params["strength"]       = ClampDSStrength(argv[3]->i, path_sv);
-            } else if (path_sv.ends_with("/vibration") && std::strcmp(types, "iiii") == 0 && argc == 4) {
-                effect = "vibration";
-                params["position"]  = ClampDSPosition(argv[1]->i,  path_sv);
-                params["amplitude"] = ClampDSAmplitude(argv[2]->i, path_sv);
-                params["frequency"] = ClampDSFrequency(argv[3]->i, path_sv);
-            } else if (path_sv.ends_with("/bow") && std::strcmp(types, "iiiii") == 0 && argc == 5) {
-                effect = "bow";
-                params["start_position"] = ClampDSBowPos(argv[1]->i,     path_sv);
-                params["end_position"]   = ClampDSBowPos(argv[2]->i,     path_sv);
-                params["strength"]       = ClampDSStrength(argv[3]->i,   path_sv);
-                params["snap_force"]     = ClampDSSnapForce(argv[4]->i,  path_sv);
-            } else if (path_sv.ends_with("/galloping") && std::strcmp(types, "iiiiii") == 0 && argc == 6) {
-                effect = "galloping";
-                params["start_position"] = ClampDSGallopingPos(argv[1]->i, path_sv);
-                params["end_position"]   = ClampDSGallopingPos(argv[2]->i, path_sv);
-                params["first_foot"]     = ClampDSFirstFoot(argv[3]->i,   path_sv);
-                params["second_foot"]    = ClampDSSecondFoot(argv[4]->i,  path_sv);
-                params["frequency"]      = ClampDSFrequency(argv[5]->i,   path_sv);
-            } else if (path_sv.ends_with("/machine") && std::strcmp(types, "iiiiiii") == 0 && argc == 7) {
-                effect = "machine";
-                params["start_position"] = ClampDSMachinePos(argv[1]->i,  path_sv);
-                params["end_position"]   = ClampDSMachinePos(argv[2]->i,  path_sv);
-                params["amplitude_a"]    = ClampDSAmplitudeAB(argv[3]->i, path_sv);
-                params["amplitude_b"]    = ClampDSAmplitudeAB(argv[4]->i, path_sv);
-                params["frequency"]      = ClampDSFrequency(argv[5]->i,   path_sv);
-                params["period"]         = ClampDSPeriod(argv[6]->i,      path_sv);
-            } else if (path_sv.ends_with("/off")) {
-                effect = "off";
-            }
-
-            if (effect != "off" || path_sv.ends_with("/off")) {
-                gamepad->SendDualSenseTrigger(trigger.c_str(), effect.c_str(), params);
-            }
-        });
-    }
+    else if (match("/inputbridge/haptics/dualsense/trigger/left/feedback",   "ds_trigger_left_feedback"))   { handled = true; sendFeedback("left"); }
+    else if (match("/inputbridge/haptics/dualsense/trigger/right/feedback",  "ds_trigger_right_feedback"))  { handled = true; sendFeedback("right"); }
+    else if (match("/inputbridge/haptics/dualsense/trigger/left/weapon",     "ds_trigger_left_weapon"))     { handled = true; sendWeapon("left"); }
+    else if (match("/inputbridge/haptics/dualsense/trigger/right/weapon",    "ds_trigger_right_weapon"))    { handled = true; sendWeapon("right"); }
+    else if (match("/inputbridge/haptics/dualsense/trigger/left/vibration",  "ds_trigger_left_vibration"))  { handled = true; sendVibration("left"); }
+    else if (match("/inputbridge/haptics/dualsense/trigger/right/vibration", "ds_trigger_right_vibration")) { handled = true; sendVibration("right"); }
+    else if (match("/inputbridge/haptics/dualsense/trigger/left/bow",        "ds_trigger_left_bow"))        { handled = true; sendBow("left"); }
+    else if (match("/inputbridge/haptics/dualsense/trigger/right/bow",       "ds_trigger_right_bow"))       { handled = true; sendBow("right"); }
+    else if (match("/inputbridge/haptics/dualsense/trigger/left/galloping",  "ds_trigger_left_galloping"))  { handled = true; sendGalloping("left"); }
+    else if (match("/inputbridge/haptics/dualsense/trigger/right/galloping", "ds_trigger_right_galloping")) { handled = true; sendGalloping("right"); }
+    else if (match("/inputbridge/haptics/dualsense/trigger/left/machine",    "ds_trigger_left_machine"))    { handled = true; sendMachine("left"); }
+    else if (match("/inputbridge/haptics/dualsense/trigger/right/machine",   "ds_trigger_right_machine"))   { handled = true; sendMachine("right"); }
+    else if (match("/inputbridge/haptics/dualsense/trigger/left/off",        "ds_trigger_left_off"))        { handled = true; sendOff("left"); }
+    else if (match("/inputbridge/haptics/dualsense/trigger/right/off",       "ds_trigger_right_off"))       { handled = true; sendOff("right"); }
     // /inputbridge/wheel/led_rpm  f  (rpm_percent 0.0–1.0)
     else if (path_sv == "/inputbridge/wheel/led_rpm" && std::strcmp(types, "f") == 0 && argc == 1) {
         handled = true;

--- a/src/Protocols/OSCBaseProtocol.cpp
+++ b/src/Protocols/OSCBaseProtocol.cpp
@@ -167,7 +167,14 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
         });
     }
     // DualSense Trigger Effects
-    // /inputbridge/haptics/dualsense/trigger/{left|right}/{feedback|weapon|vibration|off}
+    // /inputbridge/haptics/dualsense/trigger/{left|right}/{feedback|weapon|vibration|bow|galloping|machine|off}
+    //   feedback:  iii     (deviceId, position, strength)
+    //   weapon:    iiii    (deviceId, start_position, end_position, strength)
+    //   vibration: iiii    (deviceId, position, amplitude, frequency)
+    //   bow:       iiiii   (deviceId, start_position, end_position, strength, snap_force)
+    //   galloping: iiiiii  (deviceId, start_position, end_position, first_foot, second_foot, frequency)
+    //   machine:   iiiiiii (deviceId, start_position, end_position, amplitude_a, amplitude_b, frequency, period)
+    //   off:       (no args required)
     else if (path_sv.find("/inputbridge/haptics/dualsense/trigger/") != std::string_view::npos) {
         handled = true;
         DispatchHapticCommand<GamepadHaptics>([&](GamepadHaptics* gamepad) {
@@ -189,6 +196,27 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
                 params["position"]  = ClampDSPosition(argv[1]->i,  path_sv);
                 params["amplitude"] = ClampDSAmplitude(argv[2]->i, path_sv);
                 params["frequency"] = ClampDSFrequency(argv[3]->i, path_sv);
+            } else if (path_sv.ends_with("/bow") && std::strcmp(types, "iiiii") == 0 && argc == 5) {
+                effect = "bow";
+                params["start_position"] = ClampDSBowPos(argv[1]->i,     path_sv);
+                params["end_position"]   = ClampDSBowPos(argv[2]->i,     path_sv);
+                params["strength"]       = ClampDSStrength(argv[3]->i,   path_sv);
+                params["snap_force"]     = ClampDSSnapForce(argv[4]->i,  path_sv);
+            } else if (path_sv.ends_with("/galloping") && std::strcmp(types, "iiiiii") == 0 && argc == 6) {
+                effect = "galloping";
+                params["start_position"] = ClampDSGallopingPos(argv[1]->i, path_sv);
+                params["end_position"]   = ClampDSGallopingPos(argv[2]->i, path_sv);
+                params["first_foot"]     = ClampDSFirstFoot(argv[3]->i,   path_sv);
+                params["second_foot"]    = ClampDSSecondFoot(argv[4]->i,  path_sv);
+                params["frequency"]      = ClampDSFrequency(argv[5]->i,   path_sv);
+            } else if (path_sv.ends_with("/machine") && std::strcmp(types, "iiiiiii") == 0 && argc == 7) {
+                effect = "machine";
+                params["start_position"] = ClampDSMachinePos(argv[1]->i,  path_sv);
+                params["end_position"]   = ClampDSMachinePos(argv[2]->i,  path_sv);
+                params["amplitude_a"]    = ClampDSAmplitudeAB(argv[3]->i, path_sv);
+                params["amplitude_b"]    = ClampDSAmplitudeAB(argv[4]->i, path_sv);
+                params["frequency"]      = ClampDSFrequency(argv[5]->i,   path_sv);
+                params["period"]         = ClampDSPeriod(argv[6]->i,      path_sv);
             } else if (path_sv.ends_with("/off")) {
                 effect = "off";
             }

--- a/src/Protocols/OSCBaseProtocol.cpp
+++ b/src/Protocols/OSCBaseProtocol.cpp
@@ -127,8 +127,8 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
 
     bool handled = false;
 
-    // /inputbridge/haptics/rumble  iiffi  (deviceId, slot, low_freq, high_freq, duration_ms)
-    if (match("/inputbridge/haptics/rumble", "haptic_rumble") && std::strcmp(types, "iiffi") == 0 && argc == 5) {
+    // /haptic/rumble  iiffi  (deviceId, slot, low_freq, high_freq, duration_ms)
+    if (match("/haptic/rumble", "haptic_rumble") && std::strcmp(types, "iiffi") == 0 && argc == 5) {
         handled = true;
         int   slot        = argv[1]->i;
         float low_freq    = argv[2]->f;
@@ -144,8 +144,8 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
                 (duration_ms < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration_ms);
         });
     }
-    // /inputbridge/haptics/force  iifi  (deviceId, slot, strength, duration_ms)
-    else if (match("/inputbridge/haptics/force", "haptic_constant") && std::strcmp(types, "iifi") == 0 && argc == 4) {
+    // /haptic/force  iifi  (deviceId, slot, strength, duration_ms)
+    else if (match("/haptic/force", "haptic_constant") && std::strcmp(types, "iifi") == 0 && argc == 4) {
         handled = true;
         int   slot         = argv[1]->i;
         float strength     = argv[2]->f;
@@ -159,8 +159,8 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
                 (duration_int < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration_int);
         });
     }
-    // /inputbridge/haptics/periodic  iiififfii  (deviceId, slot, wave_type, strength, period, magnitude, offset, phase, duration_ms)
-    else if (match("/inputbridge/haptics/periodic", "haptic_periodic") && std::strcmp(types, "iiififfii") == 0 && argc == 9) {
+    // /haptic/periodic  iiififfii  (deviceId, slot, wave_type, strength, period, magnitude, offset, phase, duration_ms)
+    else if (match("/haptic/periodic", "haptic_periodic") && std::strcmp(types, "iiififfii") == 0 && argc == 9) {
         handled = true;
         int   slot         = argv[1]->i;
         int   wave_idx     = argv[2]->i;
@@ -184,7 +184,7 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
         });
     }
     // Legacy periodic - no wave_type, defaults to Sine.
-    else if (match("/inputbridge/haptics/periodic", "haptic_periodic") && std::strcmp(types, "iififfii") == 0 && argc == 8) {
+    else if (match("/haptic/periodic", "haptic_periodic") && std::strcmp(types, "iififfii") == 0 && argc == 8) {
         handled = true;
         int   slot         = argv[1]->i;
         float strength     = argv[2]->f;
@@ -204,8 +204,8 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
                 (duration_int < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration_int);
         });
     }
-    // /inputbridge/haptics/condition  iiiffffffi  (deviceId, slot, condition_type, right_sat, left_sat, right_coeff, left_coeff, deadband, center, duration_ms)
-    else if (match("/inputbridge/haptics/condition", "haptic_condition") && std::strcmp(types, "iiiffffffi") == 0 && argc == 10) {
+    // /haptic/condition  iiiffffffi  (deviceId, slot, condition_type, right_sat, left_sat, right_coeff, left_coeff, deadband, center, duration_ms)
+    else if (match("/haptic/condition", "haptic_condition") && std::strcmp(types, "iiiffffffi") == 0 && argc == 10) {
         handled = true;
         int   slot           = argv[1]->i;
         int   cond_idx       = argv[2]->i;
@@ -233,8 +233,8 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
                 (duration_int < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration_int);
         });
     }
-    // /inputbridge/haptics/gain  ii  (deviceId, gain)
-    else if (match("/inputbridge/haptics/gain", "haptic_gain") && std::strcmp(types, "ii") == 0 && argc == 2) {
+    // /haptic/gain  ii  (deviceId, gain)
+    else if (match("/haptic/gain", "haptic_gain") && std::strcmp(types, "ii") == 0 && argc == 2) {
         handled = true;
         int gain = ClampGain(argv[1]->i, path_sv);
         DispatchHapticCommand<SteeringWheelHaptics>([&](SteeringWheelHaptics* wheel) {
@@ -245,9 +245,9 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
     // x effect (see "Adaptive Trigger" category), each independently
     // customizable since they're distinct addresses/arg signatures rather
     // than variations on one message shape. Addresses follow the same flat
-    // single-segment convention as the other Haptic fields above
-    // (/inputbridge/haptics/{name}) rather than nesting left/right and the
-    // effect name as separate path segments.
+    // /haptic/{name} single-segment convention as the other Haptic fields
+    // above, rather than nesting left/right and the effect name as separate
+    // path segments.
     //   feedback:  iii     (deviceId, position, strength)
     //   weapon:    iiii    (deviceId, start_position, end_position, strength)
     //   vibration: iiii    (deviceId, position, amplitude, frequency)
@@ -255,20 +255,20 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
     //   galloping: iiiiii  (deviceId, start_position, end_position, first_foot, second_foot, frequency)
     //   machine:   iiiiiii (deviceId, start_position, end_position, amplitude_a, amplitude_b, frequency, period)
     //   off:       (no args required)
-    else if (match("/haptics/dualsense/trigger/left/feedback",   "ds_trigger_left_feedback"))   { handled = true; sendFeedback("left"); }
-    else if (match("/haptics/dualsense/trigger/right/feedback",  "ds_trigger_right_feedback"))  { handled = true; sendFeedback("right"); }
-    else if (match("/haptics/dualsense/trigger/left/weapon",     "ds_trigger_left_weapon"))     { handled = true; sendWeapon("left"); }
-    else if (match("/haptics/dualsense/trigger/right/weapon",    "ds_trigger_right_weapon"))    { handled = true; sendWeapon("right"); }
-    else if (match("/haptics/dualsense/trigger/left/vibration",  "ds_trigger_left_vibration"))  { handled = true; sendVibration("left"); }
-    else if (match("/haptics/dualsense/trigger/right/vibration", "ds_trigger_right_vibration")) { handled = true; sendVibration("right"); }
-    else if (match("/haptics/dualsense/trigger/left/bow",        "ds_trigger_left_bow"))        { handled = true; sendBow("left"); }
-    else if (match("/haptics/dualsense/trigger/right/bow",       "ds_trigger_right_bow"))       { handled = true; sendBow("right"); }
-    else if (match("/haptics/dualsense/trigger/left/galloping",  "ds_trigger_left_galloping"))  { handled = true; sendGalloping("left"); }
-    else if (match("/haptics/dualsense/trigger/right/galloping", "ds_trigger_right_galloping")) { handled = true; sendGalloping("right"); }
-    else if (match("/haptics/dualsense/trigger/left/machine",    "ds_trigger_left_machine"))    { handled = true; sendMachine("left"); }
-    else if (match("/haptics/dualsense/trigger/right/machine",   "ds_trigger_right_machine"))   { handled = true; sendMachine("right"); }
-    else if (match("/haptics/dualsense/trigger/left/off",        "ds_trigger_left_off"))        { handled = true; sendOff("left"); }
-    else if (match("/haptics/dualsense/trigger/right/off",       "ds_trigger_right_off"))       { handled = true; sendOff("right"); }
+    else if (match("/haptic/dualsense/trigger/left/feedback",   "ds_trigger_left_feedback"))   { handled = true; sendFeedback("left"); }
+    else if (match("/haptic/dualsense/trigger/right/feedback",  "ds_trigger_right_feedback"))  { handled = true; sendFeedback("right"); }
+    else if (match("/haptic/dualsense/trigger/left/weapon",     "ds_trigger_left_weapon"))     { handled = true; sendWeapon("left"); }
+    else if (match("/haptic/dualsense/trigger/right/weapon",    "ds_trigger_right_weapon"))    { handled = true; sendWeapon("right"); }
+    else if (match("/haptic/dualsense/trigger/left/vibration",  "ds_trigger_left_vibration"))  { handled = true; sendVibration("left"); }
+    else if (match("/haptic/dualsense/trigger/right/vibration", "ds_trigger_right_vibration")) { handled = true; sendVibration("right"); }
+    else if (match("/haptic/dualsense/trigger/left/bow",        "ds_trigger_left_bow"))        { handled = true; sendBow("left"); }
+    else if (match("/haptic/dualsense/trigger/right/bow",       "ds_trigger_right_bow"))       { handled = true; sendBow("right"); }
+    else if (match("/haptic/dualsense/trigger/left/galloping",  "ds_trigger_left_galloping"))  { handled = true; sendGalloping("left"); }
+    else if (match("/haptic/dualsense/trigger/right/galloping", "ds_trigger_right_galloping")) { handled = true; sendGalloping("right"); }
+    else if (match("/haptic/dualsense/trigger/left/machine",    "ds_trigger_left_machine"))    { handled = true; sendMachine("left"); }
+    else if (match("/haptic/dualsense/trigger/right/machine",   "ds_trigger_right_machine"))   { handled = true; sendMachine("right"); }
+    else if (match("/haptic/dualsense/trigger/left/off",        "ds_trigger_left_off"))        { handled = true; sendOff("left"); }
+    else if (match("/haptic/dualsense/trigger/right/off",       "ds_trigger_right_off"))       { handled = true; sendOff("right"); }
     // /inputbridge/wheel/led_rpm  f  (rpm_percent 0.0–1.0)
     else if (path_sv == "/inputbridge/wheel/led_rpm" && std::strcmp(types, "f") == 0 && argc == 1) {
         handled = true;
@@ -280,14 +280,14 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
         }
     }
 
-    // ── Subchannel paths: /inputbridge/haptics/<effect>/<slot> ───────────────
+    // ── Subchannel paths: /haptic/<effect>/<slot> ───────────────
     // The slot is encoded as the trailing decimal path component instead of
     // being passed as a message argument.  This lets hosts that can send only
     // one OSC message per frame per path (e.g. Resonite) address multiple
     // independent slots by using distinct paths:
     //
-    //   /inputbridge/haptics/rumble/0   iffi  (id, low_freq, high_freq, dur)
-    //   /inputbridge/haptics/rumble/1   iffi  (id, low_freq, high_freq, dur)
+    //   /haptic/rumble/0   iffi  (id, low_freq, high_freq, dur)
+    //   /haptic/rumble/1   iffi  (id, low_freq, high_freq, dur)
     //
     // Custom-protocol field IDs are matched against the base path (without the
     // trailing /N), so user-defined paths like "/my/rumble/0" also work.
@@ -320,8 +320,8 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
         return (baseFieldId == fid) || (baseFieldId.empty() && base == legacyPath);
     };
 
-    // /inputbridge/haptics/rumble/N  iffi  (id, low_freq, high_freq, duration_ms)
-    if (matchBase("/inputbridge/haptics/rumble", "haptic_rumble")
+    // /haptic/rumble/N  iffi  (id, low_freq, high_freq, duration_ms)
+    if (matchBase("/haptic/rumble", "haptic_rumble")
         && std::strcmp(types, "iffi") == 0 && argc == 4) {
         handled = true;
         float low      = ClampNorm(argv[1]->f, "low_freq",  path_sv);
@@ -331,8 +331,8 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
             gamepad->PlayRumble(slot, low, high, (duration < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration);
         });
     }
-    // /inputbridge/haptics/force/N  ifi  (id, strength, duration_ms)
-    else if (matchBase("/inputbridge/haptics/force", "haptic_constant")
+    // /haptic/force/N  ifi  (id, strength, duration_ms)
+    else if (matchBase("/haptic/force", "haptic_constant")
         && std::strcmp(types, "ifi") == 0 && argc == 3) {
         handled = true;
         float strength     = ClampStrength(argv[1]->f, "strength", path_sv);
@@ -341,8 +341,8 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
             wheel->PlayConstant(slot, strength, (duration < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration);
         });
     }
-    // /inputbridge/haptics/periodic/N  iififfii  (id, wave_type, strength, period, magnitude, offset, phase, duration_ms)
-    else if (matchBase("/inputbridge/haptics/periodic", "haptic_periodic")
+    // /haptic/periodic/N  iififfii  (id, wave_type, strength, period, magnitude, offset, phase, duration_ms)
+    else if (matchBase("/haptic/periodic", "haptic_periodic")
         && std::strcmp(types, "iififfii") == 0 && argc == 8) {
         handled = true;
         int wave_idx = argv[1]->i;
@@ -359,8 +359,8 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
                 (duration < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration);
         });
     }
-    // Legacy: /inputbridge/haptics/periodic/N  ififfii  - no wave_type, defaults to Sine
-    else if (matchBase("/inputbridge/haptics/periodic", "haptic_periodic")
+    // Legacy: /haptic/periodic/N  ififfii  - no wave_type, defaults to Sine
+    else if (matchBase("/haptic/periodic", "haptic_periodic")
         && std::strcmp(types, "ififfii") == 0 && argc == 7) {
         handled = true;
         float strength      = ClampNorm(argv[1]->f,    "strength",  path_sv);
@@ -374,8 +374,8 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
                 (duration < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration);
         });
     }
-    // /inputbridge/haptics/condition/N  iiffffffi  (id, condition_type, rsat, lsat, rcoeff, lcoeff, deadband, center, duration_ms)
-    else if (matchBase("/inputbridge/haptics/condition", "haptic_condition")
+    // /haptic/condition/N  iiffffffi  (id, condition_type, rsat, lsat, rcoeff, lcoeff, deadband, center, duration_ms)
+    else if (matchBase("/haptic/condition", "haptic_condition")
         && std::strcmp(types, "iiffffffi") == 0 && argc == 9) {
         handled = true;
         int cond_idx = argv[1]->i;

--- a/src/Protocols/OSCProtocol.cpp
+++ b/src/Protocols/OSCProtocol.cpp
@@ -54,6 +54,80 @@ bool OSCProtocol::handle_osc_message(const char* path, const char* types, lo_arg
     std::string_view path_sv(path);
     bool handled = false;
 
+    // DualSense adaptive trigger senders - one per effect shape, parameterized
+    // by trigger side ("left"/"right"). Defined here so they're available to
+    // the flat per-side/per-effect address checks further down.
+    auto sendFeedback = [&](const char* trig) {
+        if (std::strcmp(types, "iii") != 0 || argc != 3) return;
+        std::map<std::string, int> params;
+        params["position"] = ClampDSPosition(argv[1]->i, path_sv);
+        params["strength"] = ClampDSStrength(argv[2]->i, path_sv);
+        DispatchHapticCommand<GamepadHaptics>([&, trig](GamepadHaptics* gamepad) {
+            gamepad->SendDualSenseTrigger(trig, "feedback", params);
+        });
+    };
+    auto sendWeapon = [&](const char* trig) {
+        if (std::strcmp(types, "iiii") != 0 || argc != 4) return;
+        std::map<std::string, int> params;
+        params["start_position"] = ClampDSStartPos(argv[1]->i, path_sv);
+        params["end_position"]   = ClampDSEndPos(argv[2]->i,   path_sv);
+        params["strength"]       = ClampDSStrength(argv[3]->i, path_sv);
+        DispatchHapticCommand<GamepadHaptics>([&, trig](GamepadHaptics* gamepad) {
+            gamepad->SendDualSenseTrigger(trig, "weapon", params);
+        });
+    };
+    auto sendVibration = [&](const char* trig) {
+        if (std::strcmp(types, "iiii") != 0 || argc != 4) return;
+        std::map<std::string, int> params;
+        params["position"]  = ClampDSPosition(argv[1]->i,  path_sv);
+        params["amplitude"] = ClampDSAmplitude(argv[2]->i, path_sv);
+        params["frequency"] = ClampDSFrequency(argv[3]->i, path_sv);
+        DispatchHapticCommand<GamepadHaptics>([&, trig](GamepadHaptics* gamepad) {
+            gamepad->SendDualSenseTrigger(trig, "vibration", params);
+        });
+    };
+    auto sendBow = [&](const char* trig) {
+        if (std::strcmp(types, "iiiii") != 0 || argc != 5) return;
+        std::map<std::string, int> params;
+        params["start_position"] = ClampDSBowPos(argv[1]->i,    path_sv);
+        params["end_position"]   = ClampDSBowPos(argv[2]->i,    path_sv);
+        params["strength"]       = ClampDSStrength(argv[3]->i,  path_sv);
+        params["snap_force"]     = ClampDSSnapForce(argv[4]->i, path_sv);
+        DispatchHapticCommand<GamepadHaptics>([&, trig](GamepadHaptics* gamepad) {
+            gamepad->SendDualSenseTrigger(trig, "bow", params);
+        });
+    };
+    auto sendGalloping = [&](const char* trig) {
+        if (std::strcmp(types, "iiiiii") != 0 || argc != 6) return;
+        std::map<std::string, int> params;
+        params["start_position"] = ClampDSGallopingPos(argv[1]->i, path_sv);
+        params["end_position"]   = ClampDSGallopingPos(argv[2]->i, path_sv);
+        params["first_foot"]     = ClampDSFirstFoot(argv[3]->i,    path_sv);
+        params["second_foot"]    = ClampDSSecondFoot(argv[4]->i,   path_sv);
+        params["frequency"]      = ClampDSFrequency(argv[5]->i,    path_sv);
+        DispatchHapticCommand<GamepadHaptics>([&, trig](GamepadHaptics* gamepad) {
+            gamepad->SendDualSenseTrigger(trig, "galloping", params);
+        });
+    };
+    auto sendMachine = [&](const char* trig) {
+        if (std::strcmp(types, "iiiiiii") != 0 || argc != 7) return;
+        std::map<std::string, int> params;
+        params["start_position"] = ClampDSMachinePos(argv[1]->i,  path_sv);
+        params["end_position"]   = ClampDSMachinePos(argv[2]->i,  path_sv);
+        params["amplitude_a"]    = ClampDSAmplitudeAB(argv[3]->i, path_sv);
+        params["amplitude_b"]    = ClampDSAmplitudeAB(argv[4]->i, path_sv);
+        params["frequency"]      = ClampDSFrequency(argv[5]->i,   path_sv);
+        params["period"]         = ClampDSPeriod(argv[6]->i,      path_sv);
+        DispatchHapticCommand<GamepadHaptics>([&, trig](GamepadHaptics* gamepad) {
+            gamepad->SendDualSenseTrigger(trig, "machine", params);
+        });
+    };
+    auto sendOff = [&](const char* trig) {
+        DispatchHapticCommand<GamepadHaptics>([&, trig](GamepadHaptics* gamepad) {
+            gamepad->SendDualSenseTrigger(trig, "off", {});
+        });
+    };
+
     // /inputbridge/haptics/rumble  iiffi  (deviceId, slot, low_freq, high_freq, duration_ms)
     if (path_sv == "/inputbridge/haptics/rumble" && std::strcmp(types, "iiffi") == 0 && argc == 5) {
         handled = true;
@@ -168,8 +242,10 @@ bool OSCProtocol::handle_osc_message(const char* path, const char* types, lo_arg
             wheel->SetGain(gain);
         });
     }
-    // DualSense Trigger Effects
-    // /inputbridge/haptics/dualsense/trigger/{left|right}/{feedback|weapon|vibration|bow|galloping|machine|off}
+    // DualSense Trigger Effects, addresses follow the same flat
+    // single-segment convention as the other /inputbridge/haptics/{name}
+    // handlers above, rather than nesting left/right and the effect name
+    // as separate path segments.
     //   feedback:  iii     (deviceId, position, strength)
     //   weapon:    iiii    (deviceId, start_position, end_position, strength)
     //   vibration: iiii    (deviceId, position, amplitude, frequency)
@@ -177,57 +253,20 @@ bool OSCProtocol::handle_osc_message(const char* path, const char* types, lo_arg
     //   galloping: iiiiii  (deviceId, start_position, end_position, first_foot, second_foot, frequency)
     //   machine:   iiiiiii (deviceId, start_position, end_position, amplitude_a, amplitude_b, frequency, period)
     //   off:       (no args required)
-    else if (path_sv.find("/inputbridge/haptics/dualsense/trigger/") != std::string_view::npos) {
-        handled = true;
-        DispatchHapticCommand<GamepadHaptics>([&](GamepadHaptics* gamepad) {
-            std::string trigger = (path_sv.find("/left/") != std::string_view::npos) ? "left" : "right";
-            std::string effect = "off";
-            std::map<std::string, int> params;
-
-            if (path_sv.ends_with("/feedback") && std::strcmp(types, "iii") == 0 && argc == 3) {
-                effect = "feedback";
-                params["position"] = ClampDSPosition(argv[1]->i, path_sv);
-                params["strength"] = ClampDSStrength(argv[2]->i, path_sv);
-            } else if (path_sv.ends_with("/weapon") && std::strcmp(types, "iiii") == 0 && argc == 4) {
-                effect = "weapon";
-                params["start_position"] = ClampDSStartPos(argv[1]->i, path_sv);
-                params["end_position"]   = ClampDSEndPos(argv[2]->i,   path_sv);
-                params["strength"]       = ClampDSStrength(argv[3]->i, path_sv);
-            } else if (path_sv.ends_with("/vibration") && std::strcmp(types, "iiii") == 0 && argc == 4) {
-                effect = "vibration";
-                params["position"]  = ClampDSPosition(argv[1]->i,  path_sv);
-                params["amplitude"] = ClampDSAmplitude(argv[2]->i, path_sv);
-                params["frequency"] = ClampDSFrequency(argv[3]->i, path_sv);
-            } else if (path_sv.ends_with("/bow") && std::strcmp(types, "iiiii") == 0 && argc == 5) {
-                effect = "bow";
-                params["start_position"] = ClampDSBowPos(argv[1]->i,     path_sv);
-                params["end_position"]   = ClampDSBowPos(argv[2]->i,     path_sv);
-                params["strength"]       = ClampDSStrength(argv[3]->i,   path_sv);
-                params["snap_force"]     = ClampDSSnapForce(argv[4]->i,  path_sv);
-            } else if (path_sv.ends_with("/galloping") && std::strcmp(types, "iiiiii") == 0 && argc == 6) {
-                effect = "galloping";
-                params["start_position"] = ClampDSGallopingPos(argv[1]->i, path_sv);
-                params["end_position"]   = ClampDSGallopingPos(argv[2]->i, path_sv);
-                params["first_foot"]     = ClampDSFirstFoot(argv[3]->i,   path_sv);
-                params["second_foot"]    = ClampDSSecondFoot(argv[4]->i,  path_sv);
-                params["frequency"]      = ClampDSFrequency(argv[5]->i,   path_sv);
-            } else if (path_sv.ends_with("/machine") && std::strcmp(types, "iiiiiii") == 0 && argc == 7) {
-                effect = "machine";
-                params["start_position"] = ClampDSMachinePos(argv[1]->i,  path_sv);
-                params["end_position"]   = ClampDSMachinePos(argv[2]->i,  path_sv);
-                params["amplitude_a"]    = ClampDSAmplitudeAB(argv[3]->i, path_sv);
-                params["amplitude_b"]    = ClampDSAmplitudeAB(argv[4]->i, path_sv);
-                params["frequency"]      = ClampDSFrequency(argv[5]->i,   path_sv);
-                params["period"]         = ClampDSPeriod(argv[6]->i,      path_sv);
-            } else if (path_sv.ends_with("/off")) {
-                effect = "off";
-            }
-
-            if (effect != "off" || path_sv.ends_with("/off")) {
-                gamepad->SendDualSenseTrigger(trigger.c_str(), effect.c_str(), params);
-            }
-        });
-    }
+    else if (path_sv == "/inputbridge/haptics/dualsense_trigger_left_feedback")   { handled = true; sendFeedback("left"); }
+    else if (path_sv == "/inputbridge/haptics/dualsense_trigger_right_feedback")  { handled = true; sendFeedback("right"); }
+    else if (path_sv == "/inputbridge/haptics/dualsense_trigger_left_weapon")     { handled = true; sendWeapon("left"); }
+    else if (path_sv == "/inputbridge/haptics/dualsense_trigger_right_weapon")    { handled = true; sendWeapon("right"); }
+    else if (path_sv == "/inputbridge/haptics/dualsense_trigger_left_vibration")  { handled = true; sendVibration("left"); }
+    else if (path_sv == "/inputbridge/haptics/dualsense_trigger_right_vibration") { handled = true; sendVibration("right"); }
+    else if (path_sv == "/inputbridge/haptics/dualsense_trigger_left_bow")        { handled = true; sendBow("left"); }
+    else if (path_sv == "/inputbridge/haptics/dualsense_trigger_right_bow")       { handled = true; sendBow("right"); }
+    else if (path_sv == "/inputbridge/haptics/dualsense_trigger_left_galloping")  { handled = true; sendGalloping("left"); }
+    else if (path_sv == "/inputbridge/haptics/dualsense_trigger_right_galloping") { handled = true; sendGalloping("right"); }
+    else if (path_sv == "/inputbridge/haptics/dualsense_trigger_left_machine")    { handled = true; sendMachine("left"); }
+    else if (path_sv == "/inputbridge/haptics/dualsense_trigger_right_machine")   { handled = true; sendMachine("right"); }
+    else if (path_sv == "/inputbridge/haptics/dualsense_trigger_left_off")        { handled = true; sendOff("left"); }
+    else if (path_sv == "/inputbridge/haptics/dualsense_trigger_right_off")       { handled = true; sendOff("right"); }
     // /inputbridge/wheel/led_rpm  f  (rpm_percent 0.0–1.0)
     else if (path_sv == "/inputbridge/wheel/led_rpm" && std::strcmp(types, "f") == 0 && argc == 1) {
         handled = true;

--- a/src/Protocols/OSCProtocol.cpp
+++ b/src/Protocols/OSCProtocol.cpp
@@ -1,5 +1,7 @@
 #include "Protocols/OSCProtocol.h"
 #include "Protocols/OSCValidation.h"
+#include "Protocols/ProtocolManager.h"
+#include "Protocols/ProtocolRegistry.h"
 #include "Network/OSCServer.h"
 #include "Devices/DeviceManager.h"
 #include "Haptics/GamepadHaptics.h"
@@ -53,6 +55,29 @@ bool OSCProtocol::handle_osc_message(const char* path, const char* types, lo_arg
 
     std::string_view path_sv(path);
     bool handled = false;
+
+    // Field-customization lookup: lets a Protocol Editor field's custom OSC
+    // Path override the legacy default below, same mechanism as
+    // OSCBaseProtocol.cpp. Only actually consulted by match() calls further
+    // down (currently just the DualSense trigger branch) - everything else
+    // in this handler still uses its fixed legacy address directly.
+    std::string activeId = ProtocolManager::GetInstance().GetActiveInputProtocolId();
+    const ProtocolDefinition* def = nullptr;
+    if (!activeId.empty()) def = ProtocolRegistry::GetInstance().FindById(activeId);
+
+    std::string fieldId;
+    if (def) {
+        for (const auto& field : def->fields) {
+            if (field.enabled && field.oscPath == path_sv) {
+                fieldId = field.fieldId;
+                break;
+            }
+        }
+    }
+
+    auto match = [&](const char* legacyPath, const char* fid) {
+        return (fieldId == fid) || (fieldId.empty() && path_sv == legacyPath);
+    };
 
     // DualSense adaptive trigger senders - one per effect shape, parameterized
     // by trigger side ("left"/"right"). Defined here so they're available to
@@ -242,10 +267,9 @@ bool OSCProtocol::handle_osc_message(const char* path, const char* types, lo_arg
             wheel->SetGain(gain);
         });
     }
-    // DualSense Trigger Effects, addresses follow the same flat
-    // single-segment convention as the other /inputbridge/haptics/{name}
-    // handlers above, rather than nesting left/right and the effect name
-    // as separate path segments.
+    // DualSense Trigger Effects, one Protocol Editor field per trigger side
+    // x effect (see "Adaptive Trigger" category), falling back to this
+    // nested legacy address when no custom OSC Path has been set.
     //   feedback:  iii     (deviceId, position, strength)
     //   weapon:    iiii    (deviceId, start_position, end_position, strength)
     //   vibration: iiii    (deviceId, position, amplitude, frequency)
@@ -253,20 +277,20 @@ bool OSCProtocol::handle_osc_message(const char* path, const char* types, lo_arg
     //   galloping: iiiiii  (deviceId, start_position, end_position, first_foot, second_foot, frequency)
     //   machine:   iiiiiii (deviceId, start_position, end_position, amplitude_a, amplitude_b, frequency, period)
     //   off:       (no args required)
-    else if (path_sv == "/inputbridge/haptics/dualsense_trigger_left_feedback")   { handled = true; sendFeedback("left"); }
-    else if (path_sv == "/inputbridge/haptics/dualsense_trigger_right_feedback")  { handled = true; sendFeedback("right"); }
-    else if (path_sv == "/inputbridge/haptics/dualsense_trigger_left_weapon")     { handled = true; sendWeapon("left"); }
-    else if (path_sv == "/inputbridge/haptics/dualsense_trigger_right_weapon")    { handled = true; sendWeapon("right"); }
-    else if (path_sv == "/inputbridge/haptics/dualsense_trigger_left_vibration")  { handled = true; sendVibration("left"); }
-    else if (path_sv == "/inputbridge/haptics/dualsense_trigger_right_vibration") { handled = true; sendVibration("right"); }
-    else if (path_sv == "/inputbridge/haptics/dualsense_trigger_left_bow")        { handled = true; sendBow("left"); }
-    else if (path_sv == "/inputbridge/haptics/dualsense_trigger_right_bow")       { handled = true; sendBow("right"); }
-    else if (path_sv == "/inputbridge/haptics/dualsense_trigger_left_galloping")  { handled = true; sendGalloping("left"); }
-    else if (path_sv == "/inputbridge/haptics/dualsense_trigger_right_galloping") { handled = true; sendGalloping("right"); }
-    else if (path_sv == "/inputbridge/haptics/dualsense_trigger_left_machine")    { handled = true; sendMachine("left"); }
-    else if (path_sv == "/inputbridge/haptics/dualsense_trigger_right_machine")   { handled = true; sendMachine("right"); }
-    else if (path_sv == "/inputbridge/haptics/dualsense_trigger_left_off")        { handled = true; sendOff("left"); }
-    else if (path_sv == "/inputbridge/haptics/dualsense_trigger_right_off")       { handled = true; sendOff("right"); }
+    else if (match("/haptics/dualsense/trigger/left/feedback",   "ds_trigger_left_feedback"))   { handled = true; sendFeedback("left"); }
+    else if (match("/haptics/dualsense/trigger/right/feedback",  "ds_trigger_right_feedback"))  { handled = true; sendFeedback("right"); }
+    else if (match("/haptics/dualsense/trigger/left/weapon",     "ds_trigger_left_weapon"))     { handled = true; sendWeapon("left"); }
+    else if (match("/haptics/dualsense/trigger/right/weapon",    "ds_trigger_right_weapon"))    { handled = true; sendWeapon("right"); }
+    else if (match("/haptics/dualsense/trigger/left/vibration",  "ds_trigger_left_vibration"))  { handled = true; sendVibration("left"); }
+    else if (match("/haptics/dualsense/trigger/right/vibration", "ds_trigger_right_vibration")) { handled = true; sendVibration("right"); }
+    else if (match("/haptics/dualsense/trigger/left/bow",        "ds_trigger_left_bow"))        { handled = true; sendBow("left"); }
+    else if (match("/haptics/dualsense/trigger/right/bow",       "ds_trigger_right_bow"))       { handled = true; sendBow("right"); }
+    else if (match("/haptics/dualsense/trigger/left/galloping",  "ds_trigger_left_galloping"))  { handled = true; sendGalloping("left"); }
+    else if (match("/haptics/dualsense/trigger/right/galloping", "ds_trigger_right_galloping")) { handled = true; sendGalloping("right"); }
+    else if (match("/haptics/dualsense/trigger/left/machine",    "ds_trigger_left_machine"))    { handled = true; sendMachine("left"); }
+    else if (match("/haptics/dualsense/trigger/right/machine",   "ds_trigger_right_machine"))   { handled = true; sendMachine("right"); }
+    else if (match("/haptics/dualsense/trigger/left/off",        "ds_trigger_left_off"))        { handled = true; sendOff("left"); }
+    else if (match("/haptics/dualsense/trigger/right/off",       "ds_trigger_right_off"))       { handled = true; sendOff("right"); }
     // /inputbridge/wheel/led_rpm  f  (rpm_percent 0.0–1.0)
     else if (path_sv == "/inputbridge/wheel/led_rpm" && std::strcmp(types, "f") == 0 && argc == 1) {
         handled = true;

--- a/src/Protocols/OSCProtocol.cpp
+++ b/src/Protocols/OSCProtocol.cpp
@@ -153,8 +153,8 @@ bool OSCProtocol::handle_osc_message(const char* path, const char* types, lo_arg
         });
     };
 
-    // /inputbridge/haptics/rumble  iiffi  (deviceId, slot, low_freq, high_freq, duration_ms)
-    if (path_sv == "/inputbridge/haptics/rumble" && std::strcmp(types, "iiffi") == 0 && argc == 5) {
+    // /haptic/rumble  iiffi  (deviceId, slot, low_freq, high_freq, duration_ms)
+    if (path_sv == "/haptic/rumble" && std::strcmp(types, "iiffi") == 0 && argc == 5) {
         handled = true;
         int   slot        = argv[1]->i;
         float low_freq    = argv[2]->f;
@@ -170,8 +170,8 @@ bool OSCProtocol::handle_osc_message(const char* path, const char* types, lo_arg
                 (duration_ms < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration_ms);
         });
     }
-    // /inputbridge/haptics/force  iifi  (deviceId, slot, strength, duration_ms)
-    else if (path_sv == "/inputbridge/haptics/force" && std::strcmp(types, "iifi") == 0 && argc == 4) {
+    // /haptic/force  iifi  (deviceId, slot, strength, duration_ms)
+    else if (path_sv == "/haptic/force" && std::strcmp(types, "iifi") == 0 && argc == 4) {
         handled = true;
         int   slot         = argv[1]->i;
         float strength     = argv[2]->f;
@@ -185,8 +185,8 @@ bool OSCProtocol::handle_osc_message(const char* path, const char* types, lo_arg
                 (duration_int < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration_int);
         });
     }
-    // /inputbridge/haptics/periodic  iiififfii  (deviceId, slot, wave_type, strength, period, magnitude, offset, phase, duration_ms)
-    else if (path_sv == "/inputbridge/haptics/periodic" && std::strcmp(types, "iiififfii") == 0 && argc == 9) {
+    // /haptic/periodic  iiififfii  (deviceId, slot, wave_type, strength, period, magnitude, offset, phase, duration_ms)
+    else if (path_sv == "/haptic/periodic" && std::strcmp(types, "iiififfii") == 0 && argc == 9) {
         handled = true;
         int   slot         = argv[1]->i;
         int   wave_idx     = argv[2]->i;
@@ -210,7 +210,7 @@ bool OSCProtocol::handle_osc_message(const char* path, const char* types, lo_arg
         });
     }
     // Legacy periodic - no wave_type, defaults to Sine.
-    else if (path_sv == "/inputbridge/haptics/periodic" && std::strcmp(types, "iififfii") == 0 && argc == 8) {
+    else if (path_sv == "/haptic/periodic" && std::strcmp(types, "iififfii") == 0 && argc == 8) {
         handled = true;
         int   slot         = argv[1]->i;
         float strength     = argv[2]->f;
@@ -230,8 +230,8 @@ bool OSCProtocol::handle_osc_message(const char* path, const char* types, lo_arg
                 (duration_int < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration_int);
         });
     }
-    // /inputbridge/haptics/condition  iiiffffffi  (deviceId, slot, condition_type, right_sat, left_sat, right_coeff, left_coeff, deadband, center, duration_ms)
-    else if (path_sv == "/inputbridge/haptics/condition" && std::strcmp(types, "iiiffffffi") == 0 && argc == 10) {
+    // /haptic/condition  iiiffffffi  (deviceId, slot, condition_type, right_sat, left_sat, right_coeff, left_coeff, deadband, center, duration_ms)
+    else if (path_sv == "/haptic/condition" && std::strcmp(types, "iiiffffffi") == 0 && argc == 10) {
         handled = true;
         int   slot           = argv[1]->i;
         int   cond_idx       = argv[2]->i;
@@ -259,8 +259,8 @@ bool OSCProtocol::handle_osc_message(const char* path, const char* types, lo_arg
                 (duration_int < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration_int);
         });
     }
-    // /inputbridge/haptics/gain  ii  (deviceId, gain)
-    else if (path_sv == "/inputbridge/haptics/gain" && std::strcmp(types, "ii") == 0 && argc == 2) {
+    // /haptic/gain  ii  (deviceId, gain)
+    else if (path_sv == "/haptic/gain" && std::strcmp(types, "ii") == 0 && argc == 2) {
         handled = true;
         int gain = ClampGain(argv[1]->i, path_sv);
         DispatchHapticCommand<SteeringWheelHaptics>([&](SteeringWheelHaptics* wheel) {
@@ -269,7 +269,7 @@ bool OSCProtocol::handle_osc_message(const char* path, const char* types, lo_arg
     }
     // DualSense Trigger Effects, one Protocol Editor field per trigger side
     // x effect (see "Adaptive Trigger" category), falling back to this
-    // nested legacy address when no custom OSC Path has been set.
+    // flat /haptic/{name} address when no custom OSC Path has been set.
     //   feedback:  iii     (deviceId, position, strength)
     //   weapon:    iiii    (deviceId, start_position, end_position, strength)
     //   vibration: iiii    (deviceId, position, amplitude, frequency)
@@ -277,20 +277,20 @@ bool OSCProtocol::handle_osc_message(const char* path, const char* types, lo_arg
     //   galloping: iiiiii  (deviceId, start_position, end_position, first_foot, second_foot, frequency)
     //   machine:   iiiiiii (deviceId, start_position, end_position, amplitude_a, amplitude_b, frequency, period)
     //   off:       (no args required)
-    else if (match("/haptics/dualsense/trigger/left/feedback",   "ds_trigger_left_feedback"))   { handled = true; sendFeedback("left"); }
-    else if (match("/haptics/dualsense/trigger/right/feedback",  "ds_trigger_right_feedback"))  { handled = true; sendFeedback("right"); }
-    else if (match("/haptics/dualsense/trigger/left/weapon",     "ds_trigger_left_weapon"))     { handled = true; sendWeapon("left"); }
-    else if (match("/haptics/dualsense/trigger/right/weapon",    "ds_trigger_right_weapon"))    { handled = true; sendWeapon("right"); }
-    else if (match("/haptics/dualsense/trigger/left/vibration",  "ds_trigger_left_vibration"))  { handled = true; sendVibration("left"); }
-    else if (match("/haptics/dualsense/trigger/right/vibration", "ds_trigger_right_vibration")) { handled = true; sendVibration("right"); }
-    else if (match("/haptics/dualsense/trigger/left/bow",        "ds_trigger_left_bow"))        { handled = true; sendBow("left"); }
-    else if (match("/haptics/dualsense/trigger/right/bow",       "ds_trigger_right_bow"))       { handled = true; sendBow("right"); }
-    else if (match("/haptics/dualsense/trigger/left/galloping",  "ds_trigger_left_galloping"))  { handled = true; sendGalloping("left"); }
-    else if (match("/haptics/dualsense/trigger/right/galloping", "ds_trigger_right_galloping")) { handled = true; sendGalloping("right"); }
-    else if (match("/haptics/dualsense/trigger/left/machine",    "ds_trigger_left_machine"))    { handled = true; sendMachine("left"); }
-    else if (match("/haptics/dualsense/trigger/right/machine",   "ds_trigger_right_machine"))   { handled = true; sendMachine("right"); }
-    else if (match("/haptics/dualsense/trigger/left/off",        "ds_trigger_left_off"))        { handled = true; sendOff("left"); }
-    else if (match("/haptics/dualsense/trigger/right/off",       "ds_trigger_right_off"))       { handled = true; sendOff("right"); }
+    else if (match("/haptic/dualsense/trigger/left/feedback",   "ds_trigger_left_feedback"))   { handled = true; sendFeedback("left"); }
+    else if (match("/haptic/dualsense/trigger/right/feedback",  "ds_trigger_right_feedback"))  { handled = true; sendFeedback("right"); }
+    else if (match("/haptic/dualsense/trigger/left/weapon",     "ds_trigger_left_weapon"))     { handled = true; sendWeapon("left"); }
+    else if (match("/haptic/dualsense/trigger/right/weapon",    "ds_trigger_right_weapon"))    { handled = true; sendWeapon("right"); }
+    else if (match("/haptic/dualsense/trigger/left/vibration",  "ds_trigger_left_vibration"))  { handled = true; sendVibration("left"); }
+    else if (match("/haptic/dualsense/trigger/right/vibration", "ds_trigger_right_vibration")) { handled = true; sendVibration("right"); }
+    else if (match("/haptic/dualsense/trigger/left/bow",        "ds_trigger_left_bow"))        { handled = true; sendBow("left"); }
+    else if (match("/haptic/dualsense/trigger/right/bow",       "ds_trigger_right_bow"))       { handled = true; sendBow("right"); }
+    else if (match("/haptic/dualsense/trigger/left/galloping",  "ds_trigger_left_galloping"))  { handled = true; sendGalloping("left"); }
+    else if (match("/haptic/dualsense/trigger/right/galloping", "ds_trigger_right_galloping")) { handled = true; sendGalloping("right"); }
+    else if (match("/haptic/dualsense/trigger/left/machine",    "ds_trigger_left_machine"))    { handled = true; sendMachine("left"); }
+    else if (match("/haptic/dualsense/trigger/right/machine",   "ds_trigger_right_machine"))   { handled = true; sendMachine("right"); }
+    else if (match("/haptic/dualsense/trigger/left/off",        "ds_trigger_left_off"))        { handled = true; sendOff("left"); }
+    else if (match("/haptic/dualsense/trigger/right/off",       "ds_trigger_right_off"))       { handled = true; sendOff("right"); }
     // /inputbridge/wheel/led_rpm  f  (rpm_percent 0.0–1.0)
     else if (path_sv == "/inputbridge/wheel/led_rpm" && std::strcmp(types, "f") == 0 && argc == 1) {
         handled = true;
@@ -302,14 +302,14 @@ bool OSCProtocol::handle_osc_message(const char* path, const char* types, lo_arg
         }
     }
 
-    // ── Subchannel paths: /inputbridge/haptics/<effect>/<slot> ───────────────
+    // ── Subchannel paths: /haptic/<effect>/<slot> ───────────────
     // The slot is encoded as the trailing decimal path component instead of
     // being passed as a message argument.  This lets hosts that can send only
     // one OSC message per frame per path (e.g. Resonite) address multiple
     // independent slots by using distinct paths:
     //
-    //   /inputbridge/haptics/rumble/0   iffi  (id, low_freq, high_freq, dur)
-    //   /inputbridge/haptics/rumble/1   iffi  (id, low_freq, high_freq, dur)
+    //   /haptic/rumble/0   iffi  (id, low_freq, high_freq, dur)
+    //   /haptic/rumble/1   iffi  (id, low_freq, high_freq, dur)
 
     const auto last_slash = path_sv.rfind('/');
     if (last_slash == std::string_view::npos) return handled;
@@ -325,8 +325,8 @@ bool OSCProtocol::handle_osc_message(const char* path, const char* types, lo_arg
 
     if (!ValidateSlot(slot, path_sv)) return handled;
 
-    // /inputbridge/haptics/rumble/N  iffi  (id, low_freq, high_freq, duration_ms)
-    if (base == "/inputbridge/haptics/rumble" && std::strcmp(types, "iffi") == 0 && argc == 4) {
+    // /haptic/rumble/N  iffi  (id, low_freq, high_freq, duration_ms)
+    if (base == "/haptic/rumble" && std::strcmp(types, "iffi") == 0 && argc == 4) {
         handled = true;
         float low      = ClampNorm(argv[1]->f, "low_freq",  path_sv);
         float high     = ClampNorm(argv[2]->f, "high_freq", path_sv);
@@ -335,8 +335,8 @@ bool OSCProtocol::handle_osc_message(const char* path, const char* types, lo_arg
             gamepad->PlayRumble(slot, low, high, (duration < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration);
         });
     }
-    // /inputbridge/haptics/force/N  ifi  (id, strength, duration_ms)
-    else if (base == "/inputbridge/haptics/force" && std::strcmp(types, "ifi") == 0 && argc == 3) {
+    // /haptic/force/N  ifi  (id, strength, duration_ms)
+    else if (base == "/haptic/force" && std::strcmp(types, "ifi") == 0 && argc == 3) {
         handled = true;
         float strength     = ClampStrength(argv[1]->f, "strength", path_sv);
         const int duration = argv[2]->i;
@@ -344,8 +344,8 @@ bool OSCProtocol::handle_osc_message(const char* path, const char* types, lo_arg
             wheel->PlayConstant(slot, strength, (duration < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration);
         });
     }
-    // /inputbridge/haptics/periodic/N  iififfii  (id, wave_type, strength, period, magnitude, offset, phase, duration_ms)
-    else if (base == "/inputbridge/haptics/periodic" && std::strcmp(types, "iififfii") == 0 && argc == 8) {
+    // /haptic/periodic/N  iififfii  (id, wave_type, strength, period, magnitude, offset, phase, duration_ms)
+    else if (base == "/haptic/periodic" && std::strcmp(types, "iififfii") == 0 && argc == 8) {
         handled = true;
         int wave_idx = argv[1]->i;
         if (!ValidateWaveType(wave_idx, path_sv)) return handled;
@@ -361,8 +361,8 @@ bool OSCProtocol::handle_osc_message(const char* path, const char* types, lo_arg
                 (duration < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration);
         });
     }
-    // Legacy: /inputbridge/haptics/periodic/N  ififfii  - no wave_type, defaults to Sine
-    else if (base == "/inputbridge/haptics/periodic" && std::strcmp(types, "ififfii") == 0 && argc == 7) {
+    // Legacy: /haptic/periodic/N  ififfii  - no wave_type, defaults to Sine
+    else if (base == "/haptic/periodic" && std::strcmp(types, "ififfii") == 0 && argc == 7) {
         handled = true;
         float strength      = ClampNorm(argv[1]->f,    "strength",  path_sv);
         const int period    = argv[2]->i;
@@ -375,8 +375,8 @@ bool OSCProtocol::handle_osc_message(const char* path, const char* types, lo_arg
                 (duration < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration);
         });
     }
-    // /inputbridge/haptics/condition/N  iiffffffi  (id, condition_type, rsat, lsat, rcoeff, lcoeff, deadband, center, duration_ms)
-    else if (base == "/inputbridge/haptics/condition" && std::strcmp(types, "iiffffffi") == 0 && argc == 9) {
+    // /haptic/condition/N  iiffffffi  (id, condition_type, rsat, lsat, rcoeff, lcoeff, deadband, center, duration_ms)
+    else if (base == "/haptic/condition" && std::strcmp(types, "iiffffffi") == 0 && argc == 9) {
         handled = true;
         int cond_idx = argv[1]->i;
         if (!ValidateConditionType(cond_idx, path_sv)) return handled;
@@ -393,7 +393,7 @@ bool OSCProtocol::handle_osc_message(const char* path, const char* types, lo_arg
                 (duration < 0) ? SDL_HAPTIC_INFINITY : (uint32_t)duration);
         });
     }
-    // Note: /inputbridge/haptics/gain has no slot dimension - no subchannel variant is defined.
+    // Note: /haptic/gain has no slot dimension - no subchannel variant is defined.
 
     return handled;
 }

--- a/src/Protocols/OSCProtocol.cpp
+++ b/src/Protocols/OSCProtocol.cpp
@@ -169,7 +169,14 @@ bool OSCProtocol::handle_osc_message(const char* path, const char* types, lo_arg
         });
     }
     // DualSense Trigger Effects
-    // /inputbridge/haptics/dualsense/trigger/{left|right}/{feedback|weapon|vibration|off}
+    // /inputbridge/haptics/dualsense/trigger/{left|right}/{feedback|weapon|vibration|bow|galloping|machine|off}
+    //   feedback:  iii     (deviceId, position, strength)
+    //   weapon:    iiii    (deviceId, start_position, end_position, strength)
+    //   vibration: iiii    (deviceId, position, amplitude, frequency)
+    //   bow:       iiiii   (deviceId, start_position, end_position, strength, snap_force)
+    //   galloping: iiiiii  (deviceId, start_position, end_position, first_foot, second_foot, frequency)
+    //   machine:   iiiiiii (deviceId, start_position, end_position, amplitude_a, amplitude_b, frequency, period)
+    //   off:       (no args required)
     else if (path_sv.find("/inputbridge/haptics/dualsense/trigger/") != std::string_view::npos) {
         handled = true;
         DispatchHapticCommand<GamepadHaptics>([&](GamepadHaptics* gamepad) {
@@ -191,6 +198,27 @@ bool OSCProtocol::handle_osc_message(const char* path, const char* types, lo_arg
                 params["position"]  = ClampDSPosition(argv[1]->i,  path_sv);
                 params["amplitude"] = ClampDSAmplitude(argv[2]->i, path_sv);
                 params["frequency"] = ClampDSFrequency(argv[3]->i, path_sv);
+            } else if (path_sv.ends_with("/bow") && std::strcmp(types, "iiiii") == 0 && argc == 5) {
+                effect = "bow";
+                params["start_position"] = ClampDSBowPos(argv[1]->i,     path_sv);
+                params["end_position"]   = ClampDSBowPos(argv[2]->i,     path_sv);
+                params["strength"]       = ClampDSStrength(argv[3]->i,   path_sv);
+                params["snap_force"]     = ClampDSSnapForce(argv[4]->i,  path_sv);
+            } else if (path_sv.ends_with("/galloping") && std::strcmp(types, "iiiiii") == 0 && argc == 6) {
+                effect = "galloping";
+                params["start_position"] = ClampDSGallopingPos(argv[1]->i, path_sv);
+                params["end_position"]   = ClampDSGallopingPos(argv[2]->i, path_sv);
+                params["first_foot"]     = ClampDSFirstFoot(argv[3]->i,   path_sv);
+                params["second_foot"]    = ClampDSSecondFoot(argv[4]->i,  path_sv);
+                params["frequency"]      = ClampDSFrequency(argv[5]->i,   path_sv);
+            } else if (path_sv.ends_with("/machine") && std::strcmp(types, "iiiiiii") == 0 && argc == 7) {
+                effect = "machine";
+                params["start_position"] = ClampDSMachinePos(argv[1]->i,  path_sv);
+                params["end_position"]   = ClampDSMachinePos(argv[2]->i,  path_sv);
+                params["amplitude_a"]    = ClampDSAmplitudeAB(argv[3]->i, path_sv);
+                params["amplitude_b"]    = ClampDSAmplitudeAB(argv[4]->i, path_sv);
+                params["frequency"]      = ClampDSFrequency(argv[5]->i,   path_sv);
+                params["period"]         = ClampDSPeriod(argv[6]->i,      path_sv);
             } else if (path_sv.ends_with("/off")) {
                 effect = "off";
             }

--- a/src/Protocols/OSCValidation.h
+++ b/src/Protocols/OSCValidation.h
@@ -111,7 +111,23 @@ inline int ClampDSPosition(int v, std::string_view p)  { return ClampInt(v,   0,
 inline int ClampDSStrength(int v, std::string_view p)  { return ClampInt(v,   0,   8, "strength",       p); }
 inline int ClampDSAmplitude(int v, std::string_view p) { return ClampInt(v,   0,   8, "amplitude",      p); }
 inline int ClampDSFrequency(int v, std::string_view p) { return ClampInt(v,   0, 255, "frequency",      p); }
+
+// Weapon start/end position matches ApplyTriggerEffect's getParam("start_position",2,2,7) and getParam("end_position",7,0,8).
 inline int ClampDSStartPos(int v, std::string_view p)  { return ClampInt(v,   2,   7, "start_position", p); }
-inline int ClampDSEndPos(int v, std::string_view p)    { return ClampInt(v,   3,   8, "end_position",   p); }
+inline int ClampDSEndPos(int v, std::string_view p)    { return ClampInt(v,   0,   8, "end_position",   p); }
+
+// Bow start/end position and snap force - 0-8, matches ApplyTriggerEffect's "bow" branch.
+inline int ClampDSBowPos(int v, std::string_view p)       { return ClampInt(v, 0, 8, "position",   p); }
+inline int ClampDSSnapForce(int v, std::string_view p)    { return ClampInt(v, 0, 8, "snap_force", p); }
+
+// Galloping start/end position (0-9) and foot indices matches ApplyTriggerEffect's "galloping" branch.
+inline int ClampDSGallopingPos(int v, std::string_view p) { return ClampInt(v, 0, 9, "position",     p); }
+inline int ClampDSFirstFoot(int v, std::string_view p)    { return ClampInt(v, 0, 6, "first_foot",   p); }
+inline int ClampDSSecondFoot(int v, std::string_view p)   { return ClampInt(v, 0, 7, "second_foot",  p); }
+
+// Machine start/end position (0-9), amplitude A/B (0-7), and period (0-2) matches ApplyTriggerEffect's "machine" branch.
+inline int ClampDSMachinePos(int v, std::string_view p)   { return ClampInt(v, 0, 9, "position",     p); }
+inline int ClampDSAmplitudeAB(int v, std::string_view p)  { return ClampInt(v, 0, 7, "amplitude",    p); }
+inline int ClampDSPeriod(int v, std::string_view p)       { return ClampInt(v, 0, 2, "period",       p); }
 
 } // namespace OscValidation

--- a/src/Protocols/ProtocolDefinition.h
+++ b/src/Protocols/ProtocolDefinition.h
@@ -40,8 +40,8 @@ struct ProtocolField {
 // ─── Protocol direction ─────────────────────────────────────────────────────
 
 enum class ProtocolDirection {
-    Output, // server → client  (send input / sensor data)
-    Input   // client → server  (receive haptic / command data)
+    Send,    // server → client  (send input / sensor data)
+    Receive  // client → server  (receive haptic / command data)
 };
 
 // ─── Transport type ─────────────────────────────────────────────────────────
@@ -57,7 +57,7 @@ struct ProtocolDefinition {
     std::string        id;          // unique UUID / slug (generated on creation)
     std::string        name;        // user-facing name, e.g. "Sim Racing OSC Out"
     ProtocolTransport  transport  = ProtocolTransport::OSC;
-    ProtocolDirection  direction  = ProtocolDirection::Output;
+    ProtocolDirection  direction  = ProtocolDirection::Send;
 
     // OSC-specific
     std::string oscHost     = "127.0.0.1";

--- a/src/Protocols/ProtocolEditorWindow.cpp
+++ b/src/Protocols/ProtocolEditorWindow.cpp
@@ -1309,10 +1309,33 @@ void ProtocolEditorWindow::DrawFieldTable(ProtocolDefinition& def,
                         ImGui::AlignTextToFramePadding();
                         ImGui::TextUnformatted("OSC Path:");
                         if (ImGui::GetContentRegionAvail().x > 300.0f) ImGui::SameLine();
-                        ImGui::SetNextItemWidth(-FLT_MIN);
+
+                        // Reserve space for the "Reset" button so the input field
+                        // doesn't overlap it.
+                        const bool isDefaultPath = (pf->oscPath == fd.defaultOscPath);
+                        const float resetBtnWidth = ImGui::CalcTextSize("Reset").x +
+                                                    ImGui::GetStyle().FramePadding.x * 2.0f;
+                        const float inputWidth = ImGui::GetContentRegionAvail().x -
+                                                 resetBtnWidth - ImGui::GetStyle().ItemSpacing.x;
+                        ImGui::SetNextItemWidth(inputWidth > 0.0f ? inputWidth : -FLT_MIN);
                         if (ImGui::InputText("##oscPath", pathBuffer, sizeof(pathBuffer))) {
                             pf->oscPath = pathBuffer;
                             pendingSave = true;
+                        }
+
+                        // Revert this field's OSC path back to its internal safe default
+                        // (e.g. "/haptic/rumble" for the Haptic category), discarding any
+                        // custom override.
+                        ImGui::SameLine();
+                        if (isDefaultPath) ImGui::BeginDisabled();
+                        if (ImGui::SmallButton("Reset##resetOscPath")) {
+                            pf->oscPath = fd.defaultOscPath;
+                            pendingSave = true;
+                        }
+                        if (isDefaultPath) ImGui::EndDisabled();
+                        if (ImGui::IsItemHovered() && !isDefaultPath) {
+                            ImGui::SetTooltip("Revert to the default safe path:\n%s",
+                                               fd.defaultOscPath.c_str());
                         }
                     } else {
                         char keyBuffer[128];

--- a/src/Protocols/ProtocolEditorWindow.cpp
+++ b/src/Protocols/ProtocolEditorWindow.cpp
@@ -833,7 +833,7 @@ void ProtocolEditorWindow::DrawProtocolList() {
         const char* icon = (definition.transport == ProtocolTransport::OSC) ? "[OSC] " : "[WS]  ";
 
         // Direction indicator
-        const char* direction = (definition.direction == ProtocolDirection::Output) ? "↑" : "↓";
+        const char* direction = (definition.direction == ProtocolDirection::Send) ? "↑" : "↓";
 
         std::string label = std::string(icon) + direction + " " + definition.name + "##" + definition.id;
 
@@ -909,7 +909,7 @@ void ProtocolEditorWindow::DrawEditor() {
     ImGui::Text("Transport: %s",
                 definition.transport == ProtocolTransport::OSC ? "OSC" : "WebSocket");
     ImGui::Text("Direction: %s",
-                definition.direction == ProtocolDirection::Output ? "Output" : "Input");
+                definition.direction == ProtocolDirection::Send ? "Send" : "Receive");
 
     // ── Transport-specific settings ──────────────────────────────────────────
     if (definition.transport == ProtocolTransport::OSC) {
@@ -924,7 +924,7 @@ void ProtocolEditorWindow::DrawEditor() {
             needsSave = true;
         }
 
-        if (definition.direction == ProtocolDirection::Output) {
+        if (definition.direction == ProtocolDirection::Send) {
             ImGui::AlignTextToFramePadding();
             ImGui::TextUnformatted("Send Port:");
             if (ImGui::GetContentRegionAvail().x > 300.0f) ImGui::SameLine();
@@ -954,7 +954,7 @@ void ProtocolEditorWindow::DrawEditor() {
     ImGui::Separator();
 
     // ── Field selection ──────────────────────────────────────────────────────
-    if (definition.direction == ProtocolDirection::Output) {
+    if (definition.direction == ProtocolDirection::Send) {
         DrawOutputFieldPicker();
     } else {
         DrawInputFieldPicker();
@@ -1381,7 +1381,7 @@ void ProtocolEditorWindow::DrawNewProtocolModal() {
         const char* transports[] = {"OSC", "WebSocket"};
         ImGui::Combo("Transport", &s_newTransport, transports, 2);
 
-        const char* directions[] = {"Output", "Input"};
+        const char* directions[] = {"Send", "Receive"};
         ImGui::Combo("Direction", &s_newDirection, directions, 2);
 
         // Template selection - templates and presets are the same thing.
@@ -1399,7 +1399,7 @@ void ProtocolEditorWindow::DrawNewProtocolModal() {
             ProtocolTransport transport = (s_newTransport == 0) ?
                 ProtocolTransport::OSC : ProtocolTransport::WebSocket;
             ProtocolDirection direction = (s_newDirection == 0) ?
-                ProtocolDirection::Output : ProtocolDirection::Input;
+                ProtocolDirection::Send : ProtocolDirection::Receive;
 
             std::string newId = ProtocolRegistry::GetInstance().CreateDefinition(
                 s_newName, transport, direction);
@@ -2301,7 +2301,7 @@ void ProtocolEditorWindow::DrawHideCategoryModal() {
             ImGui::Separator();
 
             // Build the full category list for the relevant catalog.
-            bool isOutput = (def.direction == ProtocolDirection::Output);
+            bool isOutput = (def.direction == ProtocolDirection::Send);
             const auto& catalog = isOutput ? registry.GetOutputFields()
                                            : registry.GetInputFields();
             std::vector<std::string> cats;
@@ -2390,7 +2390,7 @@ void ProtocolEditorWindow::DrawSaveTemplateModal() {
                     j["protocol_id"]      = def.id;
                     j["protocol_name"]    = def.name;
                     j["transport"]        = (def.transport == ProtocolTransport::OSC) ? "OSC" : "WebSocket";
-                    j["direction"]        = (def.direction == ProtocolDirection::Output) ? "Output" : "Input";
+                    j["direction"]        = (def.direction == ProtocolDirection::Send) ? "Send" : "Receive";
                     json fieldsArr = json::array();
                     for (const auto& pf : def.fields) {
                         if (!pf.enabled) continue;

--- a/src/Protocols/ProtocolRegistry.cpp
+++ b/src/Protocols/ProtocolRegistry.cpp
@@ -909,10 +909,9 @@ void ProtocolRegistry::LoadBuiltinCatalog() {
     // -- Adaptive Trigger (DualSense) ---------------------------------------
     // One field per trigger side x effect, since each combination is its
     // own OSC address/arg signature rather than a single message shape.
-    // Addresses use the same flat /haptics/{name} convention as
-    // the Haptic fields above (rumble, force, periodic, condition, gain)
-    // rather than nesting left/right and the effect name as separate path
-    // segments:
+    // Addresses use the same flat /haptic/{name} convention as
+    // the Haptic fields above (rumble, force, periodic, condition, gain),
+    // not nested left/right + effect-name path segments:
     //   feedback:  iii     (deviceId, position, strength)
     //   weapon:    iiii    (deviceId, start_position, end_position, strength)
     //   vibration: iiii    (deviceId, position, amplitude, frequency)
@@ -920,20 +919,20 @@ void ProtocolRegistry::LoadBuiltinCatalog() {
     //   galloping: iiiiii  (deviceId, start_position, end_position, first_foot, second_foot, frequency)
     //   machine:   iiiiiii (deviceId, start_position, end_position, amplitude_a, amplitude_b, frequency, period)
     //   off:       (no args)
-    addIn("ds_trigger_left_feedback",   "Left Trigger: Feedback",   "Adaptive Trigger", "/haptics/dualsense/trigger/left/feedback",   "dualsense_trigger_left_feedback");
-    addIn("ds_trigger_right_feedback",  "Right Trigger: Feedback",  "Adaptive Trigger", "/haptics/dualsense/trigger/right/feedback",  "dualsense_trigger_right_feedback");
-    addIn("ds_trigger_left_weapon",     "Left Trigger: Weapon",     "Adaptive Trigger", "/haptics/dualsense/trigger/left/weapon",     "dualsense_trigger_left_weapon");
-    addIn("ds_trigger_right_weapon",    "Right Trigger: Weapon",    "Adaptive Trigger", "/haptics/dualsense/trigger/right/weapon",    "dualsense_trigger_right_weapon");
-    addIn("ds_trigger_left_vibration",  "Left Trigger: Vibration",  "Adaptive Trigger", "/haptics/dualsense/trigger/left/vibration",  "dualsense_trigger_left_vibration");
-    addIn("ds_trigger_right_vibration", "Right Trigger: Vibration", "Adaptive Trigger", "/haptics/dualsense/trigger/right/vibration", "dualsense_trigger_right_vibration");
-    addIn("ds_trigger_left_bow",        "Left Trigger: Bow",        "Adaptive Trigger", "/haptics/dualsense/trigger/left/bow",        "dualsense_trigger_left_bow");
-    addIn("ds_trigger_right_bow",       "Right Trigger: Bow",       "Adaptive Trigger", "/haptics/dualsense/trigger/right/bow",       "dualsense_trigger_right_bow");
-    addIn("ds_trigger_left_galloping",  "Left Trigger: Galloping",  "Adaptive Trigger", "/haptics/dualsense/trigger/left/galloping",  "dualsense_trigger_left_galloping");
-    addIn("ds_trigger_right_galloping", "Right Trigger: Galloping", "Adaptive Trigger", "/haptics/dualsense/trigger/right/galloping", "dualsense_trigger_right_galloping");
-    addIn("ds_trigger_left_machine",    "Left Trigger: Machine",    "Adaptive Trigger", "/haptics/dualsense/trigger/left/machine",    "dualsense_trigger_left_machine");
-    addIn("ds_trigger_right_machine",   "Right Trigger: Machine",   "Adaptive Trigger", "/haptics/dualsense/trigger/right/machine",   "dualsense_trigger_right_machine");
-    addIn("ds_trigger_left_off",        "Left Trigger: Off",        "Adaptive Trigger", "/haptics/dualsense/trigger/left/off",        "dualsense_trigger_left_off");
-    addIn("ds_trigger_right_off",       "Right Trigger: Off",       "Adaptive Trigger", "/haptics/dualsense/trigger/right/off",       "dualsense_trigger_right_off");
+    addIn("ds_trigger_left_feedback",   "Left Trigger: Feedback",   "Adaptive Trigger", "/haptic/dualsense/trigger/left/feedback",   "dualsense_trigger_left_feedback");
+    addIn("ds_trigger_right_feedback",  "Right Trigger: Feedback",  "Adaptive Trigger", "/haptic/dualsense/trigger/right/feedback",  "dualsense_trigger_right_feedback");
+    addIn("ds_trigger_left_weapon",     "Left Trigger: Weapon",     "Adaptive Trigger", "/haptic/dualsense/trigger/left/weapon",     "dualsense_trigger_left_weapon");
+    addIn("ds_trigger_right_weapon",    "Right Trigger: Weapon",    "Adaptive Trigger", "/haptic/dualsense/trigger/right/weapon",    "dualsense_trigger_right_weapon");
+    addIn("ds_trigger_left_vibration",  "Left Trigger: Vibration",  "Adaptive Trigger", "/haptic/dualsense/trigger/left/vibration",  "dualsense_trigger_left_vibration");
+    addIn("ds_trigger_right_vibration", "Right Trigger: Vibration", "Adaptive Trigger", "/haptic/dualsense/trigger/right/vibration", "dualsense_trigger_right_vibration");
+    addIn("ds_trigger_left_bow",        "Left Trigger: Bow",        "Adaptive Trigger", "/haptic/dualsense/trigger/left/bow",        "dualsense_trigger_left_bow");
+    addIn("ds_trigger_right_bow",       "Right Trigger: Bow",       "Adaptive Trigger", "/haptic/dualsense/trigger/right/bow",       "dualsense_trigger_right_bow");
+    addIn("ds_trigger_left_galloping",  "Left Trigger: Galloping",  "Adaptive Trigger", "/haptic/dualsense/trigger/left/galloping",  "dualsense_trigger_left_galloping");
+    addIn("ds_trigger_right_galloping", "Right Trigger: Galloping", "Adaptive Trigger", "/haptic/dualsense/trigger/right/galloping", "dualsense_trigger_right_galloping");
+    addIn("ds_trigger_left_machine",    "Left Trigger: Machine",    "Adaptive Trigger", "/haptic/dualsense/trigger/left/machine",    "dualsense_trigger_left_machine");
+    addIn("ds_trigger_right_machine",   "Right Trigger: Machine",   "Adaptive Trigger", "/haptic/dualsense/trigger/right/machine",   "dualsense_trigger_right_machine");
+    addIn("ds_trigger_left_off",        "Left Trigger: Off",        "Adaptive Trigger", "/haptic/dualsense/trigger/left/off",        "dualsense_trigger_left_off");
+    addIn("ds_trigger_right_off",       "Right Trigger: Off",       "Adaptive Trigger", "/haptic/dualsense/trigger/right/off",       "dualsense_trigger_right_off");
 
     // -- Rumble (simple gamepad) -------------------------------------------
     addIn("rumble_left",  "Rumble Left Motor",  "Rumble", "/rumble/left",  "rumble_left");

--- a/src/Protocols/ProtocolRegistry.cpp
+++ b/src/Protocols/ProtocolRegistry.cpp
@@ -13,6 +13,13 @@
 
 static constexpr const char* kTag = "ProtocolRegistry";
 
+// Bump this whenever WriteDefaultBuiltinCatalog()'s field list changes (fields
+// added/removed/renamed). LoadBuiltinCatalog() compares it against the
+// "_version" stored in the cached builtin_fields.json and regenerates the
+// file automatically on a mismatch, so users don't have to know to delete a
+// stale cache by hand after an update.
+static constexpr int kBuiltinCatalogVersion = 1;
+
 namespace fs = std::filesystem;
 using json = nlohmann::json;
 
@@ -809,7 +816,32 @@ void ProtocolRegistry::LoadBuiltinCatalog() {
     std::string path = GetProtocolsDir() + "builtin_fields.json";
     std::ifstream ifs(path);
     if (!ifs.is_open()) {
+        LOG_INFO(kTag, "builtin_fields.json not found - writing defaults (schema v%d)", kBuiltinCatalogVersion);
         WriteDefaultBuiltinCatalog();
+        ifs.open(path);
+        if (!ifs.is_open()) return;
+    } else {
+        // Peek at "_version" before doing the real parse below. A missing or
+        // mismatched version means this cache predates (or postdates) the
+        // built-in field list currently compiled into the program - most
+        // commonly seen after an update that added/removed/renamed fields.
+        // Regenerate rather than silently running with a stale/foreign list.
+        int cachedVersion = -1;
+        try {
+            json probe = json::parse(ifs);
+            cachedVersion = probe.value("_version", -1);
+        } catch (const std::exception&) {
+            // Unparseable - treat the same as a version mismatch below.
+        }
+
+        if (cachedVersion != kBuiltinCatalogVersion) {
+            LOG_WARN(kTag,
+                "builtin_fields.json schema mismatch (cached v%d, program expects v%d) - "
+                "regenerating from current defaults", cachedVersion, kBuiltinCatalogVersion);
+            WriteDefaultBuiltinCatalog();
+        }
+
+        ifs.close();
         ifs.open(path);
         if (!ifs.is_open()) return;
     }
@@ -851,7 +883,9 @@ void ProtocolRegistry::LoadBuiltinCatalog() {
 
 void ProtocolRegistry::WriteDefaultBuiltinCatalog() {
     json j;
-    j["_comment"] = "Default built-in fields. Delete this file to regenerate defaults.";
+    j["_comment"] = "Default built-in fields. Auto-regenerated whenever InputBridge's "
+                    "built-in field list changes; also regenerated if this file is deleted.";
+    j["_version"] = kBuiltinCatalogVersion;
 
     json outArr = json::array();
     auto addOut = [&](const char* id, const char* label, const char* cat, FieldType type, const char* oscPath, const char* wsKey) {

--- a/src/Protocols/ProtocolRegistry.cpp
+++ b/src/Protocols/ProtocolRegistry.cpp
@@ -16,7 +16,7 @@ static constexpr const char* kTag = "ProtocolRegistry";
 namespace fs = std::filesystem;
 using json = nlohmann::json;
 
-// ─── Singleton ───────────────────────────────────────────────────────────────
+// --- Singleton ---------------------------------------------------------------
 
 ProtocolRegistry& ProtocolRegistry::GetInstance() {
     static ProtocolRegistry instance;
@@ -28,7 +28,7 @@ ProtocolRegistry::ProtocolRegistry() {
     LoadBuiltinCatalog();
 }
 
-// ─── Public API ──────────────────────────────────────────────────────────────
+// --- Public API --------------------------------------------------------------
 
 void ProtocolRegistry::LoadAll() {
     EnsureDirectories();
@@ -421,7 +421,7 @@ void ProtocolRegistry::SaveDefinition(const ProtocolDefinition& def) {
     }
 }
 
-// ─── Paths ───────────────────────────────────────────────────────────────────
+// --- Paths -------------------------------------------------------------------
 
 std::string ProtocolRegistry::GetProtocolsDir() {
     // Protocol definitions, field catalogs, and templates are user data -
@@ -452,7 +452,7 @@ const char* ProtocolRegistry::DirectionLabel(ProtocolDirection d) {
     return d == ProtocolDirection::Output ? "Output (server → client)" : "Input (client → server)";
 }
 
-// ─── Private helpers ─────────────────────────────────────────────────────────
+// --- Private helpers ---------------------------------------------------------
 
 // Copies seed files from the read-only install directory into the writable
 // pref directory, but only when a file is absent (never overwrites).
@@ -800,7 +800,7 @@ void ProtocolRegistry::WriteDefaultFieldCatalog() {
     if (ofs) ofs << j.dump(4);
 }
 
-// ─── Built-in field catalogs ─────────────────────────────────────────────────
+// --- Built-in field catalogs -------------------------------------------------
 
 void ProtocolRegistry::LoadBuiltinCatalog() {
     m_outputFields.clear();
@@ -865,7 +865,7 @@ void ProtocolRegistry::WriteDefaultBuiltinCatalog() {
         outArr.push_back(item);
     };
 
-    // ── Analog axes ──────────────────────────────────────────────────────────
+    // -- Analog axes ----------------------------------------------------------
     addOut("axis_steering",   "Steering / Yaw",  "Analog Axes", FieldType::AnalogAxis, "/input/yaw",        "yaw");
     addOut("axis_throttle",   "Throttle",        "Analog Axes", FieldType::AnalogAxis, "/input/throttle",   "throttle");
     addOut("axis_clutch",     "Clutch",          "Analog Axes", FieldType::AnalogAxis, "/input/clutch",     "clutch");
@@ -875,7 +875,7 @@ void ProtocolRegistry::WriteDefaultBuiltinCatalog() {
     addOut("axis_roll",       "Roll",            "Analog Axes", FieldType::AnalogAxis, "/input/roll",       "roll");
     addOut("axis_collective", "Collective",      "Analog Axes", FieldType::AnalogAxis, "/input/collective", "collective");
 
-    // ── Digital: Vehicle ─────────────────────────────────────────────────────
+    // -- Digital: Vehicle -----------------------------------------------------
     addOut("btn_gear_up",     "Gear Up",         "Digital: Vehicle", FieldType::DigitalButton, "/input/gear_up",   "gear_up");
     addOut("btn_gear_down",   "Gear Down",       "Digital: Vehicle", FieldType::DigitalButton, "/input/gear_down", "gear_down");
     addOut("btn_neutral",     "Neutral",         "Digital: Vehicle", FieldType::DigitalButton, "/input/neutral",   "neutral");
@@ -894,7 +894,7 @@ void ProtocolRegistry::WriteDefaultBuiltinCatalog() {
     addOut("btn_difflock_f",  "Diff-lock Front", "Digital: Vehicle", FieldType::DigitalButton, "/input/difflock_front", "difflock_front");
     addOut("btn_difflock_b",  "Diff-lock Rear",  "Digital: Vehicle", FieldType::DigitalButton, "/input/difflock_rear",  "difflock_rear");
 
-    // ── Digital: Lights ──────────────────────────────────────────────────────
+    // -- Digital: Lights ------------------------------------------------------
     addOut("btn_lights",      "Lights",          "Digital: Lights", FieldType::DigitalButton, "/input/lights",      "lights");
     addOut("btn_beam",        "Low/High Beam",   "Digital: Lights", FieldType::DigitalButton, "/input/beam",        "beam");
     addOut("btn_parking",     "Parking Light",   "Digital: Lights", FieldType::DigitalButton, "/input/parking",     "parking");
@@ -903,7 +903,7 @@ void ProtocolRegistry::WriteDefaultBuiltinCatalog() {
     addOut("btn_turn_right",  "Turn Right",      "Digital: Lights", FieldType::DigitalButton, "/input/turn_right",  "turn_right");
     addOut("btn_hazard",      "Hazard",          "Digital: Lights", FieldType::DigitalButton, "/input/hazard",      "hazard");
 
-    // ── Digital: Other ───────────────────────────────────────────────────────
+    // -- Digital: Other -------------------------------------------------------
     addOut("btn_engine",      "Engine",          "Digital: Other",  FieldType::DigitalButton, "/input/engine",      "engine");
     addOut("btn_horn",        "Horn",            "Digital: Other",  FieldType::DigitalButton, "/input/horn",        "horn");
     addOut("btn_cam_switch",  "Camera Switch",   "Digital: Other",  FieldType::DigitalButton, "/input/cam_switch",  "cam_switch");
@@ -914,18 +914,18 @@ void ProtocolRegistry::WriteDefaultBuiltinCatalog() {
     addOut("btn_weapon_sec",  "Weapon Secondary","Digital: Other",  FieldType::DigitalButton, "/input/weapon_sec",  "weapon_sec");
     addOut("btn_reload",      "Reload",          "Digital: Other",  FieldType::DigitalButton, "/input/reload",      "reload");
     
-    // ── Sensors: Gyroscope ───────────────────────────────────────────────────
+    // -- Sensors: Gyroscope ---------------------------------------------------
     // Available on DualSense and Steam Controller.  Values normalised to [-1, 1].
     addOut("sensor_gyro_x",   "Gyro X (pitch)",    "Sensors: Gyroscope",      FieldType::AnalogAxis,   "/sensor/gyro/x",         "gyro_x");
     addOut("sensor_gyro_y",   "Gyro Y (yaw)",      "Sensors: Gyroscope",      FieldType::AnalogAxis,   "/sensor/gyro/y",         "gyro_y");
     addOut("sensor_gyro_z",   "Gyro Z (roll)",     "Sensors: Gyroscope",      FieldType::AnalogAxis,   "/sensor/gyro/z",         "gyro_z");
 
-    // ── Sensors: Accelerometer ───────────────────────────────────────────────
+    // -- Sensors: Accelerometer -----------------------------------------------
     addOut("sensor_accel_x",  "Accel X (lateral)",  "Sensors: Accelerometer", FieldType::AnalogAxis,  "/sensor/accel/x",        "accel_x");
     addOut("sensor_accel_y",  "Accel Y (vertical)", "Sensors: Accelerometer", FieldType::AnalogAxis,  "/sensor/accel/y",        "accel_y");
     addOut("sensor_accel_z",  "Accel Z (fore/aft)", "Sensors: Accelerometer", FieldType::AnalogAxis,  "/sensor/accel/z",        "accel_z");
 
-    // ── Sensors: Touchpad ────────────────────────────────────────────────────
+    // -- Sensors: Touchpad ----------------------------------------------------
     // x/y centred: left/top=-1, right/bottom=+1.  Pressure: [0, 1].
     addOut("sensor_touch_x",     "Touch X (centered)",  "Sensors: Touchpad", FieldType::AnalogAxis,    "/sensor/touch/x",        "touch_x");
     addOut("sensor_touch_y",     "Touch Y (centered)",  "Sensors: Touchpad", FieldType::AnalogAxis,    "/sensor/touch/y",        "touch_y");
@@ -950,14 +950,17 @@ void ProtocolRegistry::WriteDefaultBuiltinCatalog() {
         inArr.push_back(item);
     };
 
-    // ── Haptic feedback fields (received from client) ─────────────────────
+    // -- Haptic feedback fields (received from client) ---------------------
     addIn("haptic_rumble",      "Rumble",                  "Haptic", "/haptic/rumble",      "rumble");
     addIn("haptic_constant",    "Constant Force",          "Haptic", "/haptic/constant",    "constant");
     addIn("haptic_periodic",    "Periodic Effect",         "Haptic", "/haptic/periodic",    "periodic");
     addIn("haptic_condition",   "Condition Effect",        "Haptic", "/haptic/condition",   "condition");
     addIn("haptic_gain",        "Global Gain",             "Haptic", "/haptic/gain",        "gain");
+    
+    // -- Adaptive trigger fields (received from client) ---------------------
+    addIn("haptic_dualsense_trigger", "DualSense Adaptive Trigger", "Haptic", "/haptic/dualsense_trigger", "dualsense_trigger");
 
-    // ── Rumble (simple gamepad) ───────────────────────────────────────────
+    // -- Rumble (simple gamepad) -------------------------------------------
     addIn("rumble_left",  "Rumble Left Motor",  "Rumble", "/rumble/left",  "rumble_left");
     addIn("rumble_right", "Rumble Right Motor", "Rumble", "/rumble/right", "rumble_right");
 
@@ -968,7 +971,7 @@ void ProtocolRegistry::WriteDefaultBuiltinCatalog() {
     if (ofs) ofs << j.dump(4);
 }
 
-// ─── ID generation ───────────────────────────────────────────────────────────
+// --- ID generation -----------------------------------------------------------
 
 std::string ProtocolRegistry::GenerateId() {
     // Short hex ID based on time + random bits

--- a/src/Protocols/ProtocolRegistry.cpp
+++ b/src/Protocols/ProtocolRegistry.cpp
@@ -197,7 +197,7 @@ bool ProtocolRegistry::ExportDefinition(const std::string& id, const std::string
     j["id"]        = def->id;
     j["name"]      = def->name;
     j["transport"] = (def->transport == ProtocolTransport::OSC) ? "osc" : "websocket";
-    j["direction"] = (def->direction == ProtocolDirection::Output) ? "output" : "input";
+    j["direction"] = (def->direction == ProtocolDirection::Send) ? "send" : "receive";
     j["active"]    = false; // Don't activate exported protocols by default
 
     j["osc"]["host"]     = def->oscHost;
@@ -257,10 +257,14 @@ std::string ProtocolRegistry::ImportDefinition(const std::string& path) {
         std::string ts = j.value("transport", "osc");
         def.transport = (ts == "websocket") ? ProtocolTransport::WebSocket : ProtocolTransport::OSC;
 
-        std::string dir_s = j.value("direction", "output");
-        def.direction = (dir_s == "input") ? ProtocolDirection::Input : ProtocolDirection::Output;
-
         def.active = false;
+
+        // Accept both the current "send"/"receive" terms and the legacy
+        // "output"/"input" terms so protocol files exported by older builds
+        // still import correctly.
+        std::string dir_s = j.value("direction", "send");
+        def.direction = (dir_s == "receive" || dir_s == "input")
+                            ? ProtocolDirection::Receive : ProtocolDirection::Send;
 
         if (j.contains("osc")) {
             def.oscHost     = j["osc"].value("host",     "127.0.0.1");
@@ -297,7 +301,7 @@ std::string ProtocolRegistry::ImportDefinition(const std::string& path) {
                 // Auto-register the field in the catalog when it is unknown so
                 // that the editor can display and manipulate it without requiring
                 // a matching entry in input_fields.json.
-                auto& catalog = (def.direction == ProtocolDirection::Output)
+                auto& catalog = (def.direction == ProtocolDirection::Send)
                                  ? m_outputFields : m_inputFields;
 
                 // Check both catalogs: a field may legitimately live in the
@@ -369,7 +373,7 @@ void ProtocolRegistry::SaveDefinition(const ProtocolDefinition& def) {
     j["id"]        = def.id;
     j["name"]      = def.name;
     j["transport"] = (def.transport == ProtocolTransport::OSC) ? "osc" : "websocket";
-    j["direction"] = (def.direction == ProtocolDirection::Output) ? "output" : "input";
+    j["direction"] = (def.direction == ProtocolDirection::Send) ? "send" : "receive";
     j["active"]    = def.active;
 
     j["osc"]["host"]     = def.oscHost;
@@ -449,7 +453,7 @@ const char* ProtocolRegistry::TransportLabel(ProtocolTransport t) {
 }
 
 const char* ProtocolRegistry::DirectionLabel(ProtocolDirection d) {
-    return d == ProtocolDirection::Output ? "Output (server → client)" : "Input (client → server)";
+    return d == ProtocolDirection::Send ? "Send (server → client)" : "Receive (client → server)";
 }
 
 // --- Private helpers ---------------------------------------------------------
@@ -654,8 +658,12 @@ void ProtocolRegistry::LoadDefinitionFiles() {
             std::string ts = j.value("transport", "osc");
             def.transport = (ts == "websocket") ? ProtocolTransport::WebSocket : ProtocolTransport::OSC;
 
-            std::string dir_s = j.value("direction", "output");
-            def.direction = (dir_s == "input") ? ProtocolDirection::Input : ProtocolDirection::Output;
+            // Accept both "send"/"receive" (current) and "output"/"input"
+            // (legacy) so definition files saved by older builds still load
+            // with the correct direction.
+            std::string dir_s = j.value("direction", "send");
+            def.direction = (dir_s == "receive" || dir_s == "input")
+                                ? ProtocolDirection::Receive : ProtocolDirection::Send;
 
             def.active = j.value("active", false);
 
@@ -689,7 +697,7 @@ void ProtocolRegistry::LoadDefinitionFiles() {
                     def.fields.push_back(f);
 
                     // Auto-register unknown fields so the editor shows them.
-                    auto& catalog = (def.direction == ProtocolDirection::Output)
+                    auto& catalog = (def.direction == ProtocolDirection::Send)
                                      ? m_outputFields : m_inputFields;
                     // Check both catalogs before synthesising an entry; the
                     // field may already be registered on the opposite side.

--- a/src/Protocols/ProtocolRegistry.cpp
+++ b/src/Protocols/ProtocolRegistry.cpp
@@ -9,7 +9,6 @@
 #include <chrono>
 #include <iomanip>
 #include <random>
-#include <algorithm>
 #include <SDL3/SDL_filesystem.h>
 
 static constexpr const char* kTag = "ProtocolRegistry";
@@ -668,7 +667,6 @@ void ProtocolRegistry::LoadDefinitionFiles() {
             if (j.contains("ws")) {
                 def.wssPort = j["ws"].value("port", 4269);
             }
-            bool defFieldMigrated = false;
             if (j.contains("fields") && j["fields"].is_array()) {
                 for (const auto& fj : j["fields"]) {
                     ProtocolField f;
@@ -678,18 +676,6 @@ void ProtocolRegistry::LoadDefinitionFiles() {
                     f.enabled = fj.value("enabled",  true);
                     if (f.fieldId.empty())
                         continue;
-
-                    // One-time migration: this field's catalog default OSC
-                    // path used to be "/haptic/dualsense_trigger" (mismatched
-                    // against the actual hardcoded runtime default), so any
-                    // protocol that enabled it before the catalog fix copied
-                    // that wrong path into its own field entry. Repoint it to
-                    // the canonical address so it keeps receiving messages.
-                    if (f.fieldId == "haptic_dualsense_trigger" &&
-                        f.oscPath == "/haptic/dualsense_trigger") {
-                        f.oscPath = "/inputbridge/haptics/dualsense/trigger";
-                        defFieldMigrated = true;
-                    }
 
                     bool hasInline = fj.contains("label") || fj.contains("category") || fj.contains("type");
                     if (hasInline) {
@@ -773,9 +759,6 @@ void ProtocolRegistry::LoadDefinitionFiles() {
                     if (v.is_string()) def.excludedCategories.push_back(v.get<std::string>());
 
             m_definitions.push_back(def);
-            if (defFieldMigrated) {
-                SaveDefinition(m_definitions.back());
-            }
         } catch (const std::exception& e) {
             LOG_ERROR(kTag, "Failed to parse %s: %s",
                       entry.path().string().c_str(), e.what());
@@ -864,80 +847,22 @@ void ProtocolRegistry::LoadBuiltinCatalog() {
     } catch (const std::exception& e) {
     LOG_ERROR(kTag, "Failed to parse builtin_fields.json: %s", e.what());
     }
-
-    // Reconcile against the canonical in-code catalog: builtin_fields.json is
-    // seeded once and then never overwritten (existing installs keep whatever
-    // was on disk from whenever they first ran), so a built-in field added to
-    // BuildDefaultCatalog() later would otherwise never reach anyone who
-    // already has a builtin_fields.json. Add any built-in id that's missing
-    // from what we just loaded, and persist the merge so it's stable.
-    std::vector<FieldDescriptor> defaultOut, defaultIn;
-    BuildDefaultCatalog(defaultOut, defaultIn);
-
-    auto mergeMissing = [](std::vector<FieldDescriptor>& loaded,
-                           const std::vector<FieldDescriptor>& canonical) {
-        bool added = false;
-        for (const auto& fd : canonical) {
-            bool found = std::any_of(loaded.begin(), loaded.end(),
-                [&](const FieldDescriptor& l) { return l.id == fd.id; });
-            if (!found) {
-                loaded.push_back(fd);
-                added = true;
-            }
-        }
-        return added;
-    };
-
-    bool outAdded = mergeMissing(m_outputFields, defaultOut);
-    bool inAdded  = mergeMissing(m_inputFields,  defaultIn);
-
-    // Targeted one-time fix-up: earlier builds shipped haptic_dualsense_trigger
-    // under category "Haptic" with default OSC path "/haptic/dualsense_trigger",
-    // which mismatched the actual hardcoded runtime default and lumped it in
-    // with the unrelated generic SDL haptic effects. Installs that already
-    // have builtin_fields.json on disk from that period keep those wrong
-    // values forever (mergeMissing only adds ids that are absent, it doesn't
-    // correct ones that already exist) - so explicitly repoint this one
-    // known-bad entry back to the canonical values. This only fires when the
-    // on-disk values still exactly match the old mistake, so it won't touch
-    // a category the user has since renamed/merged on purpose.
-    bool inFixedUp = false;
-    for (auto& fd : m_inputFields) {
-        if (fd.id == "haptic_dualsense_trigger" &&
-            fd.category == "Haptic" &&
-            fd.defaultOscPath == "/haptic/dualsense_trigger") {
-            auto it = std::find_if(defaultIn.begin(), defaultIn.end(),
-                [](const FieldDescriptor& d) { return d.id == "haptic_dualsense_trigger"; });
-            if (it != defaultIn.end()) {
-                fd.category       = it->category;
-                fd.defaultOscPath = it->defaultOscPath;
-                fd.defaultWsKey   = it->defaultWsKey;
-                inFixedUp = true;
-            }
-            break;
-        }
-    }
-
-    if (outAdded || inAdded || inFixedUp) {
-        WriteBuiltinCatalogToDisk();
-    }
 }
 
-void ProtocolRegistry::BuildDefaultCatalog(std::vector<FieldDescriptor>& outFields,
-                                           std::vector<FieldDescriptor>& inFields) {
-    outFields.clear();
-    inFields.clear();
+void ProtocolRegistry::WriteDefaultBuiltinCatalog() {
+    json j;
+    j["_comment"] = "Default built-in fields. Delete this file to regenerate defaults.";
 
+    json outArr = json::array();
     auto addOut = [&](const char* id, const char* label, const char* cat, FieldType type, const char* oscPath, const char* wsKey) {
-        FieldDescriptor fd;
-        fd.id             = id;
-        fd.label          = label;
-        fd.category       = cat;
-        fd.type           = type;
-        fd.defaultOscPath = oscPath;
-        fd.defaultWsKey   = wsKey;
-        fd.isBuiltIn      = true;
-        outFields.push_back(fd);
+        json item;
+        item["id"] = id;
+        item["label"] = label;
+        item["category"] = cat;
+        item["type"] = (type == FieldType::DigitalButton) ? "digital" : "analog";
+        item["oscPath"] = oscPath;
+        item["wsKey"] = wsKey;
+        outArr.push_back(item);
     };
 
     // -- Analog axes ----------------------------------------------------------
@@ -1010,16 +935,19 @@ void ProtocolRegistry::BuildDefaultCatalog(std::vector<FieldDescriptor>& outFiel
     addOut("sensor_touch2_p",    "Touch 2 Pressure",    "Sensors: Touchpad", FieldType::AnalogAxis,    "/sensor/touch2/pressure","touch2_pressure");
     addOut("sensor_touch_active","Touch Active",         "Sensors: Touchpad", FieldType::DigitalButton, "/sensor/touch/active",   "touch_active");
 
+
+    j["output_fields"] = outArr;
+
+    json inArr = json::array();
     auto addIn = [&](const char* id, const char* label, const char* cat, const char* oscPath, const char* wsKey) {
-        FieldDescriptor fd;
-        fd.id             = id;
-        fd.label          = label;
-        fd.category       = cat;
-        fd.type           = FieldType::AnalogAxis;
-        fd.defaultOscPath = oscPath;
-        fd.defaultWsKey   = wsKey;
-        fd.isBuiltIn      = true;
-        inFields.push_back(fd);
+        json item;
+        item["id"] = id;
+        item["label"] = label;
+        item["category"] = cat;
+        item["type"] = "analog";
+        item["oscPath"] = oscPath;
+        item["wsKey"] = wsKey;
+        inArr.push_back(item);
     };
 
     // -- Haptic feedback fields (received from client) ---------------------
@@ -1028,52 +956,54 @@ void ProtocolRegistry::BuildDefaultCatalog(std::vector<FieldDescriptor>& outFiel
     addIn("haptic_periodic",    "Periodic Effect",         "Haptic", "/haptic/periodic",    "periodic");
     addIn("haptic_condition",   "Condition Effect",        "Haptic", "/haptic/condition",   "condition");
     addIn("haptic_gain",        "Global Gain",             "Haptic", "/haptic/gain",        "gain");
-
-    // -- Adaptive Trigger (received from client) -----------------------------
-    // Own category (not lumped under "Haptic") since it's a materially
-    // different kind of effect (DualSense-only, positional/zone-based)
-    // from the four generic SDL haptic effects above. Default OSC path
-    // matches the hardcoded fallback base in OSCBaseProtocol.cpp/
-    // OSCProtocol.cpp so the suggested default and the actual runtime
-    // default are the same address.
-    addIn("haptic_dualsense_trigger", "DualSense Adaptive Trigger", "Adaptive Trigger",
-          "/inputbridge/haptics/dualsense/trigger", "dualsense_trigger");
+    // -- Adaptive Trigger (DualSense) ---------------------------------------
+    // One field per trigger side x effect, since each combination is its
+    // own OSC address/arg signature rather than a single message shape:
+    //   feedback:  iii     (deviceId, position, strength)
+    //   weapon:    iiii    (deviceId, start_position, end_position, strength)
+    //   vibration: iiii    (deviceId, position, amplitude, frequency)
+    //   bow:       iiiii   (deviceId, start_position, end_position, strength, snap_force)
+    //   galloping: iiiiii  (deviceId, start_position, end_position, first_foot, second_foot, frequency)
+    //   machine:   iiiiiii (deviceId, start_position, end_position, amplitude_a, amplitude_b, frequency, period)
+    //   off:       (no args)
+    addIn("ds_trigger_left_feedback",   "Left Trigger: Feedback",   "Adaptive Trigger",
+          "/inputbridge/haptics/dualsense/trigger/left/feedback",   "dualsense_trigger_left_feedback");
+    addIn("ds_trigger_right_feedback",  "Right Trigger: Feedback",  "Adaptive Trigger",
+          "/inputbridge/haptics/dualsense/trigger/right/feedback",  "dualsense_trigger_right_feedback");
+    addIn("ds_trigger_left_weapon",     "Left Trigger: Weapon",     "Adaptive Trigger",
+          "/inputbridge/haptics/dualsense/trigger/left/weapon",     "dualsense_trigger_left_weapon");
+    addIn("ds_trigger_right_weapon",    "Right Trigger: Weapon",    "Adaptive Trigger",
+          "/inputbridge/haptics/dualsense/trigger/right/weapon",    "dualsense_trigger_right_weapon");
+    addIn("ds_trigger_left_vibration",  "Left Trigger: Vibration",  "Adaptive Trigger",
+          "/inputbridge/haptics/dualsense/trigger/left/vibration",  "dualsense_trigger_left_vibration");
+    addIn("ds_trigger_right_vibration", "Right Trigger: Vibration", "Adaptive Trigger",
+          "/inputbridge/haptics/dualsense/trigger/right/vibration", "dualsense_trigger_right_vibration");
+    addIn("ds_trigger_left_bow",        "Left Trigger: Bow",        "Adaptive Trigger",
+          "/inputbridge/haptics/dualsense/trigger/left/bow",        "dualsense_trigger_left_bow");
+    addIn("ds_trigger_right_bow",       "Right Trigger: Bow",       "Adaptive Trigger",
+          "/inputbridge/haptics/dualsense/trigger/right/bow",       "dualsense_trigger_right_bow");
+    addIn("ds_trigger_left_galloping",  "Left Trigger: Galloping",  "Adaptive Trigger",
+          "/inputbridge/haptics/dualsense/trigger/left/galloping",  "dualsense_trigger_left_galloping");
+    addIn("ds_trigger_right_galloping", "Right Trigger: Galloping", "Adaptive Trigger",
+          "/inputbridge/haptics/dualsense/trigger/right/galloping", "dualsense_trigger_right_galloping");
+    addIn("ds_trigger_left_machine",    "Left Trigger: Machine",    "Adaptive Trigger",
+          "/inputbridge/haptics/dualsense/trigger/left/machine",    "dualsense_trigger_left_machine");
+    addIn("ds_trigger_right_machine",   "Right Trigger: Machine",   "Adaptive Trigger",
+          "/inputbridge/haptics/dualsense/trigger/right/machine",   "dualsense_trigger_right_machine");
+    addIn("ds_trigger_left_off",        "Left Trigger: Off",        "Adaptive Trigger",
+          "/inputbridge/haptics/dualsense/trigger/left/off",        "dualsense_trigger_left_off");
+    addIn("ds_trigger_right_off",       "Right Trigger: Off",       "Adaptive Trigger",
+          "/inputbridge/haptics/dualsense/trigger/right/off",       "dualsense_trigger_right_off");
 
     // -- Rumble (simple gamepad) -------------------------------------------
     addIn("rumble_left",  "Rumble Left Motor",  "Rumble", "/rumble/left",  "rumble_left");
     addIn("rumble_right", "Rumble Right Motor", "Rumble", "/rumble/right", "rumble_right");
-}
 
-void ProtocolRegistry::WriteBuiltinCatalogToDisk() {
-    json j;
-    j["_comment"] = "Default built-in fields. Delete this file to regenerate defaults.";
-
-    auto toJson = [](const std::vector<FieldDescriptor>& fields) {
-        json arr = json::array();
-        for (const auto& fd : fields) {
-            json item;
-            item["id"] = fd.id;
-            item["label"] = fd.label;
-            item["category"] = fd.category;
-            item["type"] = (fd.type == FieldType::DigitalButton) ? "digital" : "analog";
-            item["oscPath"] = fd.defaultOscPath;
-            item["wsKey"] = fd.defaultWsKey;
-            arr.push_back(item);
-        }
-        return arr;
-    };
-
-    j["output_fields"] = toJson(m_outputFields);
-    j["input_fields"]  = toJson(m_inputFields);
+    j["input_fields"] = inArr;
 
     std::string path = GetProtocolsDir() + "builtin_fields.json";
     std::ofstream ofs(path);
     if (ofs) ofs << j.dump(4);
-}
-
-void ProtocolRegistry::WriteDefaultBuiltinCatalog() {
-    BuildDefaultCatalog(m_outputFields, m_inputFields);
-    WriteBuiltinCatalogToDisk();
 }
 
 // --- ID generation -----------------------------------------------------------

--- a/src/Protocols/ProtocolRegistry.cpp
+++ b/src/Protocols/ProtocolRegistry.cpp
@@ -866,7 +866,7 @@ void ProtocolRegistry::LoadBuiltinCatalog() {
     addOut("btn_weapon_main", "Weapon Main",     "Digital: Other",  FieldType::DigitalButton, "/input/weapon_main", "weapon_main");
     addOut("btn_weapon_sec",  "Weapon Secondary","Digital: Other",  FieldType::DigitalButton, "/input/weapon_sec",  "weapon_sec");
     addOut("btn_reload",      "Reload",          "Digital: Other",  FieldType::DigitalButton, "/input/reload",      "reload");
-    
+
     // -- Sensors: Gyroscope ---------------------------------------------------
     // Available on DualSense and Steam Controller.  Values normalised to [-1, 1].
     addOut("sensor_gyro_x",   "Gyro X (pitch)",    "Sensors: Gyroscope",      FieldType::AnalogAxis,   "/sensor/gyro/x",         "gyro_x");
@@ -920,34 +920,20 @@ void ProtocolRegistry::LoadBuiltinCatalog() {
     //   galloping: iiiiii  (deviceId, start_position, end_position, first_foot, second_foot, frequency)
     //   machine:   iiiiiii (deviceId, start_position, end_position, amplitude_a, amplitude_b, frequency, period)
     //   off:       (no args)
-    addIn("ds_trigger_left_feedback",   "Left Trigger: Feedback",   "Adaptive Trigger",
-          "/haptics/dualsense/trigger/left/feedback",   "dualsense_trigger_left_feedback");
-    addIn("ds_trigger_right_feedback",  "Right Trigger: Feedback",  "Adaptive Trigger",
-          "/haptics/dualsense/trigger/right/feedback",  "dualsense_trigger_right_feedback");
-    addIn("ds_trigger_left_weapon",     "Left Trigger: Weapon",     "Adaptive Trigger",
-          "/haptics/dualsense/trigger/left/weapon",     "dualsense_trigger_left_weapon");
-    addIn("ds_trigger_right_weapon",    "Right Trigger: Weapon",    "Adaptive Trigger",
-          "/haptics/dualsense/trigger/right/weapon",    "dualsense_trigger_right_weapon");
-    addIn("ds_trigger_left_vibration",  "Left Trigger: Vibration",  "Adaptive Trigger",
-          "/haptics/dualsense/trigger/left/vibration",  "dualsense_trigger_left_vibration");
-    addIn("ds_trigger_right_vibration", "Right Trigger: Vibration", "Adaptive Trigger",
-          "/haptics/dualsense/trigger/right/vibration", "dualsense_trigger_right_vibration");
-    addIn("ds_trigger_left_bow",        "Left Trigger: Bow",        "Adaptive Trigger",
-          "/haptics/dualsense/trigger/left/bow",        "dualsense_trigger_left_bow");
-    addIn("ds_trigger_right_bow",       "Right Trigger: Bow",       "Adaptive Trigger",
-          "/haptics/dualsense/trigger/right/bow",       "dualsense_trigger_right_bow");
-    addIn("ds_trigger_left_galloping",  "Left Trigger: Galloping",  "Adaptive Trigger",
-          "/haptics/dualsense/trigger/left/galloping",  "dualsense_trigger_left_galloping");
-    addIn("ds_trigger_right_galloping", "Right Trigger: Galloping", "Adaptive Trigger",
-          "/haptics/dualsense/trigger/right/galloping", "dualsense_trigger_right_galloping");
-    addIn("ds_trigger_left_machine",    "Left Trigger: Machine",    "Adaptive Trigger",
-          "/haptics/dualsense/trigger/left/machine",    "dualsense_trigger_left_machine");
-    addIn("ds_trigger_right_machine",   "Right Trigger: Machine",   "Adaptive Trigger",
-          "/haptics/dualsense/trigger/right/machine",   "dualsense_trigger_right_machine");
-    addIn("ds_trigger_left_off",        "Left Trigger: Off",        "Adaptive Trigger",
-          "/haptics/dualsense/trigger/left/off",        "dualsense_trigger_left_off");
-    addIn("ds_trigger_right_off",       "Right Trigger: Off",       "Adaptive Trigger",
-          "/haptics/dualsense/trigger/right/off",       "dualsense_trigger_right_off");
+    addIn("ds_trigger_left_feedback",   "Left Trigger: Feedback",   "Adaptive Trigger", "/haptics/dualsense/trigger/left/feedback",   "dualsense_trigger_left_feedback");
+    addIn("ds_trigger_right_feedback",  "Right Trigger: Feedback",  "Adaptive Trigger", "/haptics/dualsense/trigger/right/feedback",  "dualsense_trigger_right_feedback");
+    addIn("ds_trigger_left_weapon",     "Left Trigger: Weapon",     "Adaptive Trigger", "/haptics/dualsense/trigger/left/weapon",     "dualsense_trigger_left_weapon");
+    addIn("ds_trigger_right_weapon",    "Right Trigger: Weapon",    "Adaptive Trigger", "/haptics/dualsense/trigger/right/weapon",    "dualsense_trigger_right_weapon");
+    addIn("ds_trigger_left_vibration",  "Left Trigger: Vibration",  "Adaptive Trigger", "/haptics/dualsense/trigger/left/vibration",  "dualsense_trigger_left_vibration");
+    addIn("ds_trigger_right_vibration", "Right Trigger: Vibration", "Adaptive Trigger", "/haptics/dualsense/trigger/right/vibration", "dualsense_trigger_right_vibration");
+    addIn("ds_trigger_left_bow",        "Left Trigger: Bow",        "Adaptive Trigger", "/haptics/dualsense/trigger/left/bow",        "dualsense_trigger_left_bow");
+    addIn("ds_trigger_right_bow",       "Right Trigger: Bow",       "Adaptive Trigger", "/haptics/dualsense/trigger/right/bow",       "dualsense_trigger_right_bow");
+    addIn("ds_trigger_left_galloping",  "Left Trigger: Galloping",  "Adaptive Trigger", "/haptics/dualsense/trigger/left/galloping",  "dualsense_trigger_left_galloping");
+    addIn("ds_trigger_right_galloping", "Right Trigger: Galloping", "Adaptive Trigger", "/haptics/dualsense/trigger/right/galloping", "dualsense_trigger_right_galloping");
+    addIn("ds_trigger_left_machine",    "Left Trigger: Machine",    "Adaptive Trigger", "/haptics/dualsense/trigger/left/machine",    "dualsense_trigger_left_machine");
+    addIn("ds_trigger_right_machine",   "Right Trigger: Machine",   "Adaptive Trigger", "/haptics/dualsense/trigger/right/machine",   "dualsense_trigger_right_machine");
+    addIn("ds_trigger_left_off",        "Left Trigger: Off",        "Adaptive Trigger", "/haptics/dualsense/trigger/left/off",        "dualsense_trigger_left_off");
+    addIn("ds_trigger_right_off",       "Right Trigger: Off",       "Adaptive Trigger", "/haptics/dualsense/trigger/right/off",       "dualsense_trigger_right_off");
 
     // -- Rumble (simple gamepad) -------------------------------------------
     addIn("rumble_left",  "Rumble Left Motor",  "Rumble", "/rumble/left",  "rumble_left");

--- a/src/Protocols/ProtocolRegistry.cpp
+++ b/src/Protocols/ProtocolRegistry.cpp
@@ -13,13 +13,6 @@
 
 static constexpr const char* kTag = "ProtocolRegistry";
 
-// Bump this whenever WriteDefaultBuiltinCatalog()'s field list changes (fields
-// added/removed/renamed). LoadBuiltinCatalog() compares it against the
-// "_version" stored in the cached builtin_fields.json and regenerates the
-// file automatically on a mismatch, so users don't have to know to delete a
-// stale cache by hand after an update.
-static constexpr int kBuiltinCatalogVersion = 1;
-
 namespace fs = std::filesystem;
 using json = nlohmann::json;
 
@@ -234,8 +227,8 @@ bool ProtocolRegistry::ExportDefinition(const std::string& id, const std::string
             fj["type"]     = (desc->type == FieldType::DigitalButton) ? "digital" : "analog";
         } else if (!desc && f.hasInlineDef) {
             // Catalog entry absent (e.g. field not yet persisted) but the
-            // ProtocolField still carries its own inline metadata - use it so
-            // the exported file stays self-describing.
+            // ProtocolField still carries its own inline metadata,
+            // use it so the exported file stays self-describing.
             fj["label"]    = f.inlineLabel;
             fj["category"] = f.inlineCategory;
             fj["type"]     = (f.inlineType == FieldType::DigitalButton) ? "digital" : "analog";
@@ -328,7 +321,7 @@ std::string ProtocolRegistry::ImportDefinition(const std::string& path) {
                         fd.category       = f.inlineCategory;
                         fd.type           = f.inlineType;
                     } else {
-                        // No inline metadata - synthesise sensible defaults so
+                        // No inline metadata, synthesise sensible defaults so
                         // the field at least appears in the editor.
                         fd.label    = f.fieldId;
                         fd.category = "Custom (imported)";
@@ -407,7 +400,7 @@ void ProtocolRegistry::SaveDefinition(const ProtocolDefinition& def) {
     }
     j["fields"] = fieldsArr;
 
-    // Per-protocol exclusions - only write the keys when non-empty so that
+    // Per-protocol exclusions, only write the keys when non-empty so that
     // the vast majority of definition files stay clean.
     if (!def.excludedFieldIds.empty()) {
         json arr = json::array();
@@ -495,10 +488,10 @@ static void BootstrapFromInstallDir(const std::string& prefProtocolsDir) {
         }
     };
 
-    // Seed top-level JSON files (input_fields.json, builtin_fields.json, …).
+    // Seed top-level JSON files (input_fields.json, …).
     seedDir(srcDir, prefProtocolsDir);
 
-    // Seed built-in protocol definitions - these populate the OSC/WS output
+    // Seed built-in protocol definitions, these populate the OSC/WS output
     // dropdown via LoadDefinitionFiles(). This was the missing step that caused
     // the dropdown to appear empty on first run under AppImage.
     seedDir(srcDefs, dstDefs);
@@ -537,7 +530,7 @@ void ProtocolRegistry::LoadFieldCatalog() {
                 fd.defaultWsKey   = item.value("wsKey",    fd.id);
                 fd.isBuiltIn      = false;
 
-                // Skip if already present in either catalog - a field that
+                // Skip if already present in either catalog, a field that
                 // belongs in m_inputFields (e.g. a built-in sensor or button)
                 // must not be duplicated into m_outputFields regardless of
                 // what was written to input_fields.json by an older code path.
@@ -721,7 +714,7 @@ void ProtocolRegistry::LoadDefinitionFiles() {
                         for (const auto& fd : m_inputFields)  if (fd.id == f.fieldId) count++;
 
                         if (count > 1) {
-                            // More than one entry for this ID - keep only the
+                            // More than one entry for this ID, keep only the
                             // first real (non-stale) one and remove the rest.
                             bool kept = false;
                             auto dedup = [&](std::vector<FieldDescriptor>& cat) {
@@ -813,90 +806,16 @@ void ProtocolRegistry::LoadBuiltinCatalog() {
     m_outputFields.clear();
     m_inputFields.clear();
 
-    std::string path = GetProtocolsDir() + "builtin_fields.json";
-    std::ifstream ifs(path);
-    if (!ifs.is_open()) {
-        LOG_INFO(kTag, "builtin_fields.json not found - writing defaults (schema v%d)", kBuiltinCatalogVersion);
-        WriteDefaultBuiltinCatalog();
-        ifs.open(path);
-        if (!ifs.is_open()) return;
-    } else {
-        // Peek at "_version" before doing the real parse below. A missing or
-        // mismatched version means this cache predates (or postdates) the
-        // built-in field list currently compiled into the program - most
-        // commonly seen after an update that added/removed/renamed fields.
-        // Regenerate rather than silently running with a stale/foreign list.
-        int cachedVersion = -1;
-        try {
-            json probe = json::parse(ifs);
-            cachedVersion = probe.value("_version", -1);
-        } catch (const std::exception&) {
-            // Unparseable - treat the same as a version mismatch below.
-        }
-
-        if (cachedVersion != kBuiltinCatalogVersion) {
-            LOG_WARN(kTag,
-                "builtin_fields.json schema mismatch (cached v%d, program expects v%d) - "
-                "regenerating from current defaults", cachedVersion, kBuiltinCatalogVersion);
-            WriteDefaultBuiltinCatalog();
-        }
-
-        ifs.close();
-        ifs.open(path);
-        if (!ifs.is_open()) return;
-    }
-
-    try {
-        json j = json::parse(ifs);
-        if (j.contains("output_fields") && j["output_fields"].is_array()) {
-            for (const auto& item : j["output_fields"]) {
-                FieldDescriptor fd;
-                fd.id             = item.value("id",       "");
-                fd.label          = item.value("label",    fd.id);
-                fd.category       = item.value("category", "Custom");
-                std::string type  = item.value("type",     "analog");
-                fd.type           = (type == "digital") ? FieldType::DigitalButton : FieldType::AnalogAxis;
-                fd.defaultOscPath = item.value("oscPath",  "/" + fd.id);
-                fd.defaultWsKey   = item.value("wsKey",    fd.id);
-                fd.isBuiltIn      = true;
-                if (!fd.id.empty()) m_outputFields.push_back(fd);
-            }
-        }
-        if (j.contains("input_fields") && j["input_fields"].is_array()) {
-            for (const auto& item : j["input_fields"]) {
-                FieldDescriptor fd;
-                fd.id             = item.value("id",       "");
-                fd.label          = item.value("label",    fd.id);
-                fd.category       = item.value("category", "Haptic");
-                std::string type  = item.value("type",     "analog");
-                fd.type           = (type == "digital") ? FieldType::DigitalButton : FieldType::AnalogAxis;
-                fd.defaultOscPath = item.value("oscPath",  "/" + fd.id);
-                fd.defaultWsKey   = item.value("wsKey",    fd.id);
-                fd.isBuiltIn      = true;
-                if (!fd.id.empty()) m_inputFields.push_back(fd);
-            }
-        }
-    } catch (const std::exception& e) {
-    LOG_ERROR(kTag, "Failed to parse builtin_fields.json: %s", e.what());
-    }
-}
-
-void ProtocolRegistry::WriteDefaultBuiltinCatalog() {
-    json j;
-    j["_comment"] = "Default built-in fields. Auto-regenerated whenever InputBridge's "
-                    "built-in field list changes; also regenerated if this file is deleted.";
-    j["_version"] = kBuiltinCatalogVersion;
-
-    json outArr = json::array();
     auto addOut = [&](const char* id, const char* label, const char* cat, FieldType type, const char* oscPath, const char* wsKey) {
-        json item;
-        item["id"] = id;
-        item["label"] = label;
-        item["category"] = cat;
-        item["type"] = (type == FieldType::DigitalButton) ? "digital" : "analog";
-        item["oscPath"] = oscPath;
-        item["wsKey"] = wsKey;
-        outArr.push_back(item);
+        FieldDescriptor fd;
+        fd.id             = id;
+        fd.label          = label;
+        fd.category       = cat;
+        fd.type           = type;
+        fd.defaultOscPath = oscPath;
+        fd.defaultWsKey   = wsKey;
+        fd.isBuiltIn      = true;
+        m_outputFields.push_back(fd);
     };
 
     // -- Analog axes ----------------------------------------------------------
@@ -947,7 +866,7 @@ void ProtocolRegistry::WriteDefaultBuiltinCatalog() {
     addOut("btn_weapon_main", "Weapon Main",     "Digital: Other",  FieldType::DigitalButton, "/input/weapon_main", "weapon_main");
     addOut("btn_weapon_sec",  "Weapon Secondary","Digital: Other",  FieldType::DigitalButton, "/input/weapon_sec",  "weapon_sec");
     addOut("btn_reload",      "Reload",          "Digital: Other",  FieldType::DigitalButton, "/input/reload",      "reload");
-
+    
     // -- Sensors: Gyroscope ---------------------------------------------------
     // Available on DualSense and Steam Controller.  Values normalised to [-1, 1].
     addOut("sensor_gyro_x",   "Gyro X (pitch)",    "Sensors: Gyroscope",      FieldType::AnalogAxis,   "/sensor/gyro/x",         "gyro_x");
@@ -967,21 +886,18 @@ void ProtocolRegistry::WriteDefaultBuiltinCatalog() {
     addOut("sensor_touch2_x",    "Touch 2 X (centered)","Sensors: Touchpad", FieldType::AnalogAxis,    "/sensor/touch2/x",       "touch2_x");
     addOut("sensor_touch2_y",    "Touch 2 Y (centered)","Sensors: Touchpad", FieldType::AnalogAxis,    "/sensor/touch2/y",       "touch2_y");
     addOut("sensor_touch2_p",    "Touch 2 Pressure",    "Sensors: Touchpad", FieldType::AnalogAxis,    "/sensor/touch2/pressure","touch2_pressure");
-    addOut("sensor_touch_active","Touch Active",         "Sensors: Touchpad", FieldType::DigitalButton, "/sensor/touch/active",   "touch_active");
+    addOut("sensor_touch_active","Touch Active",        "Sensors: Touchpad", FieldType::DigitalButton, "/sensor/touch/active",   "touch_active");
 
-
-    j["output_fields"] = outArr;
-
-    json inArr = json::array();
     auto addIn = [&](const char* id, const char* label, const char* cat, const char* oscPath, const char* wsKey) {
-        json item;
-        item["id"] = id;
-        item["label"] = label;
-        item["category"] = cat;
-        item["type"] = "analog";
-        item["oscPath"] = oscPath;
-        item["wsKey"] = wsKey;
-        inArr.push_back(item);
+        FieldDescriptor fd;
+        fd.id             = id;
+        fd.label          = label;
+        fd.category       = cat;
+        fd.type           = FieldType::AnalogAxis; // Input fields are currently all analog for haptics
+        fd.defaultOscPath = oscPath;
+        fd.defaultWsKey   = wsKey;
+        fd.isBuiltIn      = true;
+        m_inputFields.push_back(fd);
     };
 
     // -- Haptic feedback fields (received from client) ---------------------
@@ -992,7 +908,11 @@ void ProtocolRegistry::WriteDefaultBuiltinCatalog() {
     addIn("haptic_gain",        "Global Gain",             "Haptic", "/haptic/gain",        "gain");
     // -- Adaptive Trigger (DualSense) ---------------------------------------
     // One field per trigger side x effect, since each combination is its
-    // own OSC address/arg signature rather than a single message shape:
+    // own OSC address/arg signature rather than a single message shape.
+    // Addresses use the same flat /haptics/{name} convention as
+    // the Haptic fields above (rumble, force, periodic, condition, gain)
+    // rather than nesting left/right and the effect name as separate path
+    // segments:
     //   feedback:  iii     (deviceId, position, strength)
     //   weapon:    iiii    (deviceId, start_position, end_position, strength)
     //   vibration: iiii    (deviceId, position, amplitude, frequency)
@@ -1001,43 +921,37 @@ void ProtocolRegistry::WriteDefaultBuiltinCatalog() {
     //   machine:   iiiiiii (deviceId, start_position, end_position, amplitude_a, amplitude_b, frequency, period)
     //   off:       (no args)
     addIn("ds_trigger_left_feedback",   "Left Trigger: Feedback",   "Adaptive Trigger",
-          "/inputbridge/haptics/dualsense/trigger/left/feedback",   "dualsense_trigger_left_feedback");
+          "/haptics/dualsense/trigger/left/feedback",   "dualsense_trigger_left_feedback");
     addIn("ds_trigger_right_feedback",  "Right Trigger: Feedback",  "Adaptive Trigger",
-          "/inputbridge/haptics/dualsense/trigger/right/feedback",  "dualsense_trigger_right_feedback");
+          "/haptics/dualsense/trigger/right/feedback",  "dualsense_trigger_right_feedback");
     addIn("ds_trigger_left_weapon",     "Left Trigger: Weapon",     "Adaptive Trigger",
-          "/inputbridge/haptics/dualsense/trigger/left/weapon",     "dualsense_trigger_left_weapon");
+          "/haptics/dualsense/trigger/left/weapon",     "dualsense_trigger_left_weapon");
     addIn("ds_trigger_right_weapon",    "Right Trigger: Weapon",    "Adaptive Trigger",
-          "/inputbridge/haptics/dualsense/trigger/right/weapon",    "dualsense_trigger_right_weapon");
+          "/haptics/dualsense/trigger/right/weapon",    "dualsense_trigger_right_weapon");
     addIn("ds_trigger_left_vibration",  "Left Trigger: Vibration",  "Adaptive Trigger",
-          "/inputbridge/haptics/dualsense/trigger/left/vibration",  "dualsense_trigger_left_vibration");
+          "/haptics/dualsense/trigger/left/vibration",  "dualsense_trigger_left_vibration");
     addIn("ds_trigger_right_vibration", "Right Trigger: Vibration", "Adaptive Trigger",
-          "/inputbridge/haptics/dualsense/trigger/right/vibration", "dualsense_trigger_right_vibration");
+          "/haptics/dualsense/trigger/right/vibration", "dualsense_trigger_right_vibration");
     addIn("ds_trigger_left_bow",        "Left Trigger: Bow",        "Adaptive Trigger",
-          "/inputbridge/haptics/dualsense/trigger/left/bow",        "dualsense_trigger_left_bow");
+          "/haptics/dualsense/trigger/left/bow",        "dualsense_trigger_left_bow");
     addIn("ds_trigger_right_bow",       "Right Trigger: Bow",       "Adaptive Trigger",
-          "/inputbridge/haptics/dualsense/trigger/right/bow",       "dualsense_trigger_right_bow");
+          "/haptics/dualsense/trigger/right/bow",       "dualsense_trigger_right_bow");
     addIn("ds_trigger_left_galloping",  "Left Trigger: Galloping",  "Adaptive Trigger",
-          "/inputbridge/haptics/dualsense/trigger/left/galloping",  "dualsense_trigger_left_galloping");
+          "/haptics/dualsense/trigger/left/galloping",  "dualsense_trigger_left_galloping");
     addIn("ds_trigger_right_galloping", "Right Trigger: Galloping", "Adaptive Trigger",
-          "/inputbridge/haptics/dualsense/trigger/right/galloping", "dualsense_trigger_right_galloping");
+          "/haptics/dualsense/trigger/right/galloping", "dualsense_trigger_right_galloping");
     addIn("ds_trigger_left_machine",    "Left Trigger: Machine",    "Adaptive Trigger",
-          "/inputbridge/haptics/dualsense/trigger/left/machine",    "dualsense_trigger_left_machine");
+          "/haptics/dualsense/trigger/left/machine",    "dualsense_trigger_left_machine");
     addIn("ds_trigger_right_machine",   "Right Trigger: Machine",   "Adaptive Trigger",
-          "/inputbridge/haptics/dualsense/trigger/right/machine",   "dualsense_trigger_right_machine");
+          "/haptics/dualsense/trigger/right/machine",   "dualsense_trigger_right_machine");
     addIn("ds_trigger_left_off",        "Left Trigger: Off",        "Adaptive Trigger",
-          "/inputbridge/haptics/dualsense/trigger/left/off",        "dualsense_trigger_left_off");
+          "/haptics/dualsense/trigger/left/off",        "dualsense_trigger_left_off");
     addIn("ds_trigger_right_off",       "Right Trigger: Off",       "Adaptive Trigger",
-          "/inputbridge/haptics/dualsense/trigger/right/off",       "dualsense_trigger_right_off");
+          "/haptics/dualsense/trigger/right/off",       "dualsense_trigger_right_off");
 
     // -- Rumble (simple gamepad) -------------------------------------------
     addIn("rumble_left",  "Rumble Left Motor",  "Rumble", "/rumble/left",  "rumble_left");
     addIn("rumble_right", "Rumble Right Motor", "Rumble", "/rumble/right", "rumble_right");
-
-    j["input_fields"] = inArr;
-
-    std::string path = GetProtocolsDir() + "builtin_fields.json";
-    std::ofstream ofs(path);
-    if (ofs) ofs << j.dump(4);
 }
 
 // --- ID generation -----------------------------------------------------------

--- a/src/Protocols/ProtocolRegistry.cpp
+++ b/src/Protocols/ProtocolRegistry.cpp
@@ -9,6 +9,7 @@
 #include <chrono>
 #include <iomanip>
 #include <random>
+#include <algorithm>
 #include <SDL3/SDL_filesystem.h>
 
 static constexpr const char* kTag = "ProtocolRegistry";
@@ -667,6 +668,7 @@ void ProtocolRegistry::LoadDefinitionFiles() {
             if (j.contains("ws")) {
                 def.wssPort = j["ws"].value("port", 4269);
             }
+            bool defFieldMigrated = false;
             if (j.contains("fields") && j["fields"].is_array()) {
                 for (const auto& fj : j["fields"]) {
                     ProtocolField f;
@@ -676,6 +678,18 @@ void ProtocolRegistry::LoadDefinitionFiles() {
                     f.enabled = fj.value("enabled",  true);
                     if (f.fieldId.empty())
                         continue;
+
+                    // One-time migration: this field's catalog default OSC
+                    // path used to be "/haptic/dualsense_trigger" (mismatched
+                    // against the actual hardcoded runtime default), so any
+                    // protocol that enabled it before the catalog fix copied
+                    // that wrong path into its own field entry. Repoint it to
+                    // the canonical address so it keeps receiving messages.
+                    if (f.fieldId == "haptic_dualsense_trigger" &&
+                        f.oscPath == "/haptic/dualsense_trigger") {
+                        f.oscPath = "/inputbridge/haptics/dualsense/trigger";
+                        defFieldMigrated = true;
+                    }
 
                     bool hasInline = fj.contains("label") || fj.contains("category") || fj.contains("type");
                     if (hasInline) {
@@ -759,6 +773,9 @@ void ProtocolRegistry::LoadDefinitionFiles() {
                     if (v.is_string()) def.excludedCategories.push_back(v.get<std::string>());
 
             m_definitions.push_back(def);
+            if (defFieldMigrated) {
+                SaveDefinition(m_definitions.back());
+            }
         } catch (const std::exception& e) {
             LOG_ERROR(kTag, "Failed to parse %s: %s",
                       entry.path().string().c_str(), e.what());
@@ -847,22 +864,80 @@ void ProtocolRegistry::LoadBuiltinCatalog() {
     } catch (const std::exception& e) {
     LOG_ERROR(kTag, "Failed to parse builtin_fields.json: %s", e.what());
     }
+
+    // Reconcile against the canonical in-code catalog: builtin_fields.json is
+    // seeded once and then never overwritten (existing installs keep whatever
+    // was on disk from whenever they first ran), so a built-in field added to
+    // BuildDefaultCatalog() later would otherwise never reach anyone who
+    // already has a builtin_fields.json. Add any built-in id that's missing
+    // from what we just loaded, and persist the merge so it's stable.
+    std::vector<FieldDescriptor> defaultOut, defaultIn;
+    BuildDefaultCatalog(defaultOut, defaultIn);
+
+    auto mergeMissing = [](std::vector<FieldDescriptor>& loaded,
+                           const std::vector<FieldDescriptor>& canonical) {
+        bool added = false;
+        for (const auto& fd : canonical) {
+            bool found = std::any_of(loaded.begin(), loaded.end(),
+                [&](const FieldDescriptor& l) { return l.id == fd.id; });
+            if (!found) {
+                loaded.push_back(fd);
+                added = true;
+            }
+        }
+        return added;
+    };
+
+    bool outAdded = mergeMissing(m_outputFields, defaultOut);
+    bool inAdded  = mergeMissing(m_inputFields,  defaultIn);
+
+    // Targeted one-time fix-up: earlier builds shipped haptic_dualsense_trigger
+    // under category "Haptic" with default OSC path "/haptic/dualsense_trigger",
+    // which mismatched the actual hardcoded runtime default and lumped it in
+    // with the unrelated generic SDL haptic effects. Installs that already
+    // have builtin_fields.json on disk from that period keep those wrong
+    // values forever (mergeMissing only adds ids that are absent, it doesn't
+    // correct ones that already exist) - so explicitly repoint this one
+    // known-bad entry back to the canonical values. This only fires when the
+    // on-disk values still exactly match the old mistake, so it won't touch
+    // a category the user has since renamed/merged on purpose.
+    bool inFixedUp = false;
+    for (auto& fd : m_inputFields) {
+        if (fd.id == "haptic_dualsense_trigger" &&
+            fd.category == "Haptic" &&
+            fd.defaultOscPath == "/haptic/dualsense_trigger") {
+            auto it = std::find_if(defaultIn.begin(), defaultIn.end(),
+                [](const FieldDescriptor& d) { return d.id == "haptic_dualsense_trigger"; });
+            if (it != defaultIn.end()) {
+                fd.category       = it->category;
+                fd.defaultOscPath = it->defaultOscPath;
+                fd.defaultWsKey   = it->defaultWsKey;
+                inFixedUp = true;
+            }
+            break;
+        }
+    }
+
+    if (outAdded || inAdded || inFixedUp) {
+        WriteBuiltinCatalogToDisk();
+    }
 }
 
-void ProtocolRegistry::WriteDefaultBuiltinCatalog() {
-    json j;
-    j["_comment"] = "Default built-in fields. Delete this file to regenerate defaults.";
+void ProtocolRegistry::BuildDefaultCatalog(std::vector<FieldDescriptor>& outFields,
+                                           std::vector<FieldDescriptor>& inFields) {
+    outFields.clear();
+    inFields.clear();
 
-    json outArr = json::array();
     auto addOut = [&](const char* id, const char* label, const char* cat, FieldType type, const char* oscPath, const char* wsKey) {
-        json item;
-        item["id"] = id;
-        item["label"] = label;
-        item["category"] = cat;
-        item["type"] = (type == FieldType::DigitalButton) ? "digital" : "analog";
-        item["oscPath"] = oscPath;
-        item["wsKey"] = wsKey;
-        outArr.push_back(item);
+        FieldDescriptor fd;
+        fd.id             = id;
+        fd.label          = label;
+        fd.category       = cat;
+        fd.type           = type;
+        fd.defaultOscPath = oscPath;
+        fd.defaultWsKey   = wsKey;
+        fd.isBuiltIn      = true;
+        outFields.push_back(fd);
     };
 
     // -- Analog axes ----------------------------------------------------------
@@ -913,7 +988,7 @@ void ProtocolRegistry::WriteDefaultBuiltinCatalog() {
     addOut("btn_weapon_main", "Weapon Main",     "Digital: Other",  FieldType::DigitalButton, "/input/weapon_main", "weapon_main");
     addOut("btn_weapon_sec",  "Weapon Secondary","Digital: Other",  FieldType::DigitalButton, "/input/weapon_sec",  "weapon_sec");
     addOut("btn_reload",      "Reload",          "Digital: Other",  FieldType::DigitalButton, "/input/reload",      "reload");
-    
+
     // -- Sensors: Gyroscope ---------------------------------------------------
     // Available on DualSense and Steam Controller.  Values normalised to [-1, 1].
     addOut("sensor_gyro_x",   "Gyro X (pitch)",    "Sensors: Gyroscope",      FieldType::AnalogAxis,   "/sensor/gyro/x",         "gyro_x");
@@ -935,19 +1010,16 @@ void ProtocolRegistry::WriteDefaultBuiltinCatalog() {
     addOut("sensor_touch2_p",    "Touch 2 Pressure",    "Sensors: Touchpad", FieldType::AnalogAxis,    "/sensor/touch2/pressure","touch2_pressure");
     addOut("sensor_touch_active","Touch Active",         "Sensors: Touchpad", FieldType::DigitalButton, "/sensor/touch/active",   "touch_active");
 
-
-    j["output_fields"] = outArr;
-
-    json inArr = json::array();
     auto addIn = [&](const char* id, const char* label, const char* cat, const char* oscPath, const char* wsKey) {
-        json item;
-        item["id"] = id;
-        item["label"] = label;
-        item["category"] = cat;
-        item["type"] = "analog";
-        item["oscPath"] = oscPath;
-        item["wsKey"] = wsKey;
-        inArr.push_back(item);
+        FieldDescriptor fd;
+        fd.id             = id;
+        fd.label          = label;
+        fd.category       = cat;
+        fd.type           = FieldType::AnalogAxis;
+        fd.defaultOscPath = oscPath;
+        fd.defaultWsKey   = wsKey;
+        fd.isBuiltIn      = true;
+        inFields.push_back(fd);
     };
 
     // -- Haptic feedback fields (received from client) ---------------------
@@ -956,19 +1028,52 @@ void ProtocolRegistry::WriteDefaultBuiltinCatalog() {
     addIn("haptic_periodic",    "Periodic Effect",         "Haptic", "/haptic/periodic",    "periodic");
     addIn("haptic_condition",   "Condition Effect",        "Haptic", "/haptic/condition",   "condition");
     addIn("haptic_gain",        "Global Gain",             "Haptic", "/haptic/gain",        "gain");
-    
-    // -- Adaptive trigger fields (received from client) ---------------------
-    addIn("haptic_dualsense_trigger", "DualSense Adaptive Trigger", "Haptic", "/haptic/dualsense_trigger", "dualsense_trigger");
+
+    // -- Adaptive Trigger (received from client) -----------------------------
+    // Own category (not lumped under "Haptic") since it's a materially
+    // different kind of effect (DualSense-only, positional/zone-based)
+    // from the four generic SDL haptic effects above. Default OSC path
+    // matches the hardcoded fallback base in OSCBaseProtocol.cpp/
+    // OSCProtocol.cpp so the suggested default and the actual runtime
+    // default are the same address.
+    addIn("haptic_dualsense_trigger", "DualSense Adaptive Trigger", "Adaptive Trigger",
+          "/inputbridge/haptics/dualsense/trigger", "dualsense_trigger");
 
     // -- Rumble (simple gamepad) -------------------------------------------
     addIn("rumble_left",  "Rumble Left Motor",  "Rumble", "/rumble/left",  "rumble_left");
     addIn("rumble_right", "Rumble Right Motor", "Rumble", "/rumble/right", "rumble_right");
+}
 
-    j["input_fields"] = inArr;
+void ProtocolRegistry::WriteBuiltinCatalogToDisk() {
+    json j;
+    j["_comment"] = "Default built-in fields. Delete this file to regenerate defaults.";
+
+    auto toJson = [](const std::vector<FieldDescriptor>& fields) {
+        json arr = json::array();
+        for (const auto& fd : fields) {
+            json item;
+            item["id"] = fd.id;
+            item["label"] = fd.label;
+            item["category"] = fd.category;
+            item["type"] = (fd.type == FieldType::DigitalButton) ? "digital" : "analog";
+            item["oscPath"] = fd.defaultOscPath;
+            item["wsKey"] = fd.defaultWsKey;
+            arr.push_back(item);
+        }
+        return arr;
+    };
+
+    j["output_fields"] = toJson(m_outputFields);
+    j["input_fields"]  = toJson(m_inputFields);
 
     std::string path = GetProtocolsDir() + "builtin_fields.json";
     std::ofstream ofs(path);
     if (ofs) ofs << j.dump(4);
+}
+
+void ProtocolRegistry::WriteDefaultBuiltinCatalog() {
+    BuildDefaultCatalog(m_outputFields, m_inputFields);
+    WriteBuiltinCatalogToDisk();
 }
 
 // --- ID generation -----------------------------------------------------------

--- a/src/Protocols/ProtocolRegistry.h
+++ b/src/Protocols/ProtocolRegistry.h
@@ -93,6 +93,16 @@ private:
     void WriteDefaultFieldCatalog();
     void LoadBuiltinCatalog();
     void WriteDefaultBuiltinCatalog();
+    // serialises current m_outputFields/m_inputFields to builtin_fields.json
+    void WriteBuiltinCatalogToDisk();
+
+    // Canonical, in-code list of built-in fields. Used both to seed a fresh
+    // builtin_fields.json for new installs and to reconcile an existing file
+    // (LoadBuiltinCatalog merges in any built-in id present here but missing
+    // from the on-disk file, so shipping a new built-in field actually
+    // reaches users who already have a builtin_fields.json on disk).
+    static void BuildDefaultCatalog(std::vector<FieldDescriptor>& outFields,
+                                    std::vector<FieldDescriptor>& inFields);
 
     static std::string GenerateId();
 

--- a/src/Protocols/ProtocolRegistry.h
+++ b/src/Protocols/ProtocolRegistry.h
@@ -91,18 +91,10 @@ private:
 
     void EnsureDirectories();
     void WriteDefaultFieldCatalog();
+    // Populates m_outputFields/m_inputFields with the canonical, in-code list
+    // of built-in fields. Purely in-memory - built-in fields are no longer
+    // cached to or read from disk.
     void LoadBuiltinCatalog();
-    void WriteDefaultBuiltinCatalog();
-    // serialises current m_outputFields/m_inputFields to builtin_fields.json
-    void WriteBuiltinCatalogToDisk();
-
-    // Canonical, in-code list of built-in fields. Used both to seed a fresh
-    // builtin_fields.json for new installs and to reconcile an existing file
-    // (LoadBuiltinCatalog merges in any built-in id present here but missing
-    // from the on-disk file, so shipping a new built-in field actually
-    // reaches users who already have a builtin_fields.json on disk).
-    static void BuildDefaultCatalog(std::vector<FieldDescriptor>& outFields,
-                                    std::vector<FieldDescriptor>& inFields);
 
     static std::string GenerateId();
 

--- a/src/UI/AboutWindow.cpp
+++ b/src/UI/AboutWindow.cpp
@@ -99,7 +99,7 @@ void AboutWindow::DrawContent() {
         ImGui::Spacing();
 
         constexpr const char* testers_beta[] = {
-            "0x8081", "esnya", "GranpaVape", "Hayden", "ShadowX", "SnubbleJr"
+            "0x8081", "Decoy", "esnya", "GranpaVape", "Hayden", "ShadowX", "SnubbleJr"
         };
         ImGui::Indent(8.0f);
         for (const char* t : testers_beta) {

--- a/src/Visualizers/GamepadHapticsVisualizer.cpp
+++ b/src/Visualizers/GamepadHapticsVisualizer.cpp
@@ -1,4 +1,4 @@
-//#include "App/Log.h" // currently unused expect for the adaptive trigger part
+#include "App/Log.h"
 #include "GamepadHapticsVisualizer.h"
 #include "imgui.h"
 #include "Haptics/GamepadHaptics.h"
@@ -194,9 +194,6 @@ void GamepadHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager& devic
             isDualSense = gamepadHaptics->IsDualSense();
     }
 
-    /***
-     * TODO: Add adaptive trigger support later down the line again
-     *
     if (isDualSense) {
         ImGui::Separator();
         ImGui::Text("DualSense Adaptive Triggers");
@@ -353,5 +350,4 @@ void GamepadHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager& devic
             }
         }
     }
-    */
 }

--- a/tests/test_haptic_parser.cpp
+++ b/tests/test_haptic_parser.cpp
@@ -506,16 +506,18 @@ TEST_F(HapticParserTest, AutoDetectDualSenseTrigger) {
     EXPECT_EQ(det.effect_type, "feedback");
 }
 
-TEST_F(HapticParserTest, TypeAutoDoesNotDispatchDualSenseTriggerYet) {
-    // This documents the current limitation in HapticParser.cpp where
-    // "auto" detection works but dispatching for DualSense is skipped.
+TEST_F(HapticParserTest, TypeAutoDispatchesDualSenseTrigger) {
     HapticParser::Parse(
-        R"({"type":"auto","params":{"trigger":"right","effect_type":"feedback"}})",
+        R"({"type":"auto","params":{"trigger":"right","effect_type":"feedback",
+                                     "position":3,"strength":6}})",
         FakeMapper());
-    
-    // No calls should happen because QueueDualSenseTrigger isn't called by dispatch()
-    // and Parse() explicitly skips it for det.kind == DualSenseTrigger.
-    EXPECT_TRUE(HapticStub::dualSenseCalls.empty());
+
+    ASSERT_EQ(HapticStub::dualSenseCalls.size(), 1u);
+    const auto& call = HapticStub::dualSenseCalls[0];
+    EXPECT_EQ(call.trigger,     "right");
+    EXPECT_EQ(call.effect_type, "feedback");
+    EXPECT_EQ(call.p1, 3);  // position
+    EXPECT_EQ(call.p2, 6);  // strength
 }
 
 // Condition must win over constant when both "strength" and sat fields co-exist.

--- a/tests/test_haptic_parser.cpp
+++ b/tests/test_haptic_parser.cpp
@@ -4,8 +4,8 @@
 
 // ─── Fake mapper pointer ──────────────────────────────────────────────────────
 // HapticParser::Parse() only requires a non-null OutputMapper*.
-// The stub's Queue methods never dereference 'this' - they only write to the
-// HapticStub global vectors.  We pass the address of a static intptr_t as
+// The stub's Queue methods never dereference 'this', they only write to the
+// HapticStub global vectors. We pass the address of a static intptr_t as
 // the sentinel; no OutputMapper is ever constructed.
 // A non-null sentinel address; the stub Queue* methods never dereference 'this'.
 // We use intptr_t to avoid strict-aliasing UB and keep the cast well-defined.
@@ -518,6 +518,54 @@ TEST_F(HapticParserTest, TypeAutoDispatchesDualSenseTrigger) {
     EXPECT_EQ(call.effect_type, "feedback");
     EXPECT_EQ(call.p1, 3);  // position
     EXPECT_EQ(call.p2, 6);  // strength
+}
+
+// Explicit (non-"auto") type must also dispatch DualSense trigger effects.
+// Previously only the "auto" path handled "trigger"/"effect_type" fields,
+// so a client using an explicit "type" with "effect":"dualsense_trigger"
+// was silently dropped.
+TEST_F(HapticParserTest, TypeHapticDispatchesDualSenseTrigger) {
+    HapticParser::Parse(
+        R"({"type":"haptic","effect":"dualsense_trigger","device":0,
+            "params":{"trigger":"left","effect_type":"feedback",
+                      "position":4,"strength":7}})",
+        FakeMapper());
+
+    ASSERT_EQ(HapticStub::dualSenseCalls.size(), 1u);
+    const auto& call = HapticStub::dualSenseCalls[0];
+    EXPECT_EQ(call.trigger,     "left");
+    EXPECT_EQ(call.effect_type, "feedback");
+    EXPECT_EQ(call.p1, 4);  // position
+    EXPECT_EQ(call.p2, 7);  // strength
+}
+
+// weapon/bow/galloping/machine effects use "start_position" rather than
+// "position" (matching the OSC address docs and TriggerDualSenseTrigger's
+// param mapping). Previously "start_position" was never read at all,
+// so it always came through as 0 regardless of what the client sent.
+TEST_F(HapticParserTest, DualSenseTriggerReadsStartPosition) {
+    HapticParser::Parse(
+        R"({"type":"auto","params":{"trigger":"right","effect_type":"weapon",
+                                     "start_position":5,"end_position":8,"strength":6}})",
+        FakeMapper());
+
+    ASSERT_EQ(HapticStub::dualSenseCalls.size(), 1u);
+    const auto& call = HapticStub::dualSenseCalls[0];
+    EXPECT_EQ(call.effect_type, "weapon");
+    EXPECT_EQ(call.p1, 5);  // position (populated from start_position)
+    EXPECT_EQ(call.p3, 8);  // end_position
+}
+
+// "position" must still work for feedback/vibration when "start_position"
+// is absent (no regression for the pre-existing key).
+TEST_F(HapticParserTest, DualSenseTriggerFallsBackToPositionWhenNoStartPosition) {
+    HapticParser::Parse(
+        R"({"type":"auto","params":{"trigger":"left","effect_type":"vibration",
+                                     "position":2,"amplitude":3,"frequency":100}})",
+        FakeMapper());
+
+    ASSERT_EQ(HapticStub::dualSenseCalls.size(), 1u);
+    EXPECT_EQ(HapticStub::dualSenseCalls[0].p1, 2);  // position
 }
 
 // Condition must win over constant when both "strength" and sat fields co-exist.

--- a/tests/test_protocol_data.cpp
+++ b/tests/test_protocol_data.cpp
@@ -11,9 +11,9 @@ TEST(ProtocolDefinition, DefaultTransportIsOSC) {
     EXPECT_EQ(def.transport, ProtocolTransport::OSC);
 }
 
-TEST(ProtocolDefinition, DefaultDirectionIsOutput) {
+TEST(ProtocolDefinition, DefaultDirectionIsSend) {
     ProtocolDefinition def;
-    EXPECT_EQ(def.direction, ProtocolDirection::Output);
+    EXPECT_EQ(def.direction, ProtocolDirection::Send);
 }
 
 TEST(ProtocolDefinition, DefaultOSCHost) {
@@ -62,10 +62,10 @@ TEST(ProtocolDefinition, CanSetTransportToWebSocket) {
     EXPECT_EQ(def.transport, ProtocolTransport::WebSocket);
 }
 
-TEST(ProtocolDefinition, CanSetDirectionToInput) {
+TEST(ProtocolDefinition, CanSetDirectionToReceive) {
     ProtocolDefinition def;
-    def.direction = ProtocolDirection::Input;
-    EXPECT_EQ(def.direction, ProtocolDirection::Input);
+    def.direction = ProtocolDirection::Receive;
+    EXPECT_EQ(def.direction, ProtocolDirection::Receive);
 }
 
 TEST(ProtocolDefinition, CanAddField) {

--- a/tests/test_protocol_validator.cpp
+++ b/tests/test_protocol_validator.cpp
@@ -247,19 +247,19 @@ TEST(ValidateFieldId, Over64CharsIsError) {
 // ═════════════════════════════════════════════════════════════════════════════
 
 TEST(ValidateProtocolJSON, MissingIdIsError) {
-    json j = { {"name","Test"}, {"transport","osc"}, {"direction","output"} };
+    json j = { {"name","Test"}, {"transport","osc"}, {"direction","send"} };
     auto r = ProtocolValidator::ValidateProtocolJSON(j);
     EXPECT_FALSE(r.IsValid());
 }
 
 TEST(ValidateProtocolJSON, MissingNameIsError) {
-    json j = { {"id","abc"}, {"transport","osc"}, {"direction","output"} };
+    json j = { {"id","abc"}, {"transport","osc"}, {"direction","send"} };
     auto r = ProtocolValidator::ValidateProtocolJSON(j);
     EXPECT_FALSE(r.IsValid());
 }
 
 TEST(ValidateProtocolJSON, MissingTransportIsError) {
-    json j = { {"id","abc"}, {"name","Test"}, {"direction","output"} };
+    json j = { {"id","abc"}, {"name","Test"}, {"direction","send"} };
     auto r = ProtocolValidator::ValidateProtocolJSON(j);
     EXPECT_FALSE(r.IsValid());
 }
@@ -271,7 +271,7 @@ TEST(ValidateProtocolJSON, MissingDirectionIsError) {
 }
 
 TEST(ValidateProtocolJSON, InvalidTransportIsError) {
-    json j = { {"id","abc"}, {"name","Test"}, {"transport","serial"}, {"direction","output"} };
+    json j = { {"id","abc"}, {"name","Test"}, {"transport","serial"}, {"direction","send"} };
     auto r = ProtocolValidator::ValidateProtocolJSON(j);
     EXPECT_FALSE(r.IsValid());
 }
@@ -282,9 +282,19 @@ TEST(ValidateProtocolJSON, InvalidDirectionIsError) {
     EXPECT_FALSE(r.IsValid());
 }
 
+TEST(ValidateProtocolJSON, LegacyOutputInputDirectionStillValid) {
+    // Files exported by older builds use "output"/"input" instead of the
+    // current "send"/"receive" - both must keep validating.
+    json outJ = { {"id","abc"}, {"name","Test"}, {"transport","osc"}, {"direction","output"} };
+    EXPECT_TRUE(ProtocolValidator::ValidateProtocolJSON(outJ).IsValid());
+
+    json inJ = { {"id","abc"}, {"name","Test"}, {"transport","osc"}, {"direction","input"} };
+    EXPECT_TRUE(ProtocolValidator::ValidateProtocolJSON(inJ).IsValid());
+}
+
 TEST(ValidateProtocolJSON, ValidMinimalOSCIsValid) {
     json j = {
-        {"id","abc"}, {"name","Test"}, {"transport","osc"}, {"direction","output"},
+        {"id","abc"}, {"name","Test"}, {"transport","osc"}, {"direction","send"},
         {"oscHost","127.0.0.1"}, {"oscSendPort",9066}, {"fields", json::array()}
     };
     auto r = ProtocolValidator::ValidateProtocolJSON(j);
@@ -293,7 +303,7 @@ TEST(ValidateProtocolJSON, ValidMinimalOSCIsValid) {
 
 TEST(ValidateProtocolJSON, ValidMinimalWebSocketIsValid) {
     json j = {
-        {"id","abc"}, {"name","Test"}, {"transport","websocket"}, {"direction","input"},
+        {"id","abc"}, {"name","Test"}, {"transport","websocket"}, {"direction","receive"},
         {"wssPort",4269}, {"fields", json::array()}
     };
     auto r = ProtocolValidator::ValidateProtocolJSON(j);
@@ -302,7 +312,7 @@ TEST(ValidateProtocolJSON, ValidMinimalWebSocketIsValid) {
 
 TEST(ValidateProtocolJSON, MissingOSCHostProducesWarningNotError) {
     json j = {
-        {"id","abc"}, {"name","Test"}, {"transport","osc"}, {"direction","output"},
+        {"id","abc"}, {"name","Test"}, {"transport","osc"}, {"direction","send"},
         {"fields", json::array()}
     };
     auto r = ProtocolValidator::ValidateProtocolJSON(j);
@@ -312,7 +322,7 @@ TEST(ValidateProtocolJSON, MissingOSCHostProducesWarningNotError) {
 
 TEST(ValidateProtocolJSON, EmptyFieldsArrayProducesWarning) {
     json j = {
-        {"id","abc"}, {"name","Test"}, {"transport","osc"}, {"direction","output"},
+        {"id","abc"}, {"name","Test"}, {"transport","osc"}, {"direction","send"},
         {"oscHost","127.0.0.1"}, {"oscSendPort",9066},
         {"fields", json::array()}
     };
@@ -330,7 +340,7 @@ TEST(ValidateProtocolDefinition, ValidOSCDefinitionPasses) {
     def.id        = "test-osc";
     def.name      = "Test OSC";
     def.transport = ProtocolTransport::OSC;
-    def.direction = ProtocolDirection::Output;
+    def.direction = ProtocolDirection::Send;
     def.oscHost   = "127.0.0.1";
     def.oscSendPort = 9066;
 
@@ -343,7 +353,7 @@ TEST(ValidateProtocolDefinition, ValidWebSocketDefinitionPasses) {
     def.id        = "test-ws";
     def.name      = "Test WS";
     def.transport = ProtocolTransport::WebSocket;
-    def.direction = ProtocolDirection::Input;
+    def.direction = ProtocolDirection::Receive;
     def.wssPort   = 4269;
 
     auto r = ProtocolValidator::ValidateProtocolDefinition(def);
@@ -355,7 +365,7 @@ TEST(ValidateProtocolDefinition, InvalidPortIsError) {
     def.id        = "bad-port";
     def.name      = "Bad Port";
     def.transport = ProtocolTransport::OSC;
-    def.direction = ProtocolDirection::Output;
+    def.direction = ProtocolDirection::Send;
     def.oscHost   = "127.0.0.1";
     def.oscSendPort = 0;  // invalid
 
@@ -368,7 +378,7 @@ TEST(ValidateProtocolDefinition, EmptyIdIsError) {
     def.id        = "";  // empty
     def.name      = "No ID";
     def.transport = ProtocolTransport::WebSocket;
-    def.direction = ProtocolDirection::Output;
+    def.direction = ProtocolDirection::Send;
     def.wssPort   = 4269;
 
     auto r = ProtocolValidator::ValidateProtocolDefinition(def);


### PR DESCRIPTION
Implement DualSense adaptive trigger integration and normalize OSC protocol naming

### Added
- DualSense adaptive trigger support to haptic parser, effect dispatcher, and receive protocol catalog.
- Dedicated adaptive trigger testing UI, OSC handlers, path parsing, and an output panel toggle.
- `StopAll` method for gamepad haptics and adaptive trigger effects.
- Mutex protection to secure adaptive trigger effect calls.
- Versioned built-in field catalog cache validation with an auto-file-replace mechanism.
- Global toggles for valid and invalid OSC log messages.
- Comprehensive test coverage for all new adaptive trigger functionality.
- New beta tester to the about page.

### Changed / Improved
- Renamed "input" and "output" directional paths to "send" and "receive" across OSC and WebSocket protocols. (Merge PR #42)
  - Reads and validations still accept legacy "input"/"output" strings to preserve backward compatibility for existing config and protocol files.
- Normalized OSC path formats across all haptic effects and adaptive trigger classes.
- Reworked Protocol Editor customization: custom paths are used if explicitly set; otherwise, they fall back to the new default nested address.
- Added an OSC path reset button and updated customization handling in the protocol editor.
- Configured adaptive trigger effects to automatically reset on application start and end.

### Removed
- External built-in JSON cache file integration (migrated to versioned built-in field catalog cache).