### PR TITLE
Advanced adaptive trigger

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,13 @@ set(WITH_STATIC ON CACHE BOOL "Enable liblo static lib" FORCE)
 set(WITH_SHARED OFF CACHE BOOL "Disable liblo shared lib" FORCE)
 
 # liblo's CMakeLists.txt is located in the 'cmake' subdirectory
+# CMP0218 (CMake >= 4.x): CMAKE_WARN_DEPRECATED/CMAKE_ERROR_DEPRECATED variables
+# are ignored unless this policy is explicitly OLD. We still rely on the
+# variable-based suppression below, so opt into OLD explicitly rather than
+# leaving the policy unset (which just warns while still behaving as OLD).
+if(POLICY CMP0218)
+    cmake_policy(SET CMP0218 OLD)
+endif()
 if(DEFINED CMAKE_WARN_DEPRECATED)
     set(CMAKE_WARN_DEPRECATED_OLD ${CMAKE_WARN_DEPRECATED})
 else()

--- a/src/Haptics/DualSenseController.cpp
+++ b/src/Haptics/DualSenseController.cpp
@@ -223,6 +223,21 @@ bool DualSenseController::ApplyTriggerEffect(uint8_t* triggerData,
         uint8_t frequency = getParam("frequency", 10, 0, 255);
         return ExtendInput::DataTools::DualSense::DualSenseTriggerEffectGenerator::Vibration(triggerData, 0, position, amplitude, frequency);
     }
+    else if (effectType == "multi_position_feedback") {
+        uint8_t strengths[10];
+        for (int i = 0; i < 10; ++i) {
+            strengths[i] = getParam("strength_" + std::to_string(i), 0, 0, 8);
+        }
+        return ExtendInput::DataTools::DualSense::DualSenseTriggerEffectGenerator::MultiplePositionFeedback(triggerData, 0, strengths);
+    }
+    else if (effectType == "multi_position_vibration") {
+        uint8_t frequency = getParam("frequency", 10, 0, 255);
+        uint8_t amplitudes[10];
+        for (int i = 0; i < 10; ++i) {
+            amplitudes[i] = getParam("amplitude_" + std::to_string(i), 0, 0, 8);
+        }
+        return ExtendInput::DataTools::DualSense::DualSenseTriggerEffectGenerator::MultiplePositionVibration(triggerData, 0, frequency, amplitudes);
+    }
     else if (effectType == "slope_feedback") {
         uint8_t startPos      = getParam("start_position", 0, 0, 8);
         uint8_t endPos        = getParam("end_position", 9, 0, 9);

--- a/src/Haptics/DualSenseController.cpp
+++ b/src/Haptics/DualSenseController.cpp
@@ -230,14 +230,6 @@ bool DualSenseController::ApplyTriggerEffect(uint8_t* triggerData,
         }
         return ExtendInput::DataTools::DualSense::DualSenseTriggerEffectGenerator::MultiplePositionFeedback(triggerData, 0, strengths);
     }
-    else if (effectType == "multi_position_vibration") {
-        uint8_t frequency = getParam("frequency", 10, 0, 255);
-        uint8_t amplitudes[10];
-        for (int i = 0; i < 10; ++i) {
-            amplitudes[i] = getParam("amplitude_" + std::to_string(i), 0, 0, 8);
-        }
-        return ExtendInput::DataTools::DualSense::DualSenseTriggerEffectGenerator::MultiplePositionVibration(triggerData, 0, frequency, amplitudes);
-    }
     else if (effectType == "slope_feedback") {
         uint8_t startPos      = getParam("start_position", 0, 0, 8);
         uint8_t endPos        = getParam("end_position", 9, 0, 9);
@@ -245,6 +237,14 @@ bool DualSenseController::ApplyTriggerEffect(uint8_t* triggerData,
         uint8_t endStrength   = getParam("end_strength", 8, 1, 8);
         return ExtendInput::DataTools::DualSense::DualSenseTriggerEffectGenerator::SlopeFeedback(triggerData, 0, startPos, endPos,
                                                           startStrength, endStrength);
+    }
+    else if (effectType == "multi_position_vibration") {
+        uint8_t frequency = getParam("frequency", 10, 0, 255);
+        uint8_t amplitudes[10];
+        for (int i = 0; i < 10; ++i) {
+            amplitudes[i] = getParam("amplitude_" + std::to_string(i), 0, 0, 8);
+        }
+        return ExtendInput::DataTools::DualSense::DualSenseTriggerEffectGenerator::MultiplePositionVibration(triggerData, 0, frequency, amplitudes);
     }
     else if (effectType == "bow") {
         uint8_t startPos = getParam("start_position", 0, 0, 8);

--- a/src/Haptics/DualSenseController.h
+++ b/src/Haptics/DualSenseController.h
@@ -133,6 +133,8 @@ public:
      * - "weapon": Two-stage trigger (gun simulation)
      * - "vibration": Vibration at trigger position
      * - "slope_feedback": Linearly interpolated resistance between two positions
+     * - "multi_position_feedback": Per-position resistance (10 independent strengths)
+     * - "multi_position_vibration": Per-position vibration (10 independent amplitudes)
      * - "bow": Bow tension and release
      * - "galloping": Rhythmic resistance pattern
      * - "machine": Complex vibration pattern

--- a/src/Haptics/GamepadHaptics.cpp
+++ b/src/Haptics/GamepadHaptics.cpp
@@ -23,12 +23,19 @@ void GamepadHaptics::StopAll() {
         PlayDualSenseTrigger("both", "off", {});
     }
 
+    // Zero both impulse trigger motors for the same reason - the base class
+    // only clears m_activeXboxTrigger for UI display, it never tells the
+    // controller hardware to stop the motors. No-op on non-Xbox controllers.
+    if (m_xbox) {
+        PlayXboxTrigger(0, 0, 0);
+    }
+
     // Clears rumble/constant/periodic/condition effects and their SDL
-    // effect IDs, plus the m_activeDualSenseTriggers tracking map. This
-    // runs asynchronously on the device's worker thread, so it's queued
-    // after (not before) the synchronous off-command above - otherwise the
-    // "off" entry PlayDualSenseTrigger just recorded could be cleared out
-    // of order and leave a stale entry in the tracking map.
+    // effect IDs, plus the m_activeDualSenseTriggers/m_activeXboxTrigger
+    // tracking state. This runs asynchronously on the device's worker
+    // thread, so it's queued after (not before) the synchronous off-commands
+    // above - otherwise the entries just recorded could be cleared out of
+    // order and leave stale entries in the tracking state.
     HapticDevice::StopAll();
 }
 
@@ -382,4 +389,27 @@ int GamepadHaptics::SendXboxImpulseTrigger(uint8_t leftIntensity,
     }
 
     return m_xbox->SetImpulseTriggers(leftIntensity, rightIntensity, durationMs);
+}
+
+int GamepadHaptics::PlayXboxTrigger(uint8_t left_intensity, uint8_t right_intensity, uint32_t duration_ms) {
+    if (!m_xbox) {
+        LOG_WARN(kTag, "PlayXboxTrigger - Not an Xbox controller");
+        return -1;
+    }
+
+    int result = m_xbox->SetImpulseTriggers(left_intensity, right_intensity, static_cast<uint16_t>(duration_ms));
+    if (result == 0) {
+        std::lock_guard<std::mutex> lock(m_activeEffectsMutex);
+        m_activeXboxTrigger.active          = (left_intensity != 0 || right_intensity != 0);
+        m_activeXboxTrigger.left_intensity  = left_intensity;
+        m_activeXboxTrigger.right_intensity = right_intensity;
+        m_activeXboxTrigger.duration_ms     = duration_ms;
+        m_activeXboxTrigger.last_updated    = SDL_GetTicks();
+    }
+    return result;
+}
+
+ActiveXboxTriggerInfo GamepadHaptics::GetActiveXboxTrigger() {
+    std::lock_guard<std::mutex> lock(m_activeEffectsMutex);
+    return m_activeXboxTrigger;
 }

--- a/src/Haptics/GamepadHaptics.h
+++ b/src/Haptics/GamepadHaptics.h
@@ -82,12 +82,14 @@ public:
 
     /**
      * @brief Advertise gamepad capabilities: rumble always; adaptive triggers
-     *        only when a DualSense is connected.
+     *        only when a DualSense is connected; impulse triggers only when
+     *        an Xbox controller is connected.
      */
     HapticCapabilities caps() const override {
         HapticCapabilities c;
         c.rumble           = true;
         c.adaptiveTriggers = IsDualSense();
+        c.impulseTriggers  = IsXboxController();
         return c;
     }
 
@@ -147,6 +149,22 @@ public:
     int SendXboxImpulseTrigger(uint8_t leftIntensity,
                               uint8_t rightIntensity,
                               uint32_t durationMs);
+
+    /**
+     * @brief HapticDevice virtual override for Xbox impulse triggers.
+     *
+     * Only works on Xbox controllers. Silently ignored on other controllers.
+     * Delegates to SendXboxImpulseTrigger() and tracks active state for
+     * network dispatch (OutputMapper/HapticDispatcher) and UI display.
+     */
+    int PlayXboxTrigger(uint8_t left_intensity, uint8_t right_intensity, uint32_t duration_ms) override;
+
+    /**
+     * @brief Get the currently active Xbox impulse trigger state.
+     * @return ActiveXboxTriggerInfo with active=false if no effect is playing
+     *         or this isn't an Xbox controller.
+     */
+    ActiveXboxTriggerInfo GetActiveXboxTrigger() override;
 
     // ==================== Controller Detection ====================
 

--- a/src/Haptics/HapticDevice.cpp
+++ b/src/Haptics/HapticDevice.cpp
@@ -284,6 +284,7 @@ int HapticDevice::PlayPeriodic(int slot, HapticPeriodicType wave_type, float str
 int HapticDevice::PlayRumble(int slot, float large_magnitude, float small_magnitude, uint32_t duration_ms) { return -1; }
 int HapticDevice::PlayCondition(int slot, HapticConditionType type, float right_sat, float left_sat, float right_coeff, float left_coeff, float deadband, float center, uint32_t duration_ms) { return -1; }
 int HapticDevice::PlayDualSenseTrigger(const std::string& trigger, const std::string& effect_type, const std::map<std::string, int>& params) { return -1; }
+int HapticDevice::PlayXboxTrigger(uint8_t left_intensity, uint8_t right_intensity, uint32_t duration_ms) { return -1; }
 
 // --- Stop Methods (base stubs) ---
 
@@ -317,6 +318,11 @@ std::map<int, ActiveRumbleInfo> HapticDevice::GetActiveRumbles() {
 std::map<std::string, ActiveDualSenseTriggerInfo> HapticDevice::GetActiveDualSenseTriggers() {
     std::lock_guard<std::mutex> lock(m_activeEffectsMutex);
     return m_activeDualSenseTriggers;
+}
+
+ActiveXboxTriggerInfo HapticDevice::GetActiveXboxTrigger() {
+    std::lock_guard<std::mutex> lock(m_activeEffectsMutex);
+    return m_activeXboxTrigger;
 }
 
 // --- Internal steering-wheel helpers (use kInternalSlot = -1 to avoid
@@ -501,6 +507,7 @@ void HapticDevice::StopAll() {
             m_activeConditions.clear();
             m_activeRumbles.clear();
             m_activeDualSenseTriggers.clear();
+            m_activeXboxTrigger = ActiveXboxTriggerInfo{};
         }
 
         SDL_StopHapticEffects(m_haptic.Get());

--- a/src/Haptics/HapticDevice.h
+++ b/src/Haptics/HapticDevice.h
@@ -146,6 +146,7 @@ struct HapticCapabilities {
     bool rumble          = false;  ///< Dual-motor gamepad rumble
     bool forceFeedback   = false;  ///< Constant / periodic / condition FF (wheel, flight stick)
     bool adaptiveTriggers= false;  ///< DualSense adaptive trigger effects
+    bool impulseTriggers = false;  ///< Xbox impulse trigger motors
     bool gainControl     = false;  ///< Per-device haptic gain (steering wheel, flight stick)
 };
 
@@ -192,6 +193,14 @@ struct ActiveRumbleInfo {
 struct ActiveDualSenseTriggerInfo {
     std::string effect_type;
     std::map<std::string, int> params;
+    uint64_t last_updated = 0;
+};
+
+struct ActiveXboxTriggerInfo {
+    bool active = false;
+    uint8_t left_intensity = 0;
+    uint8_t right_intensity = 0;
+    uint32_t duration_ms = 0;
     uint64_t last_updated = 0;
 };
 
@@ -246,6 +255,7 @@ public:
     virtual int StopCondition(int slot);
 
     virtual int PlayDualSenseTrigger(const std::string& trigger, const std::string& effect_type, const std::map<std::string, int>& params);
+    virtual int PlayXboxTrigger(uint8_t left_intensity, uint8_t right_intensity, uint32_t duration_ms);
 
     // --- State Getters (per-slot maps) ---
     virtual std::map<int, ActiveConstantInfo>  GetActiveConstants();
@@ -253,6 +263,7 @@ public:
     virtual std::map<int, ActiveConditionInfo> GetActiveConditions();
     virtual std::map<int, ActiveRumbleInfo>    GetActiveRumbles();
     virtual std::map<std::string, ActiveDualSenseTriggerInfo> GetActiveDualSenseTriggers();
+    virtual ActiveXboxTriggerInfo GetActiveXboxTrigger();
 
     // Steering Wheel Effects
     // level: -1.0 to 1.0
@@ -292,6 +303,7 @@ protected:
     std::map<int, ActiveConditionInfo> m_activeConditions;
     std::map<int, ActiveRumbleInfo>    m_activeRumbles;
     std::map<std::string, ActiveDualSenseTriggerInfo> m_activeDualSenseTriggers; // "left", "right"
+    ActiveXboxTriggerInfo m_activeXboxTrigger;
 
     // Slot -> SDL effect ID maps for all effect types.
     std::map<int, SDL_HapticEffectID> m_constantEffects;

--- a/src/Mappers/InputMapping/MappingProfileStore.cpp
+++ b/src/Mappers/InputMapping/MappingProfileStore.cpp
@@ -99,6 +99,7 @@ void ParseHapticTargets(const json& data, MappingProfile& p) {
         t.enable_periodic = item.value("enable_periodic", true);
         t.enable_condition = item.value("enable_condition", true);
         t.enable_dualsense_trigger = item.value("enable_dualsense_trigger", true);
+        t.enable_xbox_trigger = item.value("enable_xbox_trigger", true);
         p.hapticTargets.push_back(t);
     }
 }
@@ -229,6 +230,7 @@ void SerializeHapticTargets(const MappingProfile& profile, json& data) {
             {"enable_rumble", t.enable_rumble}, {"enable_constant", t.enable_constant},
             {"enable_periodic", t.enable_periodic}, {"enable_condition", t.enable_condition},
             {"enable_dualsense_trigger", t.enable_dualsense_trigger},
+            {"enable_xbox_trigger", t.enable_xbox_trigger},
         });
     }
 }

--- a/src/Mappers/InputMapping/MappingTypes.h
+++ b/src/Mappers/InputMapping/MappingTypes.h
@@ -28,6 +28,7 @@ struct HapticTarget {
     bool enable_periodic = true;
     bool enable_condition = true;
     bool enable_dualsense_trigger = true;
+    bool enable_xbox_trigger = true;
 
     // Cached Effect IDs
     int constant_effect_id = -1;

--- a/src/Mappers/OutputMapper.cpp
+++ b/src/Mappers/OutputMapper.cpp
@@ -284,6 +284,9 @@ void OutputMapper::Update() {
                                        cmd.iParams[6], cmd.iParams[7], cmd.iParams[8],
                                        cmd.iParams[9] & 0xFF, (cmd.iParams[9] >> 8) & 0xFF);
                 break;
+            case HapticCommand::XBOX_TRIGGER:
+                TriggerXboxTrigger(cmd.virtual_id, cmd.iParams[0], cmd.iParams[1], cmd.iParams[2]);
+                break;
         }
     }
 
@@ -525,6 +528,19 @@ void OutputMapper::QueueDualSenseTrigger(int virtual_id, const char* trigger, co
     cmd.iParams[7] = second_foot;
     cmd.iParams[8] = period;
     cmd.iParams[9] = (amplitude_a & 0xFF) | ((amplitude_b & 0xFF) << 8);
+    QueueCommand(std::move(cmd));
+}
+
+void OutputMapper::QueueXboxTrigger(int virtual_id, int left_intensity, int right_intensity, int duration_ms) {
+    if (left_intensity > 0 || right_intensity > 0) {
+        m_lastHapticActivityTime = SDL_GetTicks();
+    }
+    HapticCommand cmd;
+    cmd.type = HapticCommand::XBOX_TRIGGER;
+    cmd.virtual_id = virtual_id;
+    cmd.iParams[0] = left_intensity;
+    cmd.iParams[1] = right_intensity;
+    cmd.iParams[2] = duration_ms;
     QueueCommand(std::move(cmd));
 }
 
@@ -814,5 +830,23 @@ void OutputMapper::TriggerDualSenseMultiPositionVibration(int virtual_id, const 
         }
 
         hapticDevice->PlayDualSenseTrigger(trigger, "multi_position_vibration", params);
+    }
+}
+
+void OutputMapper::TriggerXboxTrigger(int virtual_id, int left_intensity, int right_intensity, int duration_ms) {
+    std::vector<HapticTarget*> targets;
+    GetTargets(virtual_id, targets);
+    for (auto* target : targets) {
+        if (!target || target->instance_id == 0) continue;
+        if (!target->enable_xbox_trigger) continue;
+
+        auto* hapticDevice = m_DeviceManager.GetHapticDevice(target->instance_id);
+        if (!hapticDevice) continue;
+
+        uint8_t left  = static_cast<uint8_t>(std::clamp(left_intensity, 0, 255));
+        uint8_t right = static_cast<uint8_t>(std::clamp(right_intensity, 0, 255));
+        uint32_t duration = (duration_ms < 0) ? 0 : static_cast<uint32_t>(duration_ms);
+
+        hapticDevice->PlayXboxTrigger(left, right, duration);
     }
 }

--- a/src/Mappers/OutputMapper.cpp
+++ b/src/Mappers/OutputMapper.cpp
@@ -286,6 +286,23 @@ void OutputMapper::Update() {
                 break;
         }
     }
+
+    std::vector<DualSenseArrayCommand> arrayQueue;
+    {
+        std::lock_guard<std::mutex> lock(m_ArrayMutex);
+        arrayQueue.swap(m_ArrayCommandQueue);
+    }
+
+    for (const auto& cmd : arrayQueue) {
+        switch (cmd.type) {
+            case DualSenseArrayCommand::MULTI_POSITION_FEEDBACK:
+                TriggerDualSenseMultiPositionFeedback(cmd.virtual_id, cmd.trigger, cmd.values);
+                break;
+            case DualSenseArrayCommand::MULTI_POSITION_VIBRATION:
+                TriggerDualSenseMultiPositionVibration(cmd.virtual_id, cmd.trigger, cmd.frequency, cmd.values);
+                break;
+        }
+    }
 }
 
 void OutputMapper::StopAllHapticEffects()
@@ -411,6 +428,11 @@ void OutputMapper::QueueCommand(HapticCommand&& cmd) {
     m_CommandQueue.push_back(std::move(cmd));
 }
 
+void OutputMapper::QueueArrayCommand(DualSenseArrayCommand&& cmd) {
+    std::lock_guard<std::mutex> lock(m_ArrayMutex);
+    m_ArrayCommandQueue.push_back(std::move(cmd));
+}
+
 void OutputMapper::QueueRumble(int virtual_id, int slot, float low_freq, float high_freq, int duration_ms) {
     if (low_freq > 0.0f || high_freq > 0.0f) {
         m_lastHapticActivityTime = SDL_GetTicks();
@@ -504,6 +526,30 @@ void OutputMapper::QueueDualSenseTrigger(int virtual_id, const char* trigger, co
     cmd.iParams[8] = period;
     cmd.iParams[9] = (amplitude_a & 0xFF) | ((amplitude_b & 0xFF) << 8);
     QueueCommand(std::move(cmd));
+}
+
+void OutputMapper::QueueDualSenseMultiPositionFeedback(int virtual_id, const char* trigger, const uint8_t strengths[10]) {
+    m_lastHapticActivityTime = SDL_GetTicks();
+    DualSenseArrayCommand cmd;
+    cmd.type = DualSenseArrayCommand::MULTI_POSITION_FEEDBACK;
+    cmd.virtual_id = virtual_id;
+    std::strncpy(cmd.trigger, trigger, sizeof(cmd.trigger) - 1);
+    cmd.trigger[sizeof(cmd.trigger) - 1] = '\0';
+    cmd.frequency = 0; // unused for feedback
+    std::memcpy(cmd.values, strengths, 10);
+    QueueArrayCommand(std::move(cmd));
+}
+
+void OutputMapper::QueueDualSenseMultiPositionVibration(int virtual_id, const char* trigger, uint8_t frequency, const uint8_t amplitudes[10]) {
+    m_lastHapticActivityTime = SDL_GetTicks();
+    DualSenseArrayCommand cmd;
+    cmd.type = DualSenseArrayCommand::MULTI_POSITION_VIBRATION;
+    cmd.virtual_id = virtual_id;
+    std::strncpy(cmd.trigger, trigger, sizeof(cmd.trigger) - 1);
+    cmd.trigger[sizeof(cmd.trigger) - 1] = '\0';
+    cmd.frequency = frequency;
+    std::memcpy(cmd.values, amplitudes, 10);
+    QueueArrayCommand(std::move(cmd));
 }
 
 // --- Trigger Implementations ---
@@ -729,5 +775,44 @@ void OutputMapper::TriggerDualSenseTrigger(int virtual_id, const char* trigger, 
         params["amplitude_b"] = amplitude_b;
 
         hapticDevice->PlayDualSenseTrigger(trigger, effect_type, params);
+    }
+}
+
+void OutputMapper::TriggerDualSenseMultiPositionFeedback(int virtual_id, const char* trigger, const uint8_t* strengths) {
+    std::vector<HapticTarget*> targets;
+    GetTargets(virtual_id, targets);
+    for (auto* target : targets) {
+        if (!target || target->instance_id == 0) continue;
+        if (!target->enable_dualsense_trigger) continue;
+
+        auto* hapticDevice = m_DeviceManager.GetHapticDevice(target->instance_id);
+        if (!hapticDevice) continue;
+
+        std::map<std::string, int> params;
+        for (int i = 0; i < 10; ++i) {
+            params["strength_" + std::to_string(i)] = strengths[i];
+        }
+
+        hapticDevice->PlayDualSenseTrigger(trigger, "multi_position_feedback", params);
+    }
+}
+
+void OutputMapper::TriggerDualSenseMultiPositionVibration(int virtual_id, const char* trigger, uint8_t frequency, const uint8_t* amplitudes) {
+    std::vector<HapticTarget*> targets;
+    GetTargets(virtual_id, targets);
+    for (auto* target : targets) {
+        if (!target || target->instance_id == 0) continue;
+        if (!target->enable_dualsense_trigger) continue;
+
+        auto* hapticDevice = m_DeviceManager.GetHapticDevice(target->instance_id);
+        if (!hapticDevice) continue;
+
+        std::map<std::string, int> params;
+        params["frequency"] = frequency;
+        for (int i = 0; i < 10; ++i) {
+            params["amplitude_" + std::to_string(i)] = amplitudes[i];
+        }
+
+        hapticDevice->PlayDualSenseTrigger(trigger, "multi_position_vibration", params);
     }
 }

--- a/src/Mappers/OutputMapper.h
+++ b/src/Mappers/OutputMapper.h
@@ -22,6 +22,7 @@
 #include <memory>
 #include <mutex>
 #include <atomic>
+#include <cstdint>
 #include <SDL3/SDL.h>
 #include "Devices/DeviceManager.h"
 
@@ -34,6 +35,21 @@ struct HapticCommand {
     float fParams[8]; // Generic float storage
     int iParams[10];  // Generic int storage - increased for more params
     char sParams[2][32]; // String params: [0]=trigger ("left"/"right"/"both"), [1]=effect_type
+};
+
+// DualSense adaptive trigger effects that carry a 10-element per-position array
+// (MultiplePositionFeedback/MultiplePositionVibration) don't fit HapticCommand's
+// fixed 10-slot iParams - those are already fully used by the scalar-only
+// DualSense effects (feedback/weapon/vibration/slope_feedback/bow/galloping/
+// machine, see QueueDualSenseTrigger). Rather than growing iParams (which would
+// affect every other effect type's marshaling), these two get their own small,
+// dedicated queue.
+struct DualSenseArrayCommand {
+    enum Type { MULTI_POSITION_FEEDBACK, MULTI_POSITION_VIBRATION } type;
+    int virtual_id;
+    char trigger[8];     // "left" / "right" / "both"
+    uint8_t frequency;   // only used by MULTI_POSITION_VIBRATION
+    uint8_t values[10];  // per-position strength (feedback) or amplitude (vibration)
 };
 
 class OutputMapper {
@@ -70,6 +86,10 @@ public:
                                int amplitude, int frequency, int snap_force,
                                int first_foot, int second_foot, int period,
                                int amplitude_a, int amplitude_b);
+    // Array-based DualSense effects - see DualSenseArrayCommand above for why
+    // these bypass QueueDualSenseTrigger/HapticCommand.
+    void QueueDualSenseMultiPositionFeedback(int virtual_id, const char* trigger, const uint8_t strengths[10]);
+    void QueueDualSenseMultiPositionVibration(int virtual_id, const char* trigger, uint8_t frequency, const uint8_t amplitudes[10]);
 
 private:
     OutputMapper(const DeviceManager& deviceManager);
@@ -83,9 +103,13 @@ private:
     std::mutex m_Mutex;
     std::vector<HapticCommand> m_CommandQueue;
 
+    std::mutex m_ArrayMutex;
+    std::vector<DualSenseArrayCommand> m_ArrayCommandQueue;
+
     std::atomic<uint64_t> m_lastHapticActivityTime{0};
 
     void QueueCommand(HapticCommand&& cmd);
+    void QueueArrayCommand(DualSenseArrayCommand&& cmd);
     void GetTargets(int virtual_id, std::vector<HapticTarget*>& out_targets);
     void UpdateHapticDevice(HapticTarget& target);
     void CloseHapticDevice(HapticTarget& target);
@@ -101,4 +125,6 @@ private:
                                  int amplitude, int frequency, int snap_force,
                                  int first_foot, int second_foot, int period,
                                  int amplitude_a, int amplitude_b);
+    void TriggerDualSenseMultiPositionFeedback(int virtual_id, const char* trigger, const uint8_t* strengths);
+    void TriggerDualSenseMultiPositionVibration(int virtual_id, const char* trigger, uint8_t frequency, const uint8_t* amplitudes);
 };

--- a/src/Mappers/OutputMapper.h
+++ b/src/Mappers/OutputMapper.h
@@ -9,6 +9,7 @@
 // • Supports multiple force-feedback effect types, including rumble,
 //   constant force, periodic effects, condition effects, and gain control.
 // • Provides DualSense adaptive trigger effect support.
+// • Provides Xbox impulse trigger effect support.
 // • Exposes a thread-safe API for servers and background systems to
 //   generate haptic feedback.
 // • Tracks haptic activity state and offers runtime controls for
@@ -30,7 +31,7 @@ struct HapticTarget;
 class PreferencesManager;
 
 struct HapticCommand {
-    enum Type { RUMBLE, CONSTANT, PERIODIC, CONDITION, GAIN, DUALSENSE_TRIGGER } type;
+    enum Type { RUMBLE, CONSTANT, PERIODIC, CONDITION, GAIN, DUALSENSE_TRIGGER, XBOX_TRIGGER } type;
     int virtual_id;
     float fParams[8]; // Generic float storage
     int iParams[10];  // Generic int storage - increased for more params
@@ -90,6 +91,7 @@ public:
     // these bypass QueueDualSenseTrigger/HapticCommand.
     void QueueDualSenseMultiPositionFeedback(int virtual_id, const char* trigger, const uint8_t strengths[10]);
     void QueueDualSenseMultiPositionVibration(int virtual_id, const char* trigger, uint8_t frequency, const uint8_t amplitudes[10]);
+    void QueueXboxTrigger(int virtual_id, int left_intensity, int right_intensity, int duration_ms);
 
 private:
     OutputMapper(const DeviceManager& deviceManager);
@@ -127,4 +129,5 @@ private:
                                  int amplitude_a, int amplitude_b);
     void TriggerDualSenseMultiPositionFeedback(int virtual_id, const char* trigger, const uint8_t* strengths);
     void TriggerDualSenseMultiPositionVibration(int virtual_id, const char* trigger, uint8_t frequency, const uint8_t* amplitudes);
+    void TriggerXboxTrigger(int virtual_id, int left_intensity, int right_intensity, int duration_ms);
 };

--- a/src/Network/HapticDispatcher.cpp
+++ b/src/Network/HapticDispatcher.cpp
@@ -1,6 +1,7 @@
 #include "HapticDispatcher.h"
 #include "Haptics/HapticDevice.h"
 #include "../Mappers/OutputMapper.h"
+#include <cstdint>
 
 void HapticDispatcher::DispatchRumble(lo_arg** argv, int argc, OutputMapper* mapper)
 {
@@ -130,6 +131,34 @@ void HapticDispatcher::DispatchDualSenseVibration(lo_arg** argv, int argc, Outpu
                                    amplitude, frequency, /*snap_force*/0,
                                    /*first_foot*/0, /*second_foot*/0, /*period*/0,
                                    /*amplitude_a*/0, /*amplitude_b*/0);
+}
+
+void HapticDispatcher::DispatchDualSenseMultiPositionFeedback(lo_arg** argv, int argc, OutputMapper* mapper, const char* trigger)
+{
+    if (!mapper || argc < 11) return;
+    for (int i = 0; i < 11; ++i) { if (!argv[i]) return; }
+    const int id = argv[0]->i;
+    uint8_t strengths[10];
+    for (int i = 0; i < 10; ++i) {
+        int v = argv[i + 1]->i;
+        strengths[i] = static_cast<uint8_t>(v < 0 ? 0 : (v > 255 ? 255 : v));
+    }
+    mapper->QueueDualSenseMultiPositionFeedback(id, trigger, strengths);
+}
+
+void HapticDispatcher::DispatchDualSenseMultiPositionVibration(lo_arg** argv, int argc, OutputMapper* mapper, const char* trigger)
+{
+    if (!mapper || argc < 12) return;
+    for (int i = 0; i < 12; ++i) { if (!argv[i]) return; }
+    const int id = argv[0]->i;
+    int freq = argv[1]->i;
+    uint8_t frequency = static_cast<uint8_t>(freq < 0 ? 0 : (freq > 255 ? 255 : freq));
+    uint8_t amplitudes[10];
+    for (int i = 0; i < 10; ++i) {
+        int v = argv[i + 2]->i;
+        amplitudes[i] = static_cast<uint8_t>(v < 0 ? 0 : (v > 255 ? 255 : v));
+    }
+    mapper->QueueDualSenseMultiPositionVibration(id, trigger, frequency, amplitudes);
 }
 
 void HapticDispatcher::DispatchDualSenseSlopeFeedback(lo_arg** argv, int argc, OutputMapper* mapper, const char* trigger)

--- a/src/Network/HapticDispatcher.cpp
+++ b/src/Network/HapticDispatcher.cpp
@@ -88,6 +88,17 @@ void HapticDispatcher::DispatchGain(lo_arg** argv, int argc, OutputMapper* mappe
     mapper->QueueSetGain(id, gain);
 }
 
+void HapticDispatcher::DispatchXboxTrigger(lo_arg** argv, int argc, OutputMapper* mapper)
+{
+    if (!mapper || argc < 4) return;
+    for (int i = 0; i < 4; ++i) { if (!argv[i]) return; }
+    const int id              = argv[0]->i;
+    const int left_intensity  = argv[1]->i;
+    const int right_intensity = argv[2]->i;
+    const int duration        = argv[3]->i;
+    mapper->QueueXboxTrigger(id, left_intensity, right_intensity, duration);
+}
+
 void HapticDispatcher::DispatchDualSenseFeedback(lo_arg** argv, int argc, OutputMapper* mapper, const char* trigger)
 {
     if (!mapper || argc < 3) return;

--- a/src/Network/HapticDispatcher.h
+++ b/src/Network/HapticDispatcher.h
@@ -25,6 +25,8 @@ class OutputMapper;
  *   feedback   iii       id, position, strength
  *   weapon     iiii      id, start_position, end_position, strength
  *   vibration  iiii      id, position, amplitude, frequency
+ *   multi_position_feedback  iiiiiiiiiii  id, strength_0..strength_9
+ *   multi_position_vibration iiiiiiiiiiii id, frequency, amplitude_0..amplitude_9
  *   slope_feedback iiiii id, start_position, end_position, start_strength, end_strength
  *   bow        iiiii     id, start_position, end_position, strength, snap_force
  *   galloping  iiiiii    id, start_position, end_position, first_foot, second_foot, frequency
@@ -100,6 +102,20 @@ public:
      * Accepted format:  iiii  (id, position, amplitude, frequency)
      */
     static void DispatchDualSenseVibration(lo_arg** argv, int argc, OutputMapper* mapper, const char* trigger);
+
+    /**
+     * @brief Parse a DualSense adaptive trigger "multi_position_feedback" message and queue it.
+     *
+     * Accepted format:  iiiiiiiiiii  (id, strength_0..strength_9)
+     */
+    static void DispatchDualSenseMultiPositionFeedback(lo_arg** argv, int argc, OutputMapper* mapper, const char* trigger);
+
+    /**
+     * @brief Parse a DualSense adaptive trigger "multi_position_vibration" message and queue it.
+     *
+     * Accepted format:  iiiiiiiiiiii  (id, frequency, amplitude_0..amplitude_9)
+     */
+    static void DispatchDualSenseMultiPositionVibration(lo_arg** argv, int argc, OutputMapper* mapper, const char* trigger);
 
     /**
      * @brief Parse a DualSense adaptive trigger "slope_feedback" message and queue it.

--- a/src/Network/HapticDispatcher.h
+++ b/src/Network/HapticDispatcher.h
@@ -18,6 +18,7 @@ class OutputMapper;
  * Condition iiiffffffi id, slot, ctype, right_sat, left_sat, right_coeff,
  *                      left_coeff, deadband, center, duration_ms
  * Gain      ii      id, gain
+ * Xbox      iiii    id, left_intensity, right_intensity, duration_ms
  *
  * DualSense adaptive trigger effects arrive on one fixed OSC path per
  * side x effect (see DispatchDualSense* below), each carrying only the
@@ -79,6 +80,13 @@ public:
      * Accepted format:  ii  (id, gain 0–100)
      */
     static void DispatchGain(lo_arg** argv, int argc, OutputMapper* mapper);
+
+    /**
+     * @brief Parse an Xbox impulse trigger message and queue it.
+     *
+     * Accepted format:  iiii  (id, left_intensity, right_intensity, duration_ms)
+     */
+    static void DispatchXboxTrigger(lo_arg** argv, int argc, OutputMapper* mapper);
 
     /**
      * @brief Parse a DualSense adaptive trigger "feedback" message and queue it.

--- a/src/Network/HapticParser.cpp
+++ b/src/Network/HapticParser.cpp
@@ -2,6 +2,7 @@
 #include "../Mappers/OutputMapper.h"
 #include <nlohmann/json.hpp>
 #include <SDL3/SDL_haptic.h>
+#include <cstdint>
 
 namespace {
     // JSON keys for haptic commands
@@ -66,6 +67,15 @@ namespace {
     const char* const kDSAmplitudeB   = "amplitude_b";
     // Note: DualSense "strength" and "period" reuse kConstantStrength / kPeriodicPeriod
     // below since the JSON key text is identical for those fields.
+
+    // Array-based DualSense effects (10-element per-position arrays). These
+    // bypass QueueDualSenseTrigger/HapticCommand entirely - see
+    // OutputMapper::DualSenseArrayCommand for why - so they get their own
+    // JSON array fields rather than reusing the scalar keys above.
+    const char* const kEffectTypeMultiPositionFeedback  = "multi_position_feedback";
+    const char* const kEffectTypeMultiPositionVibration = "multi_position_vibration";
+    const char* const kDSStrengths  = "strengths";   // array[10], multi_position_feedback
+    const char* const kDSAmplitudes = "amplitudes";  // array[10], multi_position_vibration
 
     // Shared slot key used by all slotted effect types
     const char* const kSlot = "slot";
@@ -164,6 +174,33 @@ namespace {
     void dispatchDualSenseTrigger(const nlohmann::json& data, const std::string& trigger,
                                    const std::string& effect_type, int device, OutputMapper* mapper)
     {
+        // Array-based effects carry a JSON array of 10 per-position values
+        // rather than the scalar fields below - see OutputMapper's dedicated
+        // QueueDualSenseMultiPosition* methods.
+        if (effect_type == kEffectTypeMultiPositionFeedback) {
+            uint8_t strengths[10] = {0};
+            if (data.contains(kDSStrengths) && data[kDSStrengths].is_array()) {
+                const auto& arr = data[kDSStrengths];
+                for (size_t i = 0; i < 10 && i < arr.size(); ++i) {
+                    strengths[i] = static_cast<uint8_t>(arr[i].get<int>());
+                }
+            }
+            mapper->QueueDualSenseMultiPositionFeedback(device, trigger.c_str(), strengths);
+            return;
+        }
+        if (effect_type == kEffectTypeMultiPositionVibration) {
+            uint8_t amplitudes[10] = {0};
+            if (data.contains(kDSAmplitudes) && data[kDSAmplitudes].is_array()) {
+                const auto& arr = data[kDSAmplitudes];
+                for (size_t i = 0; i < 10 && i < arr.size(); ++i) {
+                    amplitudes[i] = static_cast<uint8_t>(arr[i].get<int>());
+                }
+            }
+            uint8_t frequency = static_cast<uint8_t>(data.value(kDSFrequency, 0));
+            mapper->QueueDualSenseMultiPositionVibration(device, trigger.c_str(), frequency, amplitudes);
+            return;
+        }
+
         // "position" is used by feedback/vibration; weapon/slope_feedback/bow/galloping/machine
         // use "start_position" instead (see OSCBaseProtocol's DualSense docs).
         // Prefer start_position when present so both naming conventions work.

--- a/src/Network/HapticParser.cpp
+++ b/src/Network/HapticParser.cpp
@@ -25,6 +25,7 @@ namespace {
     const char* const kEffectPeriodic  = "periodic";
     const char* const kEffectCondition = "condition";
     const char* const kEffectDualSenseTrigger = "dualsense_trigger";
+    const char* const kEffectXboxTrigger = "xbox_trigger";
 
     // Rumble params
     const char* const kRumbleLow      = "low";
@@ -67,6 +68,10 @@ namespace {
     const char* const kDSAmplitudeB   = "amplitude_b";
     // Note: DualSense "strength" and "period" reuse kConstantStrength / kPeriodicPeriod
     // below since the JSON key text is identical for those fields.
+
+    // Xbox impulse trigger params
+    const char* const kXboxLeftIntensity  = "left_intensity";
+    const char* const kXboxRightIntensity = "right_intensity";
 
     // Array-based DualSense effects (10-element per-position arrays). These
     // bypass QueueDualSenseTrigger/HapticCommand entirely - see
@@ -165,6 +170,12 @@ namespace {
                 data.value(kConditionDeadband,   0.0f),
                 data.value(kConditionCenter,     0.0f),
                 duration);
+        } else if (effect == kEffectXboxTrigger) {
+            int left_intensity  = data.value(kXboxLeftIntensity, 0);
+            int right_intensity = data.value(kXboxRightIntensity, 0);
+            int duration = get_duration(data);
+
+            mapper->QueueXboxTrigger(device, left_intensity, right_intensity, duration);
         }
     }
 
@@ -236,7 +247,15 @@ namespace {
             return DetectedEffect::Kind::DualSenseTrigger;
         }
 
-        // 2. Condition: distinguishing fields are the sat/coeff pair or condition_type.
+        // 2. Xbox impulse trigger: needs at least one of the intensity fields.
+        if (flat.contains(kXboxLeftIntensity) || flat.contains(kXboxRightIntensity)) {
+            out.left_intensity  = flat.value(kXboxLeftIntensity,  0);
+            out.right_intensity = flat.value(kXboxRightIntensity, 0);
+            out.duration_ms     = get_duration(flat);
+            return DetectedEffect::Kind::XboxTrigger;
+        }
+
+        // 3. Condition: distinguishing fields are the sat/coeff pair or condition_type.
         if (flat.contains(kConditionRightSat) || flat.contains(kConditionLeftSat)
                 || flat.contains(kConditionType)) {
             out.condition_type = ConditionTypeFromIndex(flat.value(kConditionType, 0));
@@ -251,7 +270,7 @@ namespace {
             return DetectedEffect::Kind::Condition;
         }
 
-        // 3. Periodic: "period" is the clearest signal; also accept "magnitude"+"offset"
+        // 4. Periodic: "period" is the clearest signal; also accept "magnitude"+"offset"
         //    together (to distinguish from constant which only has "strength").
         if (flat.contains(kPeriodicPeriod)
                 || (flat.contains(kPeriodicMagnitude) && flat.contains(kPeriodicOffset))) {
@@ -266,7 +285,7 @@ namespace {
             return DetectedEffect::Kind::Periodic;
         }
 
-        // 4. Constant: "strength" alone (no periodic sub-fields).
+        // 5. Constant: "strength" alone (no periodic sub-fields).
         if (flat.contains(kConstantStrength)) {
             out.strength    = flat.value(kConstantStrength, 0.0f);
             out.slot        = flat.value(kSlot, 0);
@@ -274,7 +293,7 @@ namespace {
             return DetectedEffect::Kind::Constant;
         }
 
-        // 5. Rumble: "low"/"high" aliases or "large_magnitude"/"small_magnitude".
+        // 6. Rumble: "low"/"high" aliases or "large_magnitude"/"small_magnitude".
         if (flat.contains(kRumbleLow) || flat.contains(kRumbleHigh)
                 || flat.contains(kRumbleLargeMag) || flat.contains(kRumbleSmallMag)) {
             out.low  = flat.contains(kRumbleLargeMag) ? flat.value(kRumbleLargeMag, 0.0f)
@@ -296,6 +315,7 @@ namespace {
             case DetectedEffect::Kind::Constant:  return kEffectConstant;
             case DetectedEffect::Kind::Periodic:  return kEffectPeriodic;
             case DetectedEffect::Kind::Condition: return kEffectCondition;
+            case DetectedEffect::Kind::XboxTrigger: return kEffectXboxTrigger;
             default:                              return "";
         }
     }
@@ -329,6 +349,7 @@ DetectedEffect HapticParser::AutoDetect(std::string_view message) {
             else if (explicit_effect == kEffectConstant)  out.kind = DetectedEffect::Kind::Constant;
             else if (explicit_effect == kEffectPeriodic)  out.kind = DetectedEffect::Kind::Periodic;
             else if (explicit_effect == kEffectCondition) out.kind = DetectedEffect::Kind::Condition;
+            else if (explicit_effect == kEffectXboxTrigger) out.kind = DetectedEffect::Kind::XboxTrigger;
         }
 
         if (out.kind == DetectedEffect::Kind::Unknown) {

--- a/src/Network/HapticParser.h
+++ b/src/Network/HapticParser.h
@@ -21,6 +21,7 @@ struct DetectedEffect {
         Periodic,
         Condition,
         DualSenseTrigger,
+        XboxTrigger,
     };
 
     Kind    kind    = Kind::Unknown;
@@ -54,6 +55,10 @@ struct DetectedEffect {
     // DualSense trigger
     std::string trigger;        // "left", "right", or "both"
     std::string effect_type;    // e.g. "feedback", "weapon", "vibration"
+
+    // Xbox impulse trigger
+    int left_intensity  = 0;
+    int right_intensity = 0;
 };
 
 class HapticParser {
@@ -77,10 +82,11 @@ public:
      *
      * Field priority (checked in order so the most-specific wins):
      *   1. DualSense trigger  - "trigger" + "effect_type"
-     *   2. Condition          - "right_sat" / "left_sat" / "condition_type"
-     *   3. Periodic           - "period" (or "magnitude" + "offset" together)
-     *   4. Constant           - "strength" alone
-     *   5. Rumble             - "low"/"high" or "large_magnitude"/"small_magnitude"
+     *   2. Xbox trigger       - "left_intensity" or "right_intensity"
+     *   3. Condition          - "right_sat" / "left_sat" / "condition_type"
+     *   4. Periodic           - "period" (or "magnitude" + "offset" together)
+     *   5. Constant           - "strength" alone
+     *   6. Rumble             - "low"/"high" or "large_magnitude"/"small_magnitude"
      *
      * If the message also carries an explicit "effect" field whose value
      * matches a known effect name, that takes precedence over field sniffing.

--- a/src/Network/OSCServer.cpp
+++ b/src/Network/OSCServer.cpp
@@ -83,6 +83,7 @@ namespace {
         { "haptic_periodic",  "/haptic/periodic",  "iififfii",   OSCServer::HapticEffectKind::PeriodicLegacy, nullptr },
         { "haptic_condition", "/haptic/condition", "iiiffffffi", OSCServer::HapticEffectKind::Condition, nullptr },
         { "haptic_gain",      "/haptic/gain",      "ii",         OSCServer::HapticEffectKind::Gain,      nullptr },
+        { "xbox_trigger",     "/haptic/xbox/trigger", "iiii",    OSCServer::HapticEffectKind::XboxTrigger, nullptr },
 
         { "ds_trigger_left_feedback",   "/haptic/dualsense/trigger/left/feedback",   "iii",     OSCServer::HapticEffectKind::DsFeedback,  "left"  },
         { "ds_trigger_right_feedback",  "/haptic/dualsense/trigger/right/feedback",  "iii",     OSCServer::HapticEffectKind::DsFeedback,  "right" },
@@ -194,6 +195,7 @@ int OSCServer::dynamic_field_handler(const char* path, const char* types, lo_arg
             case HapticEffectKind::PeriodicLegacy:  HapticDispatcher::DispatchPeriodic(argv, argc, mapper); break;
             case HapticEffectKind::Condition:       HapticDispatcher::DispatchCondition(argv, argc, mapper); break;
             case HapticEffectKind::Gain:            HapticDispatcher::DispatchGain(argv, argc, mapper); break;
+            case HapticEffectKind::XboxTrigger:     HapticDispatcher::DispatchXboxTrigger(argv, argc, mapper); break;
             case HapticEffectKind::DsFeedback:      HapticDispatcher::DispatchDualSenseFeedback(argv, argc, mapper, ctx->side); break;
             case HapticEffectKind::DsWeapon:        HapticDispatcher::DispatchDualSenseWeapon(argv, argc, mapper, ctx->side); break;
             case HapticEffectKind::DsVibration:     HapticDispatcher::DispatchDualSenseVibration(argv, argc, mapper, ctx->side); break;

--- a/src/Network/OSCServer.cpp
+++ b/src/Network/OSCServer.cpp
@@ -92,6 +92,10 @@ namespace {
         { "ds_trigger_right_vibration", "/haptic/dualsense/trigger/right/vibration", "iiii",    OSCServer::HapticEffectKind::DsVibration, "right" },
         { "ds_trigger_left_slope_feedback",  "/haptic/dualsense/trigger/left/slope_feedback",  "iiiii", OSCServer::HapticEffectKind::DsSlopeFeedback, "left"  },
         { "ds_trigger_right_slope_feedback", "/haptic/dualsense/trigger/right/slope_feedback", "iiiii", OSCServer::HapticEffectKind::DsSlopeFeedback, "right" },
+        { "ds_trigger_left_multi_position_feedback",  "/haptic/dualsense/trigger/left/multi_position_feedback",  "iiiiiiiiiii", OSCServer::HapticEffectKind::DsMultiPositionFeedback, "left"  },
+        { "ds_trigger_right_multi_position_feedback", "/haptic/dualsense/trigger/right/multi_position_feedback", "iiiiiiiiiii", OSCServer::HapticEffectKind::DsMultiPositionFeedback, "right" },
+        { "ds_trigger_left_multi_position_vibration",  "/haptic/dualsense/trigger/left/multi_position_vibration",  "iiiiiiiiiiii", OSCServer::HapticEffectKind::DsMultiPositionVibration, "left"  },
+        { "ds_trigger_right_multi_position_vibration", "/haptic/dualsense/trigger/right/multi_position_vibration", "iiiiiiiiiiii", OSCServer::HapticEffectKind::DsMultiPositionVibration, "right" },
         { "ds_trigger_left_bow",        "/haptic/dualsense/trigger/left/bow",        "iiiii",   OSCServer::HapticEffectKind::DsBow,       "left"  },
         { "ds_trigger_right_bow",       "/haptic/dualsense/trigger/right/bow",       "iiiii",   OSCServer::HapticEffectKind::DsBow,       "right" },
         { "ds_trigger_left_galloping",  "/haptic/dualsense/trigger/left/galloping",  "iiiiii",  OSCServer::HapticEffectKind::DsGalloping, "left"  },
@@ -194,6 +198,8 @@ int OSCServer::dynamic_field_handler(const char* path, const char* types, lo_arg
             case HapticEffectKind::DsWeapon:        HapticDispatcher::DispatchDualSenseWeapon(argv, argc, mapper, ctx->side); break;
             case HapticEffectKind::DsVibration:     HapticDispatcher::DispatchDualSenseVibration(argv, argc, mapper, ctx->side); break;
             case HapticEffectKind::DsSlopeFeedback: HapticDispatcher::DispatchDualSenseSlopeFeedback(argv, argc, mapper, ctx->side); break;
+            case HapticEffectKind::DsMultiPositionFeedback:  HapticDispatcher::DispatchDualSenseMultiPositionFeedback(argv, argc, mapper, ctx->side); break;
+            case HapticEffectKind::DsMultiPositionVibration: HapticDispatcher::DispatchDualSenseMultiPositionVibration(argv, argc, mapper, ctx->side); break;
             case HapticEffectKind::DsBow:           HapticDispatcher::DispatchDualSenseBow(argv, argc, mapper, ctx->side); break;
             case HapticEffectKind::DsGalloping:     HapticDispatcher::DispatchDualSenseGalloping(argv, argc, mapper, ctx->side); break;
             case HapticEffectKind::DsMachine:       HapticDispatcher::DispatchDualSenseMachine(argv, argc, mapper, ctx->side); break;

--- a/src/Network/OSCServer.h
+++ b/src/Network/OSCServer.h
@@ -50,6 +50,7 @@ public:
     // needs to name these values outside the class.
     enum class HapticEffectKind {
         Rumble, Constant, PeriodicNew, PeriodicLegacy, Condition, Gain,
+        XboxTrigger,
         DsFeedback, DsWeapon, DsVibration, DsSlopeFeedback,
         DsMultiPositionFeedback, DsMultiPositionVibration,
         DsBow, DsGalloping, DsMachine, DsOff

--- a/src/Network/OSCServer.h
+++ b/src/Network/OSCServer.h
@@ -50,7 +50,9 @@ public:
     // needs to name these values outside the class.
     enum class HapticEffectKind {
         Rumble, Constant, PeriodicNew, PeriodicLegacy, Condition, Gain,
-        DsFeedback, DsWeapon, DsVibration, DsSlopeFeedback, DsBow, DsGalloping, DsMachine, DsOff
+        DsFeedback, DsWeapon, DsVibration, DsSlopeFeedback,
+        DsMultiPositionFeedback, DsMultiPositionVibration,
+        DsBow, DsGalloping, DsMachine, DsOff
     };
 
     OSCServer();

--- a/src/Protocols/OSCBaseProtocol.cpp
+++ b/src/Protocols/OSCBaseProtocol.cpp
@@ -8,6 +8,7 @@
 #include "Haptics/SteeringWheelHaptics.h"
 #include <cstring>
 #include <string_view>
+#include <string>
 #include <map>
 
 namespace {
@@ -54,6 +55,29 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
     // by trigger side ("left"/"right"). Defined here so they're available to
     // the per-side/per-effect match() branches below (one Protocol Editor
     // field per side x effect, see "Adaptive Trigger" category).
+    auto sendMultiplePositionFeedback = [&](const char* trig) {
+        // iiiiiiiiiii = deviceId + 10 per-position strengths
+        if (std::strcmp(types, "iiiiiiiiiii") != 0 || argc != 11) return;
+        std::map<std::string, int> params;
+        for (int i = 0; i < 10; ++i) {
+            params["strength_" + std::to_string(i)] = ClampDSMultiStrength(argv[i + 1]->i, path_sv);
+        }
+        DispatchHapticCommand<GamepadHaptics>([&, trig](GamepadHaptics* gamepad) {
+            gamepad->SendDualSenseTrigger(trig, "multi_position_feedback", params);
+        });
+    };
+    auto sendMultiplePositionVibration = [&](const char* trig) {
+        // iiiiiiiiiiii = deviceId + frequency + 10 per-position amplitudes
+        if (std::strcmp(types, "iiiiiiiiiiii") != 0 || argc != 12) return;
+        std::map<std::string, int> params;
+        params["frequency"] = ClampDSFrequency(argv[1]->i, path_sv);
+        for (int i = 0; i < 10; ++i) {
+            params["amplitude_" + std::to_string(i)] = ClampDSMultiAmplitude(argv[i + 2]->i, path_sv);
+        }
+        DispatchHapticCommand<GamepadHaptics>([&, trig](GamepadHaptics* gamepad) {
+            gamepad->SendDualSenseTrigger(trig, "multi_position_vibration", params);
+        });
+    };
     auto sendFeedback = [&](const char* trig) {
         if (std::strcmp(types, "iii") != 0 || argc != 3) return;
         std::map<std::string, int> params;
@@ -262,6 +286,8 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
     //   feedback:  iii     (deviceId, position, strength)
     //   weapon:    iiii    (deviceId, start_position, end_position, strength)
     //   vibration: iiii    (deviceId, position, amplitude, frequency)
+    //   multi_position_feedback:  iiiiiiiiiii  (deviceId, strength_0..strength_9)
+    //   multi_position_vibration: iiiiiiiiiiii (deviceId, frequency, amplitude_0..amplitude_9)
     //   slope_feedback: iiiii (deviceId, start_position, end_position, start_strength, end_strength)
     //   bow:       iiiii   (deviceId, start_position, end_position, strength, snap_force)
     //   galloping: iiiiii  (deviceId, start_position, end_position, first_foot, second_foot, frequency)
@@ -273,6 +299,10 @@ bool OSCBaseProtocol::handle_osc_message(const char* path, const char* types, lo
     else if (match("/haptic/dualsense/trigger/right/weapon",    "ds_trigger_right_weapon"))    { handled = true; sendWeapon("right"); }
     else if (match("/haptic/dualsense/trigger/left/vibration",  "ds_trigger_left_vibration"))  { handled = true; sendVibration("left"); }
     else if (match("/haptic/dualsense/trigger/right/vibration", "ds_trigger_right_vibration")) { handled = true; sendVibration("right"); }
+    else if (match("/haptic/dualsense/trigger/left/multi_position_feedback",  "ds_trigger_left_multi_position_feedback"))  { handled = true; sendMultiplePositionFeedback("left"); }
+    else if (match("/haptic/dualsense/trigger/right/multi_position_feedback", "ds_trigger_right_multi_position_feedback")) { handled = true; sendMultiplePositionFeedback("right"); }
+    else if (match("/haptic/dualsense/trigger/left/multi_position_vibration",  "ds_trigger_left_multi_position_vibration"))  { handled = true; sendMultiplePositionVibration("left"); }
+    else if (match("/haptic/dualsense/trigger/right/multi_position_vibration", "ds_trigger_right_multi_position_vibration")) { handled = true; sendMultiplePositionVibration("right"); }
     else if (match("/haptic/dualsense/trigger/left/slope_feedback",  "ds_trigger_left_slope_feedback"))  { handled = true; sendSlopeFeedback("left"); }
     else if (match("/haptic/dualsense/trigger/right/slope_feedback", "ds_trigger_right_slope_feedback")) { handled = true; sendSlopeFeedback("right"); }
     else if (match("/haptic/dualsense/trigger/left/bow",        "ds_trigger_left_bow"))        { handled = true; sendBow("left"); }

--- a/src/Protocols/OSCProtocol.cpp
+++ b/src/Protocols/OSCProtocol.cpp
@@ -7,6 +7,7 @@
 #include "Haptics/GamepadHaptics.h"
 #include "Haptics/SteeringWheelHaptics.h"
 #include <string_view>
+#include <string>
 #include <cstring>
 #include <map>
 
@@ -82,6 +83,29 @@ bool OSCProtocol::handle_osc_message(const char* path, const char* types, lo_arg
     // DualSense adaptive trigger senders - one per effect shape, parameterized
     // by trigger side ("left"/"right"). Defined here so they're available to
     // the flat per-side/per-effect address checks further down.
+    auto sendMultiplePositionFeedback = [&](const char* trig) {
+        // iiiiiiiiiii = deviceId + 10 per-position strengths
+        if (std::strcmp(types, "iiiiiiiiiii") != 0 || argc != 11) return;
+        std::map<std::string, int> params;
+        for (int i = 0; i < 10; ++i) {
+            params["strength_" + std::to_string(i)] = ClampDSMultiStrength(argv[i + 1]->i, path_sv);
+        }
+        DispatchHapticCommand<GamepadHaptics>([&, trig](GamepadHaptics* gamepad) {
+            gamepad->SendDualSenseTrigger(trig, "multi_position_feedback", params);
+        });
+    };
+    auto sendMultiplePositionVibration = [&](const char* trig) {
+        // iiiiiiiiiiii = deviceId + frequency + 10 per-position amplitudes
+        if (std::strcmp(types, "iiiiiiiiiiii") != 0 || argc != 12) return;
+        std::map<std::string, int> params;
+        params["frequency"] = ClampDSFrequency(argv[1]->i, path_sv);
+        for (int i = 0; i < 10; ++i) {
+            params["amplitude_" + std::to_string(i)] = ClampDSMultiAmplitude(argv[i + 2]->i, path_sv);
+        }
+        DispatchHapticCommand<GamepadHaptics>([&, trig](GamepadHaptics* gamepad) {
+            gamepad->SendDualSenseTrigger(trig, "multi_position_vibration", params);
+        });
+    };
     auto sendFeedback = [&](const char* trig) {
         if (std::strcmp(types, "iii") != 0 || argc != 3) return;
         std::map<std::string, int> params;
@@ -284,6 +308,8 @@ bool OSCProtocol::handle_osc_message(const char* path, const char* types, lo_arg
     //   feedback:  iii     (deviceId, position, strength)
     //   weapon:    iiii    (deviceId, start_position, end_position, strength)
     //   vibration: iiii    (deviceId, position, amplitude, frequency)
+    //   multi_position_feedback:  iiiiiiiiiii  (deviceId, strength_0..strength_9)
+    //   multi_position_vibration: iiiiiiiiiiii (deviceId, frequency, amplitude_0..amplitude_9)
     //   slope_feedback: iiiii (deviceId, start_position, end_position, start_strength, end_strength)
     //   bow:       iiiii   (deviceId, start_position, end_position, strength, snap_force)
     //   galloping: iiiiii  (deviceId, start_position, end_position, first_foot, second_foot, frequency)
@@ -295,6 +321,10 @@ bool OSCProtocol::handle_osc_message(const char* path, const char* types, lo_arg
     else if (match("/haptic/dualsense/trigger/right/weapon",    "ds_trigger_right_weapon"))    { handled = true; sendWeapon("right"); }
     else if (match("/haptic/dualsense/trigger/left/vibration",  "ds_trigger_left_vibration"))  { handled = true; sendVibration("left"); }
     else if (match("/haptic/dualsense/trigger/right/vibration", "ds_trigger_right_vibration")) { handled = true; sendVibration("right"); }
+    else if (match("/haptic/dualsense/trigger/left/multi_position_feedback",  "ds_trigger_left_multi_position_feedback"))  { handled = true; sendMultiplePositionFeedback("left"); }
+    else if (match("/haptic/dualsense/trigger/right/multi_position_feedback", "ds_trigger_right_multi_position_feedback")) { handled = true; sendMultiplePositionFeedback("right"); }
+    else if (match("/haptic/dualsense/trigger/left/multi_position_vibration",  "ds_trigger_left_multi_position_vibration"))  { handled = true; sendMultiplePositionVibration("left"); }
+    else if (match("/haptic/dualsense/trigger/right/multi_position_vibration", "ds_trigger_right_multi_position_vibration")) { handled = true; sendMultiplePositionVibration("right"); }
     else if (match("/haptic/dualsense/trigger/left/slope_feedback",  "ds_trigger_left_slope_feedback"))  { handled = true; sendSlopeFeedback("left"); }
     else if (match("/haptic/dualsense/trigger/right/slope_feedback", "ds_trigger_right_slope_feedback")) { handled = true; sendSlopeFeedback("right"); }
     else if (match("/haptic/dualsense/trigger/left/bow",        "ds_trigger_left_bow"))        { handled = true; sendBow("left"); }

--- a/src/Protocols/OSCValidation.h
+++ b/src/Protocols/OSCValidation.h
@@ -116,6 +116,11 @@ inline int ClampDSFrequency(int v, std::string_view p) { return ClampInt(v,   0,
 inline int ClampDSStartPos(int v, std::string_view p)  { return ClampInt(v,   2,   7, "start_position", p); }
 inline int ClampDSEndPos(int v, std::string_view p)    { return ClampInt(v,   0,   8, "end_position",   p); }
 
+// Multi-position feedback/vibration per-index strength/amplitude - 0-8, matches
+// ApplyTriggerEffect's "multi_position_feedback"/"multi_position_vibration" branches.
+inline int ClampDSMultiStrength(int v, std::string_view p)  { return ClampInt(v, 0, 8, "strength",  p); }
+inline int ClampDSMultiAmplitude(int v, std::string_view p) { return ClampInt(v, 0, 8, "amplitude", p); }
+
 // Slope feedback start/end position (0-8 / 0-9) and start/end strength (1-8, not 0-8 -
 // SlopeFeedback rejects a strength of 0) matches ApplyTriggerEffect's "slope_feedback" branch.
 inline int ClampDSSlopePos(int v, std::string_view p)      { return ClampInt(v, 0, 8, "start_position", p); }

--- a/src/Protocols/ProtocolRegistry.cpp
+++ b/src/Protocols/ProtocolRegistry.cpp
@@ -924,6 +924,7 @@ void ProtocolRegistry::LoadBuiltinCatalog() {
     addIn("haptic_periodic",    "Periodic Effect",         "Haptic", "/haptic/periodic",    "periodic");
     addIn("haptic_condition",   "Condition Effect",        "Haptic", "/haptic/condition",   "condition");
     addIn("haptic_gain",        "Global Gain",             "Haptic", "/haptic/gain",        "gain");
+    addIn("xbox_trigger",       "Xbox Impulse Trigger",    "Haptic", "/haptic/xbox/trigger", "xbox_trigger");
     // -- Adaptive Trigger (DualSense) ---------------------------------------
     // One field per trigger side x effect, since each combination is its
     // own OSC address/arg signature rather than a single message shape.

--- a/src/Protocols/ProtocolRegistry.cpp
+++ b/src/Protocols/ProtocolRegistry.cpp
@@ -934,6 +934,8 @@ void ProtocolRegistry::LoadBuiltinCatalog() {
     //   weapon:    iiii    (deviceId, start_position, end_position, strength)
     //   vibration: iiii    (deviceId, position, amplitude, frequency)
     //   slope_feedback: iiiii (deviceId, start_position, end_position, start_strength, end_strength)
+    //   multi_position_feedback:  iiiiiiiiiii  (deviceId, strength_0..strength_9)
+    //   multi_position_vibration: iiiiiiiiiiii (deviceId, frequency, amplitude_0..amplitude_9)
     //   bow:       iiiii   (deviceId, start_position, end_position, strength, snap_force)
     //   galloping: iiiiii  (deviceId, start_position, end_position, first_foot, second_foot, frequency)
     //   machine:   iiiiiii (deviceId, start_position, end_position, amplitude_a, amplitude_b, frequency, period)
@@ -946,6 +948,10 @@ void ProtocolRegistry::LoadBuiltinCatalog() {
     addIn("ds_trigger_right_vibration", "Right Trigger: Vibration", "Adaptive Trigger", "/haptic/dualsense/trigger/right/vibration", "dualsense_trigger_right_vibration");
     addIn("ds_trigger_left_slope_feedback",  "Left Trigger: Slope Feedback",  "Adaptive Trigger", "/haptic/dualsense/trigger/left/slope_feedback",  "dualsense_trigger_left_slope_feedback");
     addIn("ds_trigger_right_slope_feedback", "Right Trigger: Slope Feedback", "Adaptive Trigger", "/haptic/dualsense/trigger/right/slope_feedback", "dualsense_trigger_right_slope_feedback");
+    addIn("ds_trigger_left_multi_position_feedback",  "Left Trigger: Multi-Position Feedback",  "Adaptive Trigger", "/haptic/dualsense/trigger/left/multi_position_feedback",  "dualsense_trigger_left_multi_position_feedback");
+    addIn("ds_trigger_right_multi_position_feedback", "Right Trigger: Multi-Position Feedback", "Adaptive Trigger", "/haptic/dualsense/trigger/right/multi_position_feedback", "dualsense_trigger_right_multi_position_feedback");
+    addIn("ds_trigger_left_multi_position_vibration",  "Left Trigger: Multi-Position Vibration",  "Adaptive Trigger", "/haptic/dualsense/trigger/left/multi_position_vibration",  "dualsense_trigger_left_multi_position_vibration");
+    addIn("ds_trigger_right_multi_position_vibration", "Right Trigger: Multi-Position Vibration", "Adaptive Trigger", "/haptic/dualsense/trigger/right/multi_position_vibration", "dualsense_trigger_right_multi_position_vibration");
     addIn("ds_trigger_left_bow",        "Left Trigger: Bow",        "Adaptive Trigger", "/haptic/dualsense/trigger/left/bow",        "dualsense_trigger_left_bow");
     addIn("ds_trigger_right_bow",       "Right Trigger: Bow",       "Adaptive Trigger", "/haptic/dualsense/trigger/right/bow",       "dualsense_trigger_right_bow");
     addIn("ds_trigger_left_galloping",  "Left Trigger: Galloping",  "Adaptive Trigger", "/haptic/dualsense/trigger/left/galloping",  "dualsense_trigger_left_galloping");

--- a/src/Protocols/WebSocketProtocol.cpp
+++ b/src/Protocols/WebSocketProtocol.cpp
@@ -176,6 +176,12 @@ bool WebSocketProtocol::parse(const std::string &message) {
                                                                   first_foot, second_foot, period,
                                                                   amplitude_a, amplitude_b);
             }
+        } else if (type == "gamepad" && effect == "xbox_trigger") {
+            // Xbox impulse trigger effect
+            int left_intensity = params.value("left_intensity", 0);
+            int right_intensity = params.value("right_intensity", 0);
+            int duration_ms = params.value("duration_ms", 0);
+            OutputMapper::GetInstance().QueueXboxTrigger(0, left_intensity, right_intensity, duration_ms);
         } else if (type == "steering_wheel") {
             if (effect == "constant") {
                 float strength = params.at("strength");

--- a/src/Protocols/WebSocketProtocol.cpp
+++ b/src/Protocols/WebSocketProtocol.cpp
@@ -3,6 +3,7 @@
 #include "Devices/DeviceManager.h"
 #include <algorithm>
 #include <cstdio>
+#include <cstdint>
 #include <string>
 #include <map>
 
@@ -129,28 +130,52 @@ bool WebSocketProtocol::parse(const std::string &message) {
         } else if (type == "gamepad" && effect == "dualsense_trigger") {
             // DualSense adaptive trigger effect
             std::string trigger = params.value("trigger", "left");  // "left", "right", or "both"
-            std::string effect_type = params.value("effect_type", "off");  // off, feedback, weapon, vibration, slope_feedback, bow, galloping, machine
+            std::string effect_type = params.value("effect_type", "off");  // off, feedback, weapon, vibration, slope_feedback, multi_position_feedback, multi_position_vibration, bow, galloping, machine
             // slope_feedback reuses the generic position/strength/end_position/amplitude
             // fields as start_position/start_strength/end_position/end_strength - see
             // OutputMapper::TriggerDualSenseTrigger, which builds those named keys.
 
-            int position = params.value("position", 0);
-            int strength = params.value("strength", 5);
-            int end_position = params.value("end_position", 9);
-            int amplitude = params.value("amplitude", 5);
-            int frequency = params.value("frequency", 10);
-            int snap_force = params.value("snap_force", 5);
-            int first_foot = params.value("first_foot", 2);
-            int second_foot = params.value("second_foot", 7);
-            int period = params.value("period", 10);
-            int amplitude_a = params.value("amplitude_a", 4);
-            int amplitude_b = params.value("amplitude_b", 4);
+            if (effect_type == "multi_position_feedback") {
+                // "strengths": [s0..s9], one value per trigger position (0-9). These
+                // bypass QueueDualSenseTrigger entirely - see OutputMapper::
+                // DualSenseArrayCommand for why.
+                uint8_t strengths[10] = {0};
+                if (params.contains("strengths") && params["strengths"].is_array()) {
+                    const auto& arr = params["strengths"];
+                    for (size_t i = 0; i < 10 && i < arr.size(); ++i)
+                        strengths[i] = static_cast<uint8_t>(arr[i].get<int>());
+                }
+                OutputMapper::GetInstance().QueueDualSenseMultiPositionFeedback(0, trigger.c_str(), strengths);
+            } else if (effect_type == "multi_position_vibration") {
+                // "amplitudes": [a0..a9], one value per trigger position (0-9), plus
+                // a single shared "frequency".
+                uint8_t amplitudes[10] = {0};
+                if (params.contains("amplitudes") && params["amplitudes"].is_array()) {
+                    const auto& arr = params["amplitudes"];
+                    for (size_t i = 0; i < 10 && i < arr.size(); ++i)
+                        amplitudes[i] = static_cast<uint8_t>(arr[i].get<int>());
+                }
+                uint8_t frequency = static_cast<uint8_t>(params.value("frequency", 10));
+                OutputMapper::GetInstance().QueueDualSenseMultiPositionVibration(0, trigger.c_str(), frequency, amplitudes);
+            } else {
+                int position = params.value("position", 0);
+                int strength = params.value("strength", 5);
+                int end_position = params.value("end_position", 9);
+                int amplitude = params.value("amplitude", 5);
+                int frequency = params.value("frequency", 10);
+                int snap_force = params.value("snap_force", 5);
+                int first_foot = params.value("first_foot", 2);
+                int second_foot = params.value("second_foot", 7);
+                int period = params.value("period", 10);
+                int amplitude_a = params.value("amplitude_a", 4);
+                int amplitude_b = params.value("amplitude_b", 4);
 
-            OutputMapper::GetInstance().QueueDualSenseTrigger(0, trigger.c_str(), effect_type.c_str(),
-                                                              position, strength, end_position,
-                                                              amplitude, frequency, snap_force,
-                                                              first_foot, second_foot, period,
-                                                              amplitude_a, amplitude_b);
+                OutputMapper::GetInstance().QueueDualSenseTrigger(0, trigger.c_str(), effect_type.c_str(),
+                                                                  position, strength, end_position,
+                                                                  amplitude, frequency, snap_force,
+                                                                  first_foot, second_foot, period,
+                                                                  amplitude_a, amplitude_b);
+            }
         } else if (type == "steering_wheel") {
             if (effect == "constant") {
                 float strength = params.at("strength");

--- a/src/Visualizers/GamepadHapticsVisualizer.cpp
+++ b/src/Visualizers/GamepadHapticsVisualizer.cpp
@@ -3,6 +3,7 @@
 #include "imgui.h"
 #include "Haptics/GamepadHaptics.h"
 #include <SDL3/SDL.h>
+#include <string>
 
 static constexpr const char* kTag = "GamepadHapticsViz";
 
@@ -200,12 +201,14 @@ void GamepadHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager& devic
 
         static int left_effect_type = 0;
         static int left_params[10] = {};
+        static int left_mp_freq = 10;
         static int right_effect_type = 0;
         static int right_params[10] = {};
+        static int right_mp_freq = 10;
 
-        const char* ds_effect_names[] = { "Off", "Feedback", "Weapon", "Vibration", "Slope Feedback", "Bow", "Galloping", "Machine" };
+        const char* ds_effect_names[] = { "Off", "Feedback", "Weapon", "Vibration", "Multi-Position Feedback", "Slope Feedback", "Multi-Position Vibration", "Bow", "Galloping", "Machine" };
 
-        auto DrawTriggerUI = [&](const char* label, int& effect_type, int* params) {
+        auto DrawTriggerUI = [&](const char* label, int& effect_type, int* params, int& mp_freq) {
             ImGui::PushID(label);
             ImGui::Text("%s", label);
             ImGui::Combo("Effect Type", &effect_type, ds_effect_names, IM_ARRAYSIZE(ds_effect_names));
@@ -225,26 +228,41 @@ void GamepadHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager& devic
                     ImGui::SliderInt("Amplitude", &params[1], 0, 8);
                     ImGui::SliderInt("Frequency", &params[2], 0, 255);
                     break;
-                case 4: // Slope Feedback
+                case 4: // Multi-Position Feedback - one strength per trigger position (0-9)
+                    for (int i = 0; i < 10; ++i) {
+                        ImGui::PushID(i);
+                        ImGui::SliderInt(("Strength " + std::to_string(i)).c_str(), &params[i], 0, 8);
+                        ImGui::PopID();
+                    }
+                    break;
+                case 5: // Slope Feedback
                     ImGui::SliderInt("Start Position", &params[0], 0, 8);
                     ImGui::SliderInt("End Position", &params[1], 0, 9);
                     ImGui::SliderInt("Start Strength", &params[2], 1, 8);
                     ImGui::SliderInt("End Strength", &params[3], 1, 8);
                     break;
-                case 5: // Bow
+                case 6: // Multi-Position Vibration - shared frequency + one amplitude per position (0-9)
+                    ImGui::SliderInt("Frequency", &mp_freq, 0, 255);
+                    for (int i = 0; i < 10; ++i) {
+                        ImGui::PushID(i);
+                        ImGui::SliderInt(("Amplitude " + std::to_string(i)).c_str(), &params[i], 0, 8);
+                        ImGui::PopID();
+                    }
+                    break;
+                case 7: // Bow
                     ImGui::SliderInt("Start Position", &params[0], 0, 8);
                     ImGui::SliderInt("End Position", &params[1], 0, 8);
                     ImGui::SliderInt("Strength", &params[2], 0, 8);
                     ImGui::SliderInt("Snap Force", &params[3], 0, 8);
                     break;
-                case 6: // Galloping
+                case 8: // Galloping
                     ImGui::SliderInt("Start Position", &params[0], 0, 9);
                     ImGui::SliderInt("End Position", &params[1], 0, 9);
                     ImGui::SliderInt("First Foot", &params[2], 0, 6);
                     ImGui::SliderInt("Second Foot", &params[3], 0, 7);
                     ImGui::SliderInt("Frequency", &params[4], 0, 255);
                     break;
-                case 7: // Machine
+                case 9: // Machine
                     ImGui::SliderInt("Start Position", &params[0], 0, 9);
                     ImGui::SliderInt("End Position", &params[1], 0, 9);
                     ImGui::SliderInt("Amplitude A", &params[2], 0, 7);
@@ -256,13 +274,13 @@ void GamepadHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager& devic
             ImGui::PopID();
         };
 
-        DrawTriggerUI("Left Trigger", left_effect_type, left_params);
+        DrawTriggerUI("Left Trigger", left_effect_type, left_params, left_mp_freq);
         ImGui::Separator();
-        DrawTriggerUI("Right Trigger", right_effect_type, right_params);
+        DrawTriggerUI("Right Trigger", right_effect_type, right_params, right_mp_freq);
 
         if (ImGui::Button("Send Effect")) {
             if (auto *gamepadHaptics = dynamic_cast<GamepadHaptics *>(haptic)) {
-                const char* effect_names[] = { "off", "feedback", "weapon", "vibration", "slope_feedback", "bow", "galloping", "machine" }; // must match ds_effect_names
+                const char* effect_names[] = { "off", "feedback", "weapon", "vibration", "multi_position_feedback", "slope_feedback", "multi_position_vibration", "bow", "galloping", "machine" }; // must match ds_effect_names
                 
                 // Send left trigger effect
                 std::map<std::string, int> leftParams;
@@ -283,26 +301,37 @@ void GamepadHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager& devic
                         leftParams["amplitude"] = left_params[1];
                         leftParams["frequency"] = left_params[2];
                         break;
-                    case 4: // Slope Feedback
+                    case 4: // Multi-Position Feedback
+                        for (int i = 0; i < 10; ++i) {
+                            leftParams["strength_" + std::to_string(i)] = left_params[i];
+                        }
+                        break;
+                    case 5: // Slope Feedback
                         leftParams["start_position"] = left_params[0];
                         leftParams["end_position"] = left_params[1];
                         leftParams["start_strength"] = left_params[2];
                         leftParams["end_strength"] = left_params[3];
                         break;
-                    case 5: // Bow
+                    case 6: // Multi-Position Vibration
+                        leftParams["frequency"] = left_mp_freq;
+                        for (int i = 0; i < 10; ++i) {
+                            leftParams["amplitude_" + std::to_string(i)] = left_params[i];
+                        }
+                        break;
+                    case 7: // Bow
                         leftParams["start_position"] = left_params[0];
                         leftParams["end_position"] = left_params[1];
                         leftParams["strength"] = left_params[2];
                         leftParams["snap_force"] = left_params[3];
                         break;
-                    case 6: // Galloping
+                    case 8: // Galloping
                         leftParams["start_position"] = left_params[0];
                         leftParams["end_position"] = left_params[1];
                         leftParams["first_foot"] = left_params[2];
                         leftParams["second_foot"] = left_params[3];
                         leftParams["frequency"] = left_params[4];
                         break;
-                    case 7: // Machine
+                    case 9: // Machine
                         leftParams["start_position"] = left_params[0];
                         leftParams["end_position"] = left_params[1];
                         leftParams["amplitude_a"] = left_params[2];
@@ -334,26 +363,37 @@ void GamepadHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager& devic
                         rightParams["amplitude"] = right_params[1];
                         rightParams["frequency"] = right_params[2];
                         break;
-                    case 4: // Slope Feedback
+                    case 4: // Multi-Position Feedback
+                        for (int i = 0; i < 10; ++i) {
+                            rightParams["strength_" + std::to_string(i)] = right_params[i];
+                        }
+                        break;
+                    case 5: // Slope Feedback
                         rightParams["start_position"] = right_params[0];
                         rightParams["end_position"] = right_params[1];
                         rightParams["start_strength"] = right_params[2];
                         rightParams["end_strength"] = right_params[3];
                         break;
-                    case 5: // Bow
+                    case 6: // Multi-Position Vibration
+                        rightParams["frequency"] = right_mp_freq;
+                        for (int i = 0; i < 10; ++i) {
+                            rightParams["amplitude_" + std::to_string(i)] = right_params[i];
+                        }
+                        break;
+                    case 7: // Bow
                         rightParams["start_position"] = right_params[0];
                         rightParams["end_position"] = right_params[1];
                         rightParams["strength"] = right_params[2];
                         rightParams["snap_force"] = right_params[3];
                         break;
-                    case 6: // Galloping
+                    case 8: // Galloping
                         rightParams["start_position"] = right_params[0];
                         rightParams["end_position"] = right_params[1];
                         rightParams["first_foot"] = right_params[2];
                         rightParams["second_foot"] = right_params[3];
                         rightParams["frequency"] = right_params[4];
                         break;
-                    case 7: // Machine
+                    case 9: // Machine
                         rightParams["start_position"] = right_params[0];
                         rightParams["end_position"] = right_params[1];
                         rightParams["amplitude_a"] = right_params[2];

--- a/src/Visualizers/GamepadHapticsVisualizer.cpp
+++ b/src/Visualizers/GamepadHapticsVisualizer.cpp
@@ -147,6 +147,23 @@ void GamepadHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager& devic
                 }
             }
 
+            // --- Xbox Impulse Trigger ---
+            if (gamepadHaptics->IsXboxController()) {
+                auto xbox_trigger = gamepadHaptics->GetActiveXboxTrigger();
+                if (xbox_trigger.active) {
+                    anyActive = true;
+                    if (ImGui::TreeNodeEx("Xbox Impulse Trigger", ImGuiTreeNodeFlags_DefaultOpen)) {
+                        ImGui::Text("Left Intensity: %u", xbox_trigger.left_intensity);
+                        ImGui::Text("Right Intensity: %u", xbox_trigger.right_intensity);
+                        if (xbox_trigger.duration_ms == 0)
+                            ImGui::Text("Duration: Continuous");
+                        else
+                            ImGui::Text("Duration: %u ms", xbox_trigger.duration_ms);
+                        ImGui::TreePop();
+                    }
+                }
+            }
+
             // --- Constant force (per-slot) ---
             auto active_constants = gamepadHaptics->GetActiveConstants();
             for (const auto& [slot, info] : active_constants) {
@@ -405,6 +422,39 @@ void GamepadHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager& devic
                 
                 result = gamepadHaptics->PlayDualSenseTrigger("right", rightEffectName, rightParams);
                 LOG_DEBUG(kTag, "Right trigger effect '%s' result: %d", rightEffectName.c_str(), result);
+            }
+        }
+    }
+
+    // Only show Xbox impulse trigger UI if it's actually an Xbox controller
+    bool isXbox = false;
+    if (haptic) {
+        if (auto* gamepadHaptics = dynamic_cast<GamepadHaptics*>(haptic))
+            isXbox = gamepadHaptics->IsXboxController();
+    }
+
+    if (isXbox) {
+        ImGui::Separator();
+        ImGui::Text("Xbox Impulse Triggers");
+        ImGui::TextDisabled("Routed through GamepadHaptics::PlayXboxTrigger - same path as OSC/WebSocket.");
+
+        ImGui::SliderInt("Left Intensity", &m_xbox_left_intensity, 0, 255);
+        ImGui::SliderInt("Right Intensity", &m_xbox_right_intensity, 0, 255);
+        ImGui::SliderInt("Duration (ms)", &m_xbox_trigger_duration, 0, 5000);
+
+        if (ImGui::Button("Play Xbox Trigger")) {
+            if (auto* gamepadHaptics = dynamic_cast<GamepadHaptics*>(haptic)) {
+                int result = gamepadHaptics->PlayXboxTrigger(
+                    static_cast<uint8_t>(m_xbox_left_intensity),
+                    static_cast<uint8_t>(m_xbox_right_intensity),
+                    static_cast<uint32_t>(m_xbox_trigger_duration));
+                LOG_DEBUG(kTag, "Xbox trigger result: %d", result);
+            }
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Stop Xbox Trigger")) {
+            if (auto* gamepadHaptics = dynamic_cast<GamepadHaptics*>(haptic)) {
+                gamepadHaptics->PlayXboxTrigger(0, 0, 0);
             }
         }
     }

--- a/src/Visualizers/GamepadHapticsVisualizer.h
+++ b/src/Visualizers/GamepadHapticsVisualizer.h
@@ -24,4 +24,9 @@ private:
     // DualSense
     int m_ds_effect_type = 0;
     int m_ds_params[5] = {0};
+
+    // Xbox Impulse Triggers (network-dispatched, via GamepadHaptics::PlayXboxTrigger)
+    int m_xbox_left_intensity = 0;
+    int m_xbox_right_intensity = 0;
+    int m_xbox_trigger_duration = 1000;
 };

--- a/tests/mocks/output_mapper_stub.cpp
+++ b/tests/mocks/output_mapper_stub.cpp
@@ -24,6 +24,7 @@ std::vector<ConstantArgs>  constantCalls;
 std::vector<PeriodicArgs>  periodicCalls;
 std::vector<ConditionArgs> conditionCalls;
 std::vector<DualSenseArgs> dualSenseCalls;
+std::vector<DualSenseArrayArgs> dualSenseArrayCalls;
 
 void Reset() {
     rumbleCalls.clear();
@@ -31,6 +32,7 @@ void Reset() {
     periodicCalls.clear();
     conditionCalls.clear();
     dualSenseCalls.clear();
+    dualSenseArrayCalls.clear();
 }
 
 } // namespace HapticStub
@@ -93,8 +95,29 @@ void OutputMapper::QueueDualSenseTrigger(int device, const char* trigger, const 
     });
 }
 
+void OutputMapper::QueueDualSenseMultiPositionFeedback(int device, const char* trigger, const uint8_t strengths[10]) {
+    HapticStub::DualSenseArrayArgs args;
+    args.device      = device;
+    args.trigger     = trigger ? trigger : "";
+    args.effect_type = "multi_position_feedback";
+    args.frequency   = 0;
+    for (int i = 0; i < 10; ++i) args.values[i] = strengths[i];
+    HapticStub::dualSenseArrayCalls.push_back(args);
+}
+
+void OutputMapper::QueueDualSenseMultiPositionVibration(int device, const char* trigger, uint8_t frequency, const uint8_t amplitudes[10]) {
+    HapticStub::DualSenseArrayArgs args;
+    args.device      = device;
+    args.trigger     = trigger ? trigger : "";
+    args.effect_type = "multi_position_vibration";
+    args.frequency   = frequency;
+    for (int i = 0; i < 10; ++i) args.values[i] = amplitudes[i];
+    HapticStub::dualSenseArrayCalls.push_back(args);
+}
+
 // Private helpers - never called from outside; stubs prevent link errors.
 void OutputMapper::QueueCommand(HapticCommand&&)                       {}
+void OutputMapper::QueueArrayCommand(DualSenseArrayCommand&&)          {}
 void OutputMapper::GetTargets(int, std::vector<HapticTarget*>&)        {}
 void OutputMapper::UpdateHapticDevice(HapticTarget&)                   {}
 void OutputMapper::CloseHapticDevice(HapticTarget&)                    {}
@@ -107,3 +130,5 @@ void OutputMapper::TriggerSetGain(int, int)                            {}
 void OutputMapper::TriggerDualSenseTrigger(int, const char*, const char*,
                                             int, int, int, int, int, int,
                                             int, int, int, int, int)  {}
+void OutputMapper::TriggerDualSenseMultiPositionFeedback(int, const char*, const uint8_t*)              {}
+void OutputMapper::TriggerDualSenseMultiPositionVibration(int, const char*, uint8_t, const uint8_t*)    {}

--- a/tests/mocks/output_mapper_stub.h
+++ b/tests/mocks/output_mapper_stub.h
@@ -16,6 +16,9 @@
 // ─────────────────────────────────────────────────────────────────────────────
 
 #include <vector>
+#include <array>
+#include <string>
+#include <cstdint>
 #include "Haptics/HapticDevice.h"
 
 namespace HapticStub {
@@ -67,12 +70,21 @@ struct DualSenseArgs {
     int         p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11;
 };
 
+struct DualSenseArrayArgs {
+    int                      device;
+    std::string              trigger;
+    std::string              effect_type; // "multi_position_feedback" / "multi_position_vibration"
+    int                      frequency;   // only meaningful for vibration
+    std::array<uint8_t, 10>  values;      // per-position strength or amplitude
+};
+
 // Populated by the stub implementations in output_mapper_stub.cpp.
 extern std::vector<RumbleArgs>    rumbleCalls;
 extern std::vector<ConstantArgs>  constantCalls;
 extern std::vector<PeriodicArgs>  periodicCalls;
 extern std::vector<ConditionArgs> conditionCalls;
 extern std::vector<DualSenseArgs> dualSenseCalls;
+extern std::vector<DualSenseArrayArgs> dualSenseArrayCalls;
 
 /// Clear all recorded calls.  Call this in test SetUp().
 void Reset();

--- a/tests/test_haptic_parser.cpp
+++ b/tests/test_haptic_parser.cpp
@@ -589,6 +589,51 @@ TEST_F(HapticParserTest, DualSenseTriggerSlopeFeedbackReadsStrengthAndAmplitude)
     EXPECT_EQ(call.p4, 8);  // amplitude (becomes end_strength downstream)
 }
 
+// multi_position_feedback/vibration bypass QueueDualSenseTrigger entirely
+// (see OutputMapper::DualSenseArrayCommand) and route through the dedicated
+// QueueDualSenseMultiPosition* methods instead - recorded in dualSenseArrayCalls.
+TEST_F(HapticParserTest, DualSenseTriggerMultiPositionFeedbackReadsStrengthsArray) {
+    HapticParser::Parse(
+        R"({"type":"auto","params":{"trigger":"left","effect_type":"multi_position_feedback",
+                                     "strengths":[0,0,0,0,0,3,0,0,0,0]}})",
+        FakeMapper());
+
+    ASSERT_EQ(HapticStub::dualSenseArrayCalls.size(), 1u);
+    const auto& call = HapticStub::dualSenseArrayCalls[0];
+    EXPECT_EQ(call.trigger, "left");
+    EXPECT_EQ(call.effect_type, "multi_position_feedback");
+    EXPECT_EQ(call.values[5], 3);
+    EXPECT_EQ(call.values[0], 0);
+}
+
+TEST_F(HapticParserTest, DualSenseTriggerMultiPositionVibrationReadsAmplitudesAndFrequency) {
+    HapticParser::Parse(
+        R"({"type":"auto","params":{"trigger":"right","effect_type":"multi_position_vibration",
+                                     "frequency":50,"amplitudes":[0,0,0,0,5,0,0,0,0,0]}})",
+        FakeMapper());
+
+    ASSERT_EQ(HapticStub::dualSenseArrayCalls.size(), 1u);
+    const auto& call = HapticStub::dualSenseArrayCalls[0];
+    EXPECT_EQ(call.trigger, "right");
+    EXPECT_EQ(call.effect_type, "multi_position_vibration");
+    EXPECT_EQ(call.frequency, 50);
+    EXPECT_EQ(call.values[4], 5);
+}
+
+// Missing/short arrays should not read out of bounds - remaining slots stay 0.
+TEST_F(HapticParserTest, DualSenseTriggerMultiPositionFeedbackHandlesShortArray) {
+    HapticParser::Parse(
+        R"({"type":"auto","params":{"trigger":"left","effect_type":"multi_position_feedback",
+                                     "strengths":[4,4]}})",
+        FakeMapper());
+
+    ASSERT_EQ(HapticStub::dualSenseArrayCalls.size(), 1u);
+    const auto& call = HapticStub::dualSenseArrayCalls[0];
+    EXPECT_EQ(call.values[0], 4);
+    EXPECT_EQ(call.values[1], 4);
+    EXPECT_EQ(call.values[9], 0);
+}
+
 // Condition must win over constant when both "strength" and sat fields co-exist.
 TEST_F(HapticParserTest, AutoDetectConditionBeatsConstantWhenSatPresent) {
     auto det = HapticParser::AutoDetect(


### PR DESCRIPTION
Added DualSense adaptive trigger effects MultiplePositionFeedback and MultiplePositionVibration.
Added dedicated OutputMapper queue DualSenseArrayCommand.
Added new tests for new adaptive trigger effects.
Added acknowledgement for cmake policy CMP0218 to avoid liblo deprecated warning.
Reordered adaptive trigger methods to match generator class.
Added Xbox impulse trigger OSC paths parity with DualSense.
Added WebSocket HapticParser WebSocketProtocol JSON support for Xbox trigger.
Added Xbox HapticDevice virtuals + active-state tracking.
Added OutputMapper queue/dispatch with a new enable_xbox_trigger toggle and OSC path + HapticDispatcher parsing.
Added UI panel wired through the same PlayXboxTrigger() path as the network layer.