### PR TITLE
Xbox haptic trigger fixes

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -80,11 +80,14 @@ void Application::SetSDLHints()
     // ── Xbox ─────────────────────────────────────────────────────────────────
     // Without this, SDL may open Xbox controllers through the platform-native
     // backend (e.g. XInput on Windows) instead of SDL's own HIDAPI Xbox
-    // driver. XboxController::SendImpulseTriggerCommand() sends a raw output
-    // report via SDL_SendJoystickEffect(), which only the HIDAPI Xbox driver
-    // implements - on the XInput backend it silently fails, so impulse
-    // triggers never actually move even though PlayXboxTrigger() reports
-    // success (see SetImpulseTriggers()'s early "return 0").
+    // driver. XboxController::SetImpulseTriggers() delegates to
+    // SDL_RumbleJoystickTriggers(), which only the HIDAPI Xbox driver
+    // implements - on the XInput backend it returns false (SDL_Unsupported),
+    // so impulse triggers never actually move, but at least SetImpulseTriggers()
+    // now surfaces that as a real failure instead of reporting success.
+    // SDL_GetRealGamepadTypeForID() (used for Xbox controller detection - see
+    // XboxController::IsXboxController()) is unaffected by this hint either
+    // way, since it doesn't depend on which backend opened the device.
     SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_XBOX, "1");
 }
 
@@ -567,16 +570,16 @@ void Application::Shutdown()
     // would be destroyed AFTER OSCServer during normal static teardown.
     // Protocol destructors (e.g. OSCProtocol::~OSCProtocol) call back into
     // OSCServer::GetInstance(), which would be a use-after-destruction crash.
-    // Clearing the protocol map now - while all singletons are still alive -
+    // Clearing the protocol map now, while all singletons are still alive
     // prevents that entire class of ordering bugs.
     ProtocolManager::GetInstance().Clear();
 
     // ── Stop network servers BEFORE destroying mappers ────────────────────────
     // Both OSCServer::Stop() and WebSocketServer::Stop() call
     // m_OutputMapper->StopAllHapticEffects() synchronously via their stored raw
-    // pointer.  If OutputMapper::Shutdown() runs first it frees the OutputMapper
+    // pointer. If OutputMapper::Shutdown() runs first it frees the OutputMapper
     // object, turning those calls into use-after-free crashes (segfault at
-    // OutputMapper.cpp StopAllHapticEffects).  Stopping the servers here -
+    // OutputMapper.cpp StopAllHapticEffects). Stopping the servers here
     // while OutputMapper is still alive - prevents that entirely.
     OSCServer::GetInstance().SaveConfig(m_prefs);
     WebSocketServer::GetInstance().SaveConfig(m_prefs);
@@ -584,7 +587,7 @@ void Application::Shutdown()
     WebSocketServer::GetInstance().Stop();
 
     // Wait for the OSC liblo cleanup thread and the uWS event-loop thread to
-    // fully exit before OutputMapper is destroyed.  Both Stop() calls above
+    // fully exit before OutputMapper is destroyed. Both Stop() calls above
     // return immediately and move their blocking teardown to background threads;
     // those threads hold raw OutputMapper* pointers and can still invoke
     // callbacks (e.g. StopAllHapticEffects) until they have fully terminated.

--- a/src/Haptics/GamepadHaptics.cpp
+++ b/src/Haptics/GamepadHaptics.cpp
@@ -115,20 +115,12 @@ bool GamepadHaptics::IsDualSense() const {
 }
 
 bool GamepadHaptics::IsXboxController() const {
-    const Uint16 vendor = SDL_GetJoystickVendor(m_joystick);
-
-    if (vendor != 0x045E) {  // Microsoft
-        return false;
-    }
-
-    const Uint16 product = SDL_GetJoystickProduct(m_joystick);
-
-    // Known Xbox controllers with impulse triggers
-    return (product == 0x02D1 ||  // Xbox One
-            product == 0x02EA ||  // Xbox One S
-            product == 0x02E3 ||  // Xbox One Elite
-            product == 0x0B00 ||  // Xbox One Elite 2
-            product == 0x0B13);   // Xbox Series X|S
+    // Detection lives solely in XboxController - delegate to its static
+    // check rather than keeping a second, separately-maintained copy of the
+    // vendor/product ID list here. (That duplication previously drifted:
+    // this copy was missing the wired/BLE Series X|S product IDs that
+    // XboxController's own list had already been updated with.)
+    return XboxController::IsXboxController(m_joystick);
 }
 
 bool GamepadHaptics::IsSteamController() const {

--- a/src/Haptics/XboxController.cpp
+++ b/src/Haptics/XboxController.cpp
@@ -34,7 +34,9 @@ bool XboxController::IsXboxController() const {
             product == XBOX_ONE_S_PRODUCT_ID ||
             product == XBOX_ONE_ELITE_PRODUCT_ID ||
             product == XBOX_ONE_ELITE2_PRODUCT_ID ||
-            product == XBOX_SERIES_X_PRODUCT_ID);
+            product == XBOX_SERIES_X_PRODUCT_ID ||
+            product == XBOX_SERIES_X_WIRED_PRODUCT_ID ||
+            product == XBOX_SERIES_X_BLE_PRODUCT_ID);
 }
 
 // ==================== Model Detection ====================
@@ -60,6 +62,8 @@ Xbox::ControllerModel XboxController::DetectModel() const {
         case XBOX_ONE_ELITE2_PRODUCT_ID:
             return Xbox::ControllerModel::XboxOneElite2;
         case XBOX_SERIES_X_PRODUCT_ID:
+        case XBOX_SERIES_X_WIRED_PRODUCT_ID:
+        case XBOX_SERIES_X_BLE_PRODUCT_ID:
             return Xbox::ControllerModel::XboxSeriesX;
         default:
             return Xbox::ControllerModel::Unknown;
@@ -137,7 +141,19 @@ bool XboxController::SendImpulseTriggerCommand(const Xbox::ImpulseTriggerState& 
            data[0], state.leftTriggerMotor, state.rightTriggerMotor, state.durationMs);
     
     if (!SDL_SendJoystickEffect(m_joystick, data.data(), data.size())) {
-        LOG_ERROR(kTag, "Impulse: Send failed - %s", SDL_GetError());
+        // Impulse triggers require the full USB/Xbox-Wireless-Adapter HID
+        // report protocol. Standard Bluetooth (classic or BLE) doesn't
+        // expose this output report at all, so SDL correctly fails here
+        // this isn't a bug, it's a hardware/protocol limitation. 
+        // Downgrade to a clear warning instead of an alarming error when
+        // that's the likely cause, so it doesn't read as something broken.
+        if (SDL_GetJoystickConnectionState(m_joystick) == SDL_JOYSTICK_CONNECTION_WIRELESS) {
+            LOG_WARN(kTag, "Impulse: Not supported over Bluetooth on this controller - "
+                           "connect via USB or the Xbox Wireless Adapter for trigger haptics (SDL: %s)",
+                     SDL_GetError());
+        } else {
+            LOG_ERROR(kTag, "Impulse: Send failed - %s", SDL_GetError());
+        }
         return false;
     }
     

--- a/src/Haptics/XboxController.cpp
+++ b/src/Haptics/XboxController.cpp
@@ -3,14 +3,13 @@
  * @brief Implementation of Xbox controller with impulse trigger support
  * 
  * @author InputBridge Team
- * @version 2.0
- * @date 2026-02-14
+ * @version 3.0
+ * @date 2026-07-12
  */
 
 #include "App/Log.h"
 #include "XboxController.h"
 #include <SDL3/SDL_gamepad.h>
-#include <array>
 
 static constexpr const char* kTag = "XboxController";
 
@@ -25,27 +24,24 @@ bool XboxController::IsXboxController() const {
 }
 
 bool XboxController::IsXboxController(SDL_Joystick* joystick) {
+    // Vendor check first: SDL_GAMEPAD_TYPE_XBOXONE also covers third-party
+    // controllers built on the same HID protocol (PDP, Mad Catz, etc.) which
+    // don't have Microsoft's impulse trigger motors, so type alone isn't
+    // sufficient - this mirrors SDL's own Xbox HIDAPI driver, which likewise
+    // only advertises trigger-rumble support for USB_VENDOR_MICROSOFT once
+    // the device has already matched SDL_GAMEPAD_TYPE_XBOXONE.
     const Uint16 vendor = SDL_GetJoystickVendor(joystick);
-
     if (vendor != MICROSOFT_VENDOR_ID) {
         return false;
     }
 
-    const Uint16 product = SDL_GetJoystickProduct(joystick);
-
-    // Check if this is a known Xbox controller with impulse triggers
-    return (product == XBOX_ONE_PRODUCT_ID ||
-            product == XBOX_ONE_2015FW_PRODUCT_ID ||
-            product == XBOX_ONE_S_PRODUCT_ID ||
-            product == XBOX_ONE_S_BT_REV1_PRODUCT_ID ||
-            product == XBOX_ONE_S_BT_REV2_PRODUCT_ID ||
-            product == XBOX_ONE_S_BLE_PRODUCT_ID ||
-            product == XBOX_ONE_ELITE_PRODUCT_ID ||
-            product == XBOX_ONE_ELITE2_PRODUCT_ID ||
-            product == XBOX_ONE_ELITE2_BT_PRODUCT_ID ||
-            product == XBOX_ONE_ELITE2_BLE_PRODUCT_ID ||
-            product == XBOX_SERIES_X_PRODUCT_ID ||
-            product == XBOX_SERIES_X_WIRED_PRODUCT_ID);
+    // "Real" (not mapping-aware) type, so a user's SDL_GAMECONTROLLERCONFIG
+    // remap can't cause a non-Xbox device to be treated as one here. Backed
+    // by the same device table SDL's Xbox HIDAPI driver uses to decide
+    // trigger-rumble support, so this can't drift out of sync the way a
+    // hand-maintained product-ID list can.
+    const SDL_JoystickID id = SDL_GetJoystickID(joystick);
+    return SDL_GetRealGamepadTypeForID(id) == SDL_GAMEPAD_TYPE_XBOXONE;
 }
 
 // ==================== Model Detection ====================
@@ -80,7 +76,13 @@ Xbox::ControllerModel XboxController::DetectModel() const {
         case XBOX_SERIES_X_WIRED_PRODUCT_ID:
             return Xbox::ControllerModel::XboxSeriesX;
         default:
-            return Xbox::ControllerModel::Unknown;
+            // Product ID isn't in our (cosmetic-only) naming table, but
+            // IsXboxController() already confirmed via SDL that this really
+            // is an Xbox-family controller with trigger rumble - we just
+            // don't have a specific model name for it. Report it as the
+            // base model rather than Unknown, which would be misleading
+            // (Unknown elsewhere means "not an Xbox controller at all").
+            return Xbox::ControllerModel::XboxOne;
     }
 }
 
@@ -94,23 +96,39 @@ int XboxController::SetImpulseTriggers(uint8_t leftIntensity,
         return -1;
     }
 
+    // Delegates to SDL's own Xbox HIDAPI driver rather than hand-rolling the
+    // HID output report ourselves. SDL_RumbleJoystickTriggers() takes 0-0xFFFF
+    // per motor; scale our 0-255 public range up by 257 (0xFF*257 == 0xFFFF)
+    // so both ends of the range map exactly. SDL itself only has ~100 real
+    // steps of resolution internally (see SDL_hidapi_xboxone.c), so this
+    // scaling doesn't lose anything meaningful versus the input precision.
+    //
+    // This also picks up transport-specific report handling SDL's driver
+    // already does for us (it builds a different-shaped report for
+    // Bluetooth vs. USB) rather than the single hardcoded report layout the
+    // previous hand-rolled implementation sent unconditionally.
+    //
     // Sent synchronously on the calling thread, matching
     // GamepadHaptics::SendSteamControllerHaptic()'s SDL_SendJoystickEffect
-    // precedent it's a single raw HID output report, not a driver-side
-    // SDL_Haptic effect, so there's no need to hop onto the worker thread
-    // via RunAsync(). This also lets the actual send result (rather than an
-    // unconditional success) propagate back to the caller: PlayXboxTrigger()
-    // only marks the trigger active when this returns 0, so a failed send
-    // e.g. because the controller was opened via the XInput backend instead
-    // of SDL's HIDAPI Xbox driver, see Application::SetSDLHints()
-    // now shows up as a failure instead of silently doing nothing.
-    Xbox::ImpulseTriggerState state;
-    state.leftTriggerMotor = leftIntensity;
-    state.rightTriggerMotor = rightIntensity;
-    state.durationMs = durationMs;
+    // precedent - there's no need to hop onto the worker thread via
+    // RunAsync() for a single driver call like this. This also lets the
+    // actual send result (rather than an unconditional success) propagate
+    // back to the caller: PlayXboxTrigger() only marks the trigger active
+    // when this returns 0, so a failed send - e.g. because the controller
+    // was opened via the XInput backend instead of SDL's HIDAPI Xbox driver,
+    // see Application::SetSDLHints() - now shows up as a failure instead of
+    // silently doing nothing.
+    const Uint16 leftRumble = static_cast<Uint16>(leftIntensity) * 257;
+    const Uint16 rightRumble = static_cast<Uint16>(rightIntensity) * 257;
 
-    if (!SendImpulseTriggerCommand(state)) {
-        LOG_ERROR(kTag, "SetImpulseTriggers: Failed to send command");
+    if (!SDL_RumbleJoystickTriggers(m_joystick, leftRumble, rightRumble, durationMs)) {
+        // SDL_Unsupported() (has_trigger_rumble false) and a genuine send
+        // failure both surface here as a false return with SDL_GetError()
+        // set log at WARN rather than ERROR since the far more common
+        // cause in practice is a controller/driver combination that simply
+        // doesn't support trigger rumble (e.g. XInput backend instead of
+        // HIDAPI), not an actual hardware fault.
+        LOG_WARN(kTag, "SetImpulseTriggers: Failed to send - %s", SDL_GetError());
         return -1;
     }
 
@@ -119,58 +137,4 @@ int XboxController::SetImpulseTriggers(uint8_t leftIntensity,
 
 void XboxController::StopImpulseTriggers() {
     SetImpulseTriggers(0, 0, 0);
-}
-
-// ==================== Protocol Implementation ====================
-
-bool XboxController::SendImpulseTriggerCommand(const Xbox::ImpulseTriggerState& state) {
-    /**
-     * Xbox Impulse Trigger Protocol
-     * 
-     * Report structure:
-     * [0] = Report ID (0x03)
-     * [1] = Enable flags (0xFF = enable all motors)
-     * [2] = Left trigger motor magnitude (0-255)
-     * [3] = Right trigger motor magnitude (0-255)
-     * [4] = Left handle motor magnitude (0-255)
-     * [5] = Right handle motor magnitude (0-255)
-     * [6] = Duration low byte
-     * [7] = Duration high byte
-     */
-    
-    std::array<uint8_t, IMPULSE_TRIGGER_REPORT_SIZE> data{};
-    
-    data[0] = IMPULSE_TRIGGER_REPORT_ID;  // 0x03
-    data[1] = 0xFF;  // Enable all motors
-    data[2] = state.leftTriggerMotor;
-    data[3] = state.rightTriggerMotor;
-    data[4] = 0;     // Left handle motor (not used for triggers)
-    data[5] = 0;     // Right handle motor (not used for triggers)
-    
-    // Duration in milliseconds (little-endian)
-    data[6] = static_cast<uint8_t>(state.durationMs & 0xFF);
-    data[7] = static_cast<uint8_t>((state.durationMs >> 8) & 0xFF);
-    
-    LOG_DEBUG(kTag, "Impulse: Report=0x%02X, L=%d, R=%d, Duration=%dms",
-           data[0], state.leftTriggerMotor, state.rightTriggerMotor, state.durationMs);
-    
-    if (!SDL_SendJoystickEffect(m_joystick, data.data(), data.size())) {
-        // Impulse triggers require the full USB/Xbox-Wireless-Adapter HID
-        // report protocol. Standard Bluetooth (classic or BLE) doesn't
-        // expose this output report at all, so SDL correctly fails here
-        // this isn't a bug, it's a hardware/protocol limitation. 
-        // Downgrade to a clear warning instead of an alarming error when
-        // that's the likely cause, so it doesn't read as something broken.
-        if (SDL_GetJoystickConnectionState(m_joystick) == SDL_JOYSTICK_CONNECTION_WIRELESS) {
-            LOG_WARN(kTag, "Impulse: Not supported over Bluetooth on this controller - "
-                           "connect via USB or the Xbox Wireless Adapter for trigger haptics (SDL: %s)",
-                     SDL_GetError());
-        } else {
-            LOG_ERROR(kTag, "Impulse: Send failed - %s", SDL_GetError());
-        }
-        return false;
-    }
-    
-    LOG_DEBUG(kTag, "Impulse: Report sent successfully");
-    return true;
 }

--- a/src/Haptics/XboxController.cpp
+++ b/src/Haptics/XboxController.cpp
@@ -21,22 +21,31 @@ bool XboxController::IsReady() const {
 }
 
 bool XboxController::IsXboxController() const {
-    const Uint16 vendor = SDL_GetJoystickVendor(m_joystick);
-    
+    return IsXboxController(m_joystick);
+}
+
+bool XboxController::IsXboxController(SDL_Joystick* joystick) {
+    const Uint16 vendor = SDL_GetJoystickVendor(joystick);
+
     if (vendor != MICROSOFT_VENDOR_ID) {
         return false;
     }
-    
-    const Uint16 product = SDL_GetJoystickProduct(m_joystick);
-    
+
+    const Uint16 product = SDL_GetJoystickProduct(joystick);
+
     // Check if this is a known Xbox controller with impulse triggers
     return (product == XBOX_ONE_PRODUCT_ID ||
+            product == XBOX_ONE_2015FW_PRODUCT_ID ||
             product == XBOX_ONE_S_PRODUCT_ID ||
+            product == XBOX_ONE_S_BT_REV1_PRODUCT_ID ||
+            product == XBOX_ONE_S_BT_REV2_PRODUCT_ID ||
+            product == XBOX_ONE_S_BLE_PRODUCT_ID ||
             product == XBOX_ONE_ELITE_PRODUCT_ID ||
             product == XBOX_ONE_ELITE2_PRODUCT_ID ||
+            product == XBOX_ONE_ELITE2_BT_PRODUCT_ID ||
+            product == XBOX_ONE_ELITE2_BLE_PRODUCT_ID ||
             product == XBOX_SERIES_X_PRODUCT_ID ||
-            product == XBOX_SERIES_X_WIRED_PRODUCT_ID ||
-            product == XBOX_SERIES_X_BLE_PRODUCT_ID);
+            product == XBOX_SERIES_X_WIRED_PRODUCT_ID);
 }
 
 // ==================== Model Detection ====================
@@ -54,16 +63,21 @@ Xbox::ControllerModel XboxController::DetectModel() const {
     
     switch (product) {
         case XBOX_ONE_PRODUCT_ID:
+        case XBOX_ONE_2015FW_PRODUCT_ID:
             return Xbox::ControllerModel::XboxOne;
         case XBOX_ONE_S_PRODUCT_ID:
+        case XBOX_ONE_S_BT_REV1_PRODUCT_ID:
+        case XBOX_ONE_S_BT_REV2_PRODUCT_ID:
+        case XBOX_ONE_S_BLE_PRODUCT_ID:
             return Xbox::ControllerModel::XboxOneS;
         case XBOX_ONE_ELITE_PRODUCT_ID:
             return Xbox::ControllerModel::XboxOneElite;
         case XBOX_ONE_ELITE2_PRODUCT_ID:
+        case XBOX_ONE_ELITE2_BT_PRODUCT_ID:
+        case XBOX_ONE_ELITE2_BLE_PRODUCT_ID:
             return Xbox::ControllerModel::XboxOneElite2;
         case XBOX_SERIES_X_PRODUCT_ID:
         case XBOX_SERIES_X_WIRED_PRODUCT_ID:
-        case XBOX_SERIES_X_BLE_PRODUCT_ID:
             return Xbox::ControllerModel::XboxSeriesX;
         default:
             return Xbox::ControllerModel::Unknown;

--- a/src/Haptics/XboxController.h
+++ b/src/Haptics/XboxController.h
@@ -5,9 +5,14 @@
  * Xbox One and Xbox Series X|S controllers feature independent motors in each trigger,
  * allowing for vibration feedback during gameplay.
  * 
+ * Detection and the actual trigger effect are both delegated to SDL3's own
+ * Xbox HIDAPI driver (SDL_GetRealGamepadTypeForID / SDL_RumbleJoystickTriggers)
+ * rather than hand-rolled vendor/product-ID checks and a hand-rolled HID
+ * report. See IsXboxController() and SetImpulseTriggers() for details.
+ * 
  * @author InputBridge Team
- * @version 2.0
- * @date 2026-02-14
+ * @version 3.0
+ * @date 2026-07-12
  */
 
 #pragma once
@@ -32,21 +37,6 @@ namespace Xbox {
         XboxOneElite,
         XboxOneElite2,
         XboxSeriesX
-    };
-
-    /**
-     * @struct ImpulseTriggerState
-     * @brief Impulse trigger motor state
-     */
-    struct ImpulseTriggerState {
-        uint8_t leftTriggerMotor;   ///< Left trigger motor (0-255)
-        uint8_t rightTriggerMotor;  ///< Right trigger motor (0-255)
-        uint16_t durationMs;        ///< Duration in milliseconds
-
-        ImpulseTriggerState() 
-            : leftTriggerMotor(0)
-            , rightTriggerMotor(0)
-            , durationMs(0) {}
     };
 }
 
@@ -88,6 +78,12 @@ public:
 
     /**
      * @brief Set impulse trigger motors
+     *
+     * Delegates to SDL_RumbleJoystickTriggers(), which is implemented by
+     * SDL's own Xbox HIDAPI driver - the same driver used for detection
+     * (see IsXboxController()). This requires SDL events to be pumped (or
+     * SDL_UpdateJoysticks() called) for the rumble state to actually be
+     * sent, same as any other SDL rumble call.
      * 
      * @param leftIntensity Left trigger motor intensity (0-255)
      * @param rightIntensity Right trigger motor intensity (0-255)
@@ -116,11 +112,22 @@ public:
     /**
      * @brief Check if a joystick handle is an Xbox controller with impulse triggers
      *
-     * Static entry point for the same vendor/product-ID detection used by the
-     * instance method above. This is the single source of truth for "is this
-     * an Xbox controller" - callers that don't (yet) own an XboxController
-     * instance, such as GamepadHaptics deciding whether to construct one,
-     * should call this instead of re-implementing the product ID list.
+     * Static entry point for the same detection used by the instance method
+     * above. This is the single source of truth for "is this an Xbox
+     * controller" - callers that don't (yet) own an XboxController instance,
+     * such as GamepadHaptics deciding whether to construct one, should call
+     * this instead of re-implementing the check.
+     *
+     * Delegates to SDL_GetRealGamepadTypeForID() rather than a hand-maintained
+     * vendor/product-ID table: SDL_GAMEPAD_TYPE_XBOXONE is derived from the
+     * same device table SDL's Xbox HIDAPI driver itself gates trigger-rumble
+     * support on, so this can't drift out of sync with what
+     * SetImpulseTriggers() is actually able to do, and it additionally
+     * applies interface class/subclass and platform-specific checks (macOS
+     * MFI passthrough, Windows's fake XGIP HID endpoint) that a raw VID/PID
+     * comparison doesn't. "RealGamepadType" (rather than the mapping-aware
+     * GamepadType) is used deliberately so a user's SDL_GAMECONTROLLERCONFIG
+     * remap can't cause a non-Xbox device to be treated as one here.
      *
      * @param joystick SDL joystick handle to check
      * @return true if Xbox controller with impulse triggers
@@ -134,23 +141,19 @@ private:
      */
     Xbox::ControllerModel DetectModel() const;
 
-    /**
-     * @brief Send impulse trigger command
-     * @param state Trigger state
-     * @return true on success
-     */
-    bool SendImpulseTriggerCommand(const Xbox::ImpulseTriggerState& state);
-
     // ==================== Protocol Constants ====================
 
     // Hardware IDs
     static constexpr uint16_t MICROSOFT_VENDOR_ID = 0x045E;
-    
-    // Product IDs (controllers with impulse triggers)
-    //
-    // Sourced against SDL upstream's authoritative list
-    // (src/joystick/usb_ids.h) to make sure every connection variant of
-    // each impulse-trigger-capable model is covered. Deliberately excluded:
+
+    // Product IDs - used ONLY for cosmetic model naming in DetectModel()
+    // (Elite vs S vs Series X, for UI display). NOT used to gate
+    // capability/detection anymore - see IsXboxController(), which delegates
+    // to SDL_GetRealGamepadTypeForID() instead. SDL has no public API for
+    // this level of model granularity (SDL_GamepadType has no XBOXSERIES
+    // value; Series X reports as SDL_GAMEPAD_TYPE_XBOXONE same as the rest),
+    // so this table stays hand-maintained, sourced against SDL upstream's
+    // own list (src/joystick/usb_ids.h) for accuracy. Deliberately excluded:
     //  - 0x02FF (XBOXGIP_CONTROLLER): a driver-software PID, not a distinct
     //    hardware model, so it isn't a meaningful entry in a model table.
     //  - Xbox Adaptive Controller (0x0B0A / 0x0B0C / 0x0B21): a hub for
@@ -169,20 +172,11 @@ private:
     static constexpr uint16_t XBOX_ONE_ELITE2_PRODUCT_ID = 0x0B00;        // Xbox One Elite 2 - USB
     static constexpr uint16_t XBOX_ONE_ELITE2_BT_PRODUCT_ID = 0x0B05;     // Xbox One Elite 2 - Bluetooth
     static constexpr uint16_t XBOX_ONE_ELITE2_BLE_PRODUCT_ID = 0x0B22;    // Xbox One Elite 2 - Bluetooth LE
-    // NOTE: 0x0B22 was previously (incorrectly) listed here as a Series X|S
-    // BLE id. Per SDL's usb_ids.h it's actually
-    // USB_PRODUCT_XBOX_ONE_ELITE_SERIES_2_BLE - Series X|S has no separate
-    // BLE-only PID; see XBOX_SERIES_X_PRODUCT_ID below.
 
     // Xbox Series X|S (model 1914) reports a different product ID per
     // connection type - USB and Bluetooth are NOT the same device ID here.
     // Unlike Xbox One S/Elite 2, Series X|S was never given a distinct
     // BLE-only PID: 0x0B13 covers both classic Bluetooth and BLE.
-    static constexpr uint16_t XBOX_SERIES_X_PRODUCT_ID = 0x0B13;      // Xbox Series X|S - Bluetooth/BLE
+    static constexpr uint16_t XBOX_SERIES_X_PRODUCT_ID = 0x0B13;       // Xbox Series X|S - Bluetooth/BLE
     static constexpr uint16_t XBOX_SERIES_X_WIRED_PRODUCT_ID = 0x0B12; // Xbox Series X|S - USB (wired)
-
-
-    // Impulse Trigger Protocol
-    static constexpr uint8_t IMPULSE_TRIGGER_REPORT_ID = 0x03;
-    static constexpr size_t IMPULSE_TRIGGER_REPORT_SIZE = 8;
 };

--- a/src/Haptics/XboxController.h
+++ b/src/Haptics/XboxController.h
@@ -137,7 +137,13 @@ private:
     static constexpr uint16_t XBOX_ONE_S_PRODUCT_ID = 0x02EA;      // Xbox One S
     static constexpr uint16_t XBOX_ONE_ELITE_PRODUCT_ID = 0x02E3;  // Xbox One Elite
     static constexpr uint16_t XBOX_ONE_ELITE2_PRODUCT_ID = 0x0B00; // Xbox One Elite 2
-    static constexpr uint16_t XBOX_SERIES_X_PRODUCT_ID = 0x0B13;   // Xbox Series X|S
+    // Xbox Series X|S (model 1914) reports a different product ID per
+    // connection type - USB and Bluetooth are NOT the same device ID here.
+    // Only 0x0B13 (Bluetooth) was previously listed, so wired controllers
+    // fell through IsXboxController() entirely.
+    static constexpr uint16_t XBOX_SERIES_X_PRODUCT_ID = 0x0B13;      // Xbox Series X|S - Bluetooth
+    static constexpr uint16_t XBOX_SERIES_X_WIRED_PRODUCT_ID = 0x0B12; // Xbox Series X|S - USB (wired)
+    static constexpr uint16_t XBOX_SERIES_X_BLE_PRODUCT_ID = 0x0B22;   // Xbox Series X|S - Bluetooth LE (post firmware 5.x)
 
     // Impulse Trigger Protocol
     static constexpr uint8_t IMPULSE_TRIGGER_REPORT_ID = 0x03;

--- a/src/Haptics/XboxController.h
+++ b/src/Haptics/XboxController.h
@@ -113,6 +113,20 @@ public:
      */
     bool IsXboxController() const;
 
+    /**
+     * @brief Check if a joystick handle is an Xbox controller with impulse triggers
+     *
+     * Static entry point for the same vendor/product-ID detection used by the
+     * instance method above. This is the single source of truth for "is this
+     * an Xbox controller" - callers that don't (yet) own an XboxController
+     * instance, such as GamepadHaptics deciding whether to construct one,
+     * should call this instead of re-implementing the product ID list.
+     *
+     * @param joystick SDL joystick handle to check
+     * @return true if Xbox controller with impulse triggers
+     */
+    static bool IsXboxController(SDL_Joystick* joystick);
+
 private:
     /**
      * @brief Detect specific Xbox controller model
@@ -133,17 +147,40 @@ private:
     static constexpr uint16_t MICROSOFT_VENDOR_ID = 0x045E;
     
     // Product IDs (controllers with impulse triggers)
-    static constexpr uint16_t XBOX_ONE_PRODUCT_ID = 0x02D1;        // Original Xbox One
-    static constexpr uint16_t XBOX_ONE_S_PRODUCT_ID = 0x02EA;      // Xbox One S
-    static constexpr uint16_t XBOX_ONE_ELITE_PRODUCT_ID = 0x02E3;  // Xbox One Elite
-    static constexpr uint16_t XBOX_ONE_ELITE2_PRODUCT_ID = 0x0B00; // Xbox One Elite 2
+    //
+    // Sourced against SDL upstream's authoritative list
+    // (src/joystick/usb_ids.h) to make sure every connection variant of
+    // each impulse-trigger-capable model is covered. Deliberately excluded:
+    //  - 0x02FF (XBOXGIP_CONTROLLER): a driver-software PID, not a distinct
+    //    hardware model, so it isn't a meaningful entry in a model table.
+    //  - Xbox Adaptive Controller (0x0B0A / 0x0B0C / 0x0B21): a hub for
+    //    external accessibility switches, has no trigger motors of its own.
+    static constexpr uint16_t XBOX_ONE_PRODUCT_ID = 0x02D1;        // Original Xbox One - USB
+    static constexpr uint16_t XBOX_ONE_2015FW_PRODUCT_ID = 0x02DD; // Original Xbox One - USB (2015 firmware revision)
+    static constexpr uint16_t XBOX_ONE_ELITE_PRODUCT_ID = 0x02E3;  // Xbox One Elite - USB
+
+    // Xbox One S reports a different product ID per connection type/firmware.
+    static constexpr uint16_t XBOX_ONE_S_PRODUCT_ID = 0x02EA;             // Xbox One S - USB
+    static constexpr uint16_t XBOX_ONE_S_BT_REV1_PRODUCT_ID = 0x02E0;     // Xbox One S - Bluetooth (older firmware)
+    static constexpr uint16_t XBOX_ONE_S_BT_REV2_PRODUCT_ID = 0x02FD;     // Xbox One S - Bluetooth (newer firmware)
+    static constexpr uint16_t XBOX_ONE_S_BLE_PRODUCT_ID = 0x0B20;         // Xbox One S - Bluetooth LE
+
+    // Xbox One Elite Series 2 likewise has separate wired/BT/BLE IDs.
+    static constexpr uint16_t XBOX_ONE_ELITE2_PRODUCT_ID = 0x0B00;        // Xbox One Elite 2 - USB
+    static constexpr uint16_t XBOX_ONE_ELITE2_BT_PRODUCT_ID = 0x0B05;     // Xbox One Elite 2 - Bluetooth
+    static constexpr uint16_t XBOX_ONE_ELITE2_BLE_PRODUCT_ID = 0x0B22;    // Xbox One Elite 2 - Bluetooth LE
+    // NOTE: 0x0B22 was previously (incorrectly) listed here as a Series X|S
+    // BLE id. Per SDL's usb_ids.h it's actually
+    // USB_PRODUCT_XBOX_ONE_ELITE_SERIES_2_BLE - Series X|S has no separate
+    // BLE-only PID; see XBOX_SERIES_X_PRODUCT_ID below.
+
     // Xbox Series X|S (model 1914) reports a different product ID per
     // connection type - USB and Bluetooth are NOT the same device ID here.
-    // Only 0x0B13 (Bluetooth) was previously listed, so wired controllers
-    // fell through IsXboxController() entirely.
-    static constexpr uint16_t XBOX_SERIES_X_PRODUCT_ID = 0x0B13;      // Xbox Series X|S - Bluetooth
+    // Unlike Xbox One S/Elite 2, Series X|S was never given a distinct
+    // BLE-only PID: 0x0B13 covers both classic Bluetooth and BLE.
+    static constexpr uint16_t XBOX_SERIES_X_PRODUCT_ID = 0x0B13;      // Xbox Series X|S - Bluetooth/BLE
     static constexpr uint16_t XBOX_SERIES_X_WIRED_PRODUCT_ID = 0x0B12; // Xbox Series X|S - USB (wired)
-    static constexpr uint16_t XBOX_SERIES_X_BLE_PRODUCT_ID = 0x0B22;   // Xbox Series X|S - Bluetooth LE (post firmware 5.x)
+
 
     // Impulse Trigger Protocol
     static constexpr uint8_t IMPULSE_TRIGGER_REPORT_ID = 0x03;

--- a/src/Mappers/InputMapping/MappingProfileStore.cpp
+++ b/src/Mappers/InputMapping/MappingProfileStore.cpp
@@ -555,6 +555,21 @@ void MappingProfileStore::UpdateActiveProtocols() {
 
     // ── OSC server ────────────────────────────────────────────────────────────
     auto& osc = OSCServer::GetInstance();
+
+    // Snapshot what the server is actually running on *before* touching the
+    // protocol definitions below. SetOutputDefinition()/SetInputDefinition()
+    // apply that definition's own host/port as a side effect (when it
+    // specifies one), overwriting the very fields GetSendHost()/GetSendPort()/
+    // GetReceivePort() read, so computing portChanged from those getters
+    // afterwards would compare the new profile's definition-port against the
+    // new profile's saved port (almost always equal, since the latter is
+    // usually derived from the former) instead of against what the server
+    // was actually still bound to. That silently skipped the restart
+    // whenever the old and new profile used different ports/host.
+    const std::string prevSendHost = osc.GetSendHost();
+    const int prevSendPort = osc.GetSendPort();
+    const int prevRecvPort = osc.GetReceivePort();
+
     osc.SetOutputDefinition(p.oscOutputProtocolId);
     osc.SetInputDefinition(p.oscInputProtocolId);
 
@@ -564,9 +579,9 @@ void MappingProfileStore::UpdateActiveProtocols() {
     // port after a profile switch.
     osc.SetOutputEnabled(p.oscOutputEnabled);
     osc.SetInputEnabled(p.oscInputEnabled);
-    const bool portChanged = (osc.GetSendPort()    != p.oscSendPort  ||
-                              osc.GetReceivePort() != p.oscRecvPort  ||
-                              osc.GetSendHost()    != p.oscSendHost);
+    const bool portChanged = (prevSendPort != p.oscSendPort  ||
+                              prevRecvPort != p.oscRecvPort  ||
+                              prevSendHost != p.oscSendHost);
     if (osc.IsRunning() && portChanged) {
         osc.Stop();
         // Block until the detached liblo cleanup thread releases the old port

--- a/src/Visualizers/GamepadHapticsVisualizer.cpp
+++ b/src/Visualizers/GamepadHapticsVisualizer.cpp
@@ -449,6 +449,22 @@ void GamepadHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager& devic
                     static_cast<uint8_t>(m_xbox_right_intensity),
                     static_cast<uint32_t>(m_xbox_trigger_duration));
                 LOG_DEBUG(kTag, "Xbox trigger result: %d", result);
+
+                if (result != 0) {
+                    // SetImpulseTriggers() already logged the underlying SDL
+                    // error via LOG_WARN, but that's not visible anywhere in
+                    // the UI - grab it here too so the user isn't left
+                    // wondering why nothing happened (e.g. controller opened
+                    // via the XInput backend instead of SDL's HIDAPI Xbox
+                    // driver, or a third-party pad that reports as Xbox type
+                    // but doesn't actually implement trigger rumble).
+                    const char* sdlError = SDL_GetError();
+                    m_xbox_trigger_error = (sdlError && sdlError[0] != '\0')
+                        ? std::string("Impulse triggers not supported: ") + sdlError
+                        : std::string("Impulse triggers not supported on this controller/driver.");
+                } else {
+                    m_xbox_trigger_error.clear();
+                }
             }
         }
         ImGui::SameLine();
@@ -456,6 +472,10 @@ void GamepadHapticsVisualizer::Draw(const DeviceState& dev, DeviceManager& devic
             if (auto* gamepadHaptics = dynamic_cast<GamepadHaptics*>(haptic)) {
                 gamepadHaptics->PlayXboxTrigger(0, 0, 0);
             }
+        }
+
+        if (!m_xbox_trigger_error.empty()) {
+            ImGui::TextColored(ImVec4(1.0f, 0.0f, 0.0f, 1.0f), "%s", m_xbox_trigger_error.c_str());
         }
     }
 }

--- a/src/Visualizers/GamepadHapticsVisualizer.h
+++ b/src/Visualizers/GamepadHapticsVisualizer.h
@@ -2,6 +2,7 @@
 #include "Devices/DeviceState.h"
 #include "Devices/DeviceManager.h"
 #include "Preferences/Preferences.h"
+#include <string>
 
 class GamepadHapticsVisualizer {
 public:
@@ -29,4 +30,5 @@ private:
     int m_xbox_left_intensity = 0;
     int m_xbox_right_intensity = 0;
     int m_xbox_trigger_duration = 1000;
+    std::string m_xbox_trigger_error;
 };


### PR DESCRIPTION
# Xbox Controller & Haptics Refactoring

## Native SDL3 Trigger Rumble:
- Replaced the hand-rolled HID output report logic (SendImpulseTriggerCommand) with SDL3’s native SDL_RumbleJoystickTriggers().
- This handles transport-specific reports (USB vs. Bluetooth) automatically and scales input intensities (0–255) to SDL’s 16-bit range.

## Unified Controller Detection:
- Streamlined GamepadHaptics::IsXboxController() to delegate directly to a new static method XboxController::IsXboxController(SDL_Joystick*).
- Removed duplicate, drift-prone VID/PID checks across files.

## SDL-Based Identification:
- Refactored Xbox detection to use SDL_GetRealGamepadTypeForID(), ensuring remapped controllers or non-Xbox devices aren't misidentified while preventing logic drift.
- Expanded Model Recognition: Added Product IDs for wired, Bluetooth, and BLE variants (Xbox One S, Elite Series 2, Series X|S) to DetectModel() for accurate cosmetic UI labels.
- Default fallback now returns ControllerModel::XboxOne instead of Unknown when a valid Xbox controller lacks a specific model lookup.

# UI Feedback & DiagnosticsHaptics Visualizer Errors
- Added m_xbox_trigger_error state to GamepadHapticsVisualizer.
- If trigger rumble fails (e.g., when running on unsupported backends like XInput), the visualizer now captures SDL_GetError() and displays an error message in red text.

# OSC Server Bug FixPort Delta Check (MappingProfileStore):
- Fixed an issue where changing profiles with different OSC host/port settings silently skipped restarting the server.
- Preserved prevSendHost, prevSendPort, and prevRecvPort prior to updating definitions so the comparison evaluates actual active server state instead of post-mutation values.  